### PR TITLE
support constant ints and bytes

### DIFF
--- a/vest-dsl/src/vest.pest
+++ b/vest-dsl/src/vest.pest
@@ -98,7 +98,9 @@ const_combinator = {
 const_array_combinator =  { "[" ~ int_combinator ~ ";" ~ const_int ~ "]" ~ "=" ~ const_array }
 const_array            =  { const_char_array | const_int_array }
 const_char_array       = ${ "\"" ~ (!"\"" ~ char)* ~ "\"" }
-const_int_array        =  { "[" ~ const_int ~ ("," ~ const_int)* ~ "]" }
+const_int_array        =  { int_array_expr | repeat_int_array_expr }
+int_array_expr         =  { "[" ~ const_int ~ ("," ~ const_int)* ~ "]" }
+repeat_int_array_expr  =  { "[" ~ const_int ~ ";" ~ const_int ~ "]" }
 
 const_int_combinator = { int_combinator ~ "=" ~ const_int }
 

--- a/vest-dsl/test/src/elab.rs
+++ b/vest-dsl/test/src/elab.rs
@@ -7,23 +7,345 @@ use vest::regular::choice::*;
 use vest::regular::cond::*;
 use vest::regular::depend::*;
 use vest::regular::map::*;
+use vest::regular::refined::*;
 use vest::regular::tail::*;
 use vest::regular::uints::*;
 use vest::utils::*;
 use vstd::prelude::*;
 verus! {
 
-pub type SpecContentType = u8;
-
-pub type ContentType = u8;
-
-pub type ContentTypeOwned = u8;
-
 pub type SpecContent0 = Seq<u8>;
 
 pub type Content0<'a> = &'a [u8];
 
 pub type Content0Owned = Vec<u8>;
+
+pub struct SpecMsgD {
+    pub f1: Seq<u8>,
+    pub f2: u16,
+}
+
+pub type SpecMsgDInner = (Seq<u8>, u16);
+
+impl SpecFrom<SpecMsgD> for SpecMsgDInner {
+    open spec fn spec_from(m: SpecMsgD) -> SpecMsgDInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl SpecFrom<SpecMsgDInner> for SpecMsgD {
+    open spec fn spec_from(m: SpecMsgDInner) -> SpecMsgD {
+        let (f1, f2) = m;
+        SpecMsgD { f1, f2 }
+    }
+}
+
+pub struct MsgD<'a> {
+    pub f1: &'a [u8],
+    pub f2: u16,
+}
+
+pub type MsgDInner<'a> = (&'a [u8], u16);
+
+impl View for MsgD<'_> {
+    type V = SpecMsgD;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgD { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl<'a> From<MsgD<'a>> for MsgDInner<'a> {
+    fn ex_from(m: MsgD<'a>) -> MsgDInner<'a> {
+        (m.f1, m.f2)
+    }
+}
+
+impl<'a> From<MsgDInner<'a>> for MsgD<'a> {
+    fn ex_from(m: MsgDInner<'a>) -> MsgD<'a> {
+        let (f1, f2) = m;
+        MsgD { f1, f2 }
+    }
+}
+
+pub struct MsgDMapper;
+
+impl View for MsgDMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgDMapper {
+    type Src = SpecMsgDInner;
+
+    type Dst = SpecMsgD;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgDMapper {
+    type Src<'a> = MsgDInner<'a>;
+
+    type Dst<'a> = MsgD<'a>;
+
+    type SrcOwned = MsgDOwnedInner;
+
+    type DstOwned = MsgDOwned;
+}
+
+pub struct MsgDOwned {
+    pub f1: Vec<u8>,
+    pub f2: u16,
+}
+
+pub type MsgDOwnedInner = (Vec<u8>, u16);
+
+impl View for MsgDOwned {
+    type V = SpecMsgD;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgD { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl From<MsgDOwned> for MsgDOwnedInner {
+    fn ex_from(m: MsgDOwned) -> MsgDOwnedInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl From<MsgDOwnedInner> for MsgDOwned {
+    fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
+        let (f1, f2) = m;
+        MsgDOwned { f1, f2 }
+    }
+}
+
+pub struct SpecMsgB {
+    pub f1: SpecMsgD,
+}
+
+pub type SpecMsgBInner = SpecMsgD;
+
+impl SpecFrom<SpecMsgB> for SpecMsgBInner {
+    open spec fn spec_from(m: SpecMsgB) -> SpecMsgBInner {
+        m.f1
+    }
+}
+
+impl SpecFrom<SpecMsgBInner> for SpecMsgB {
+    open spec fn spec_from(m: SpecMsgBInner) -> SpecMsgB {
+        let f1 = m;
+        SpecMsgB { f1 }
+    }
+}
+
+pub struct MsgB<'a> {
+    pub f1: MsgD<'a>,
+}
+
+pub type MsgBInner<'a> = MsgD<'a>;
+
+impl View for MsgB<'_> {
+    type V = SpecMsgB;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgB { f1: self.f1@ }
+    }
+}
+
+impl<'a> From<MsgB<'a>> for MsgBInner<'a> {
+    fn ex_from(m: MsgB<'a>) -> MsgBInner<'a> {
+        m.f1
+    }
+}
+
+impl<'a> From<MsgBInner<'a>> for MsgB<'a> {
+    fn ex_from(m: MsgBInner<'a>) -> MsgB<'a> {
+        let f1 = m;
+        MsgB { f1 }
+    }
+}
+
+pub struct MsgBMapper;
+
+impl View for MsgBMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgBMapper {
+    type Src = SpecMsgBInner;
+
+    type Dst = SpecMsgB;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgBMapper {
+    type Src<'a> = MsgBInner<'a>;
+
+    type Dst<'a> = MsgB<'a>;
+
+    type SrcOwned = MsgBOwnedInner;
+
+    type DstOwned = MsgBOwned;
+}
+
+pub struct MsgBOwned {
+    pub f1: MsgDOwned,
+}
+
+pub type MsgBOwnedInner = MsgDOwned;
+
+impl View for MsgBOwned {
+    type V = SpecMsgB;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgB { f1: self.f1@ }
+    }
+}
+
+impl From<MsgBOwned> for MsgBOwnedInner {
+    fn ex_from(m: MsgBOwned) -> MsgBOwnedInner {
+        m.f1
+    }
+}
+
+impl From<MsgBOwnedInner> for MsgBOwned {
+    fn ex_from(m: MsgBOwnedInner) -> MsgBOwned {
+        let f1 = m;
+        MsgBOwned { f1 }
+    }
+}
+
+pub struct SpecMsgA {
+    pub f1: SpecMsgB,
+    pub f2: Seq<u8>,
+}
+
+pub type SpecMsgAInner = (SpecMsgB, Seq<u8>);
+
+impl SpecFrom<SpecMsgA> for SpecMsgAInner {
+    open spec fn spec_from(m: SpecMsgA) -> SpecMsgAInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl SpecFrom<SpecMsgAInner> for SpecMsgA {
+    open spec fn spec_from(m: SpecMsgAInner) -> SpecMsgA {
+        let (f1, f2) = m;
+        SpecMsgA { f1, f2 }
+    }
+}
+
+pub struct MsgA<'a> {
+    pub f1: MsgB<'a>,
+    pub f2: &'a [u8],
+}
+
+pub type MsgAInner<'a> = (MsgB<'a>, &'a [u8]);
+
+impl View for MsgA<'_> {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl<'a> From<MsgA<'a>> for MsgAInner<'a> {
+    fn ex_from(m: MsgA<'a>) -> MsgAInner<'a> {
+        (m.f1, m.f2)
+    }
+}
+
+impl<'a> From<MsgAInner<'a>> for MsgA<'a> {
+    fn ex_from(m: MsgAInner<'a>) -> MsgA<'a> {
+        let (f1, f2) = m;
+        MsgA { f1, f2 }
+    }
+}
+
+pub struct MsgAMapper;
+
+impl View for MsgAMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgAMapper {
+    type Src = SpecMsgAInner;
+
+    type Dst = SpecMsgA;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgAMapper {
+    type Src<'a> = MsgAInner<'a>;
+
+    type Dst<'a> = MsgA<'a>;
+
+    type SrcOwned = MsgAOwnedInner;
+
+    type DstOwned = MsgAOwned;
+}
+
+pub struct MsgAOwned {
+    pub f1: MsgBOwned,
+    pub f2: Vec<u8>,
+}
+
+pub type MsgAOwnedInner = (MsgBOwned, Vec<u8>);
+
+impl View for MsgAOwned {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl From<MsgAOwned> for MsgAOwnedInner {
+    fn ex_from(m: MsgAOwned) -> MsgAOwnedInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl From<MsgAOwnedInner> for MsgAOwned {
+    fn ex_from(m: MsgAOwnedInner) -> MsgAOwned {
+        let (f1, f2) = m;
+        MsgAOwned { f1, f2 }
+    }
+}
+
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
 
 pub enum SpecMsgCF4 {
     C0(SpecContent0),
@@ -276,55 +598,22 @@ impl From<MsgCOwnedInner> for MsgCOwned {
     }
 }
 
-pub struct SpecMsgD {
-    pub f1: u8,
+pub type Content0Combinator = Bytes;
+
+pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
+
+pub exec const MSGD_F1: [u8; 4]
+    ensures
+        MSGD_F1@ == SPEC_MSGD_F1,
+{
+    let arr: [u8; 4] = [1;4];
+    assert(arr@ == SPEC_MSGD_F1);
+    arr
 }
 
-pub type SpecMsgDInner = u8;
+pub struct BytesPredicate16235736133663645624;
 
-impl SpecFrom<SpecMsgD> for SpecMsgDInner {
-    open spec fn spec_from(m: SpecMsgD) -> SpecMsgDInner {
-        m.f1
-    }
-}
-
-impl SpecFrom<SpecMsgDInner> for SpecMsgD {
-    open spec fn spec_from(m: SpecMsgDInner) -> SpecMsgD {
-        let f1 = m;
-        SpecMsgD { f1 }
-    }
-}
-
-pub struct MsgD {
-    pub f1: u8,
-}
-
-pub type MsgDInner = u8;
-
-impl View for MsgD {
-    type V = SpecMsgD;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgD { f1: self.f1@ }
-    }
-}
-
-impl From<MsgD> for MsgDInner {
-    fn ex_from(m: MsgD) -> MsgDInner {
-        m.f1
-    }
-}
-
-impl From<MsgDInner> for MsgD {
-    fn ex_from(m: MsgDInner) -> MsgD {
-        let f1 = m;
-        MsgD { f1 }
-    }
-}
-
-pub struct MsgDMapper;
-
-impl View for MsgDMapper {
+impl View for BytesPredicate16235736133663645624 {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -332,104 +621,29 @@ impl View for MsgDMapper {
     }
 }
 
-impl SpecIso for MsgDMapper {
-    type Src = SpecMsgDInner;
+impl SpecPred for BytesPredicate16235736133663645624 {
+    type Input = Seq<u8>;
 
-    type Dst = SpecMsgD;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        i == &SPEC_MSGD_F1
     }
 }
 
-impl Iso for MsgDMapper {
-    type Src<'a> = MsgDInner;
+impl Pred for BytesPredicate16235736133663645624 {
+    type Input<'a> = &'a [u8];
 
-    type Dst<'a> = MsgD;
+    type InputOwned = Vec<u8>;
 
-    type SrcOwned = MsgDOwnedInner;
-
-    type DstOwned = MsgDOwned;
-}
-
-pub struct MsgDOwned {
-    pub f1: u8,
-}
-
-pub type MsgDOwnedInner = u8;
-
-impl View for MsgDOwned {
-    type V = SpecMsgD;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgD { f1: self.f1@ }
+    fn apply(&self, i: &Self::Input<'_>) -> bool {
+        compare_slice(i, MSGD_F1.as_slice())
     }
 }
 
-impl From<MsgDOwned> for MsgDOwnedInner {
-    fn ex_from(m: MsgDOwned) -> MsgDOwnedInner {
-        m.f1
-    }
-}
+pub const MSGD_F2: u16 = 4660;
 
-impl From<MsgDOwnedInner> for MsgDOwned {
-    fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
-        let f1 = m;
-        MsgDOwned { f1 }
-    }
-}
+pub struct IntIs4660;
 
-pub struct SpecMsgB {
-    pub f1: SpecMsgD,
-}
-
-pub type SpecMsgBInner = SpecMsgD;
-
-impl SpecFrom<SpecMsgB> for SpecMsgBInner {
-    open spec fn spec_from(m: SpecMsgB) -> SpecMsgBInner {
-        m.f1
-    }
-}
-
-impl SpecFrom<SpecMsgBInner> for SpecMsgB {
-    open spec fn spec_from(m: SpecMsgBInner) -> SpecMsgB {
-        let f1 = m;
-        SpecMsgB { f1 }
-    }
-}
-
-pub struct MsgB {
-    pub f1: MsgD,
-}
-
-pub type MsgBInner = MsgD;
-
-impl View for MsgB {
-    type V = SpecMsgB;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgB { f1: self.f1@ }
-    }
-}
-
-impl From<MsgB> for MsgBInner {
-    fn ex_from(m: MsgB) -> MsgBInner {
-        m.f1
-    }
-}
-
-impl From<MsgBInner> for MsgB {
-    fn ex_from(m: MsgBInner) -> MsgB {
-        let f1 = m;
-        MsgB { f1 }
-    }
-}
-
-pub struct MsgBMapper;
-
-impl View for MsgBMapper {
+impl View for IntIs4660 {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -437,166 +651,34 @@ impl View for MsgBMapper {
     }
 }
 
-impl SpecIso for MsgBMapper {
-    type Src = SpecMsgBInner;
+impl SpecPred for IntIs4660 {
+    type Input = u16;
 
-    type Dst = SpecMsgB;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        *i == 4660
     }
 }
 
-impl Iso for MsgBMapper {
-    type Src<'a> = MsgBInner;
+impl Pred for IntIs4660 {
+    type Input<'a> = u16;
 
-    type Dst<'a> = MsgB;
+    type InputOwned = u16;
 
-    type SrcOwned = MsgBOwnedInner;
-
-    type DstOwned = MsgBOwned;
-}
-
-pub struct MsgBOwned {
-    pub f1: MsgDOwned,
-}
-
-pub type MsgBOwnedInner = MsgDOwned;
-
-impl View for MsgBOwned {
-    type V = SpecMsgB;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgB { f1: self.f1@ }
+    fn apply(&self, i: &Self::Input<'_>) -> bool {
+        *i == 4660
     }
 }
 
-impl From<MsgBOwned> for MsgBOwnedInner {
-    fn ex_from(m: MsgBOwned) -> MsgBOwnedInner {
-        m.f1
-    }
-}
+pub type MsgDCombinator = Mapped<
+    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16, IntIs4660>),
+    MsgDMapper,
+>;
 
-impl From<MsgBOwnedInner> for MsgBOwned {
-    fn ex_from(m: MsgBOwnedInner) -> MsgBOwned {
-        let f1 = m;
-        MsgBOwned { f1 }
-    }
-}
+pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
 
-pub struct SpecMsgA {
-    pub f1: SpecMsgB,
-    pub f2: Seq<u8>,
-}
-
-pub type SpecMsgAInner = (SpecMsgB, Seq<u8>);
-
-impl SpecFrom<SpecMsgA> for SpecMsgAInner {
-    open spec fn spec_from(m: SpecMsgA) -> SpecMsgAInner {
-        (m.f1, m.f2)
-    }
-}
-
-impl SpecFrom<SpecMsgAInner> for SpecMsgA {
-    open spec fn spec_from(m: SpecMsgAInner) -> SpecMsgA {
-        let (f1, f2) = m;
-        SpecMsgA { f1, f2 }
-    }
-}
-
-pub struct MsgA<'a> {
-    pub f1: MsgB,
-    pub f2: &'a [u8],
-}
-
-pub type MsgAInner<'a> = (MsgB, &'a [u8]);
-
-impl View for MsgA<'_> {
-    type V = SpecMsgA;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgA { f1: self.f1@, f2: self.f2@ }
-    }
-}
-
-impl<'a> From<MsgA<'a>> for MsgAInner<'a> {
-    fn ex_from(m: MsgA<'a>) -> MsgAInner<'a> {
-        (m.f1, m.f2)
-    }
-}
-
-impl<'a> From<MsgAInner<'a>> for MsgA<'a> {
-    fn ex_from(m: MsgAInner<'a>) -> MsgA<'a> {
-        let (f1, f2) = m;
-        MsgA { f1, f2 }
-    }
-}
-
-pub struct MsgAMapper;
-
-impl View for MsgAMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for MsgAMapper {
-    type Src = SpecMsgAInner;
-
-    type Dst = SpecMsgA;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for MsgAMapper {
-    type Src<'a> = MsgAInner<'a>;
-
-    type Dst<'a> = MsgA<'a>;
-
-    type SrcOwned = MsgAOwnedInner;
-
-    type DstOwned = MsgAOwned;
-}
-
-pub struct MsgAOwned {
-    pub f1: MsgBOwned,
-    pub f2: Vec<u8>,
-}
-
-pub type MsgAOwnedInner = (MsgBOwned, Vec<u8>);
-
-impl View for MsgAOwned {
-    type V = SpecMsgA;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgA { f1: self.f1@, f2: self.f2@ }
-    }
-}
-
-impl From<MsgAOwned> for MsgAOwnedInner {
-    fn ex_from(m: MsgAOwned) -> MsgAOwnedInner {
-        (m.f1, m.f2)
-    }
-}
-
-impl From<MsgAOwnedInner> for MsgAOwned {
-    fn ex_from(m: MsgAOwnedInner) -> MsgAOwned {
-        let (f1, f2) = m;
-        MsgAOwned { f1, f2 }
-    }
-}
+pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
 
 pub type ContentTypeCombinator = U8;
-
-pub type Content0Combinator = Bytes;
 
 pub type MsgCF4Combinator = AndThen<
     Bytes,
@@ -614,23 +696,6 @@ pub type MsgCCombinator = Mapped<
     MsgCMapper,
 >;
 
-pub type MsgDCombinator = Mapped<U8, MsgDMapper>;
-
-pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
-
-pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
-
-pub open spec fn spec_content_type() -> ContentTypeCombinator {
-    U8
-}
-
-pub fn content_type() -> (o: ContentTypeCombinator)
-    ensures
-        o@ == spec_content_type(),
-{
-    U8
-}
-
 pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
     Bytes(num as usize)
 }
@@ -642,50 +707,27 @@ pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
     Bytes(num as usize)
 }
 
-pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> MsgCF4Combinator {
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    Cond { lhs: f2, rhs: 1, inner: spec_content_0(f3) },
-                    Cond { lhs: f2, rhs: 0, inner: U16 },
-                ),
-                Cond { lhs: f2, rhs: 2, inner: U32 },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
-pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
-    ensures
-        o@ == spec_msg_c_f4(f2@, f3@),
-{
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    Cond { lhs: f2, rhs: 1, inner: content_0(f3) },
-                    Cond { lhs: f2, rhs: 0, inner: U16 },
-                ),
-                Cond { lhs: f2, rhs: 2, inner: U32 },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
 pub open spec fn spec_msg_d() -> MsgDCombinator {
-    Mapped { inner: U8, mapper: MsgDMapper }
+    Mapped {
+        inner: (
+            Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
+            Refined { inner: U16, predicate: IntIs4660 },
+        ),
+        mapper: MsgDMapper,
+    }
 }
 
 pub fn msg_d() -> (o: MsgDCombinator)
     ensures
         o@ == spec_msg_d(),
 {
-    Mapped { inner: U8, mapper: MsgDMapper }
+    Mapped {
+        inner: (
+            Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
+            Refined { inner: U16, predicate: IntIs4660 },
+        ),
+        mapper: MsgDMapper,
+    }
 }
 
 pub open spec fn spec_msg_b() -> MsgBCombinator {
@@ -708,6 +750,153 @@ pub fn msg_a() -> (o: MsgACombinator)
         o@ == spec_msg_a(),
 {
     Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
+}
+
+pub open spec fn spec_content_type() -> ContentTypeCombinator {
+    U8
+}
+
+pub fn content_type() -> (o: ContentTypeCombinator)
+    ensures
+        o@ == spec_content_type(),
+{
+    U8
+}
+
+pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> MsgCF4Combinator {
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    Cond { lhs: f2, rhs: 0, inner: spec_content_0(f3) },
+                    Cond { lhs: f2, rhs: 1, inner: U16 },
+                ),
+                Cond { lhs: f2, rhs: 2, inner: U32 },
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
+    ensures
+        o@ == spec_msg_c_f4(f2@, f3@),
+{
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    Cond { lhs: f2, rhs: 0, inner: content_0(f3) },
+                    Cond { lhs: f2, rhs: 1, inner: U16 },
+                ),
+                Cond { lhs: f2, rhs: 2, inner: U32 },
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
+    spec_content_0(num).spec_parse(i)
+}
+
+pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u8) -> Result<Seq<u8>, ()> {
+    spec_content_0(num).spec_serialize(msg)
+}
+
+pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
+{
+    content_0(num).parse(i)
+}
+
+pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u8) -> (o:
+    Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_content_0(msg@, num@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    content_0(num).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
+}
+
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_d().parse(i)
+}
+
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_d().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
+    spec_msg_b().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_b(msg: SpecMsgB) -> Result<Seq<u8>, ()> {
+    spec_msg_b().spec_serialize(msg)
+}
+
+pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_b(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_b().parse(i)
+}
+
+pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_b(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_b().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_a(i: Seq<u8>) -> Result<(usize, SpecMsgA), ()> {
+    spec_msg_a().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
+    spec_msg_a().spec_serialize(msg)
+}
+
+pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_a().parse(i)
+}
+
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_a(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_a().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
@@ -736,32 +925,6 @@ pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) 
         },
 {
     content_type().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
-    spec_content_0(num).spec_parse(i)
-}
-
-pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u8) -> Result<Seq<u8>, ()> {
-    spec_content_0(num).spec_serialize(msg)
-}
-
-pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
-{
-    content_0(num).parse(i)
-}
-
-pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u8) -> (o:
-    Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_content_0(msg@, num@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    content_0(num).serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u8) -> Result<
@@ -866,81 +1029,6 @@ pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
         data,
         pos,
     )
-}
-
-pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
-    spec_msg_d().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
-    spec_msg_d().spec_serialize(msg)
-}
-
-pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
-{
-    msg_d().parse(i)
-}
-
-pub fn serialize_msg_d(msg: MsgD, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_d().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
-    spec_msg_b().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg_b(msg: SpecMsgB) -> Result<Seq<u8>, ()> {
-    spec_msg_b().spec_serialize(msg)
-}
-
-pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg_b(i@) matches Ok(r_) && r@ == r_,
-{
-    msg_b().parse(i)
-}
-
-pub fn serialize_msg_b(msg: MsgB, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_b(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_b().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_msg_a(i: Seq<u8>) -> Result<(usize, SpecMsgA), ()> {
-    spec_msg_a().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
-    spec_msg_a().spec_serialize(msg)
-}
-
-pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
-{
-    msg_a().parse(i)
-}
-
-pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_a(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_a().serialize(msg, data, pos)
 }
 
 } // verus!

--- a/vest-dsl/test/src/elab.vest
+++ b/vest-dsl/test/src/elab.vest
@@ -1,5 +1,6 @@
 msg_d = {
-  f1: u8,
+  const f1: [u8; 4] = [1; 4],
+  const f2: u16 = 0x1234,
 }
 
 msg_b = {

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -145,73 +145,63 @@ use crate::utils::*;
 use vstd::prelude::*;
 verus! {
 
-    pub type SpecAType = u8;
+pub type SpecContent0 = Seq<u8>;
 
-pub type AType = u8;
+pub type Content0<'a> = &'a [u8];
 
-pub type ATypeOwned = u8;
+pub type Content0Owned = Vec<u8>;
 
-pub type SpecMsg3 = Seq<u8>;
-
-pub type Msg3<'a> = &'a [u8];
-
-pub type Msg3Owned = Vec<u8>;
-
-pub struct SpecMsg1 {
-    pub a: u8,
-    pub b: u16,
-    pub c: Seq<u8>,
-    pub d: Seq<u8>,
+pub struct SpecMsgD {
+    pub f1: Seq<u8>,
+    pub f2: u16,
 }
 
-pub type SpecMsg1Inner = (((u8, u16), Seq<u8>), Seq<u8>);
+pub type SpecMsgDInner = (Seq<u8>, u16);
 
-impl SpecFrom<SpecMsg1> for SpecMsg1Inner {
-    open spec fn spec_from(m: SpecMsg1) -> SpecMsg1Inner {
-        (((m.a, m.b), m.c), m.d)
+impl SpecFrom<SpecMsgD> for SpecMsgDInner {
+    open spec fn spec_from(m: SpecMsgD) -> SpecMsgDInner {
+        (m.f1, m.f2)
     }
 }
 
-impl SpecFrom<SpecMsg1Inner> for SpecMsg1 {
-    open spec fn spec_from(m: SpecMsg1Inner) -> SpecMsg1 {
-        let (((a, b), c), d) = m;
-        SpecMsg1 { a, b, c, d }
+impl SpecFrom<SpecMsgDInner> for SpecMsgD {
+    open spec fn spec_from(m: SpecMsgDInner) -> SpecMsgD {
+        let (f1, f2) = m;
+        SpecMsgD { f1, f2 }
     }
 }
 
-pub struct Msg1<'a> {
-    pub a: u8,
-    pub b: u16,
-    pub c: &'a [u8],
-    pub d: &'a [u8],
+pub struct MsgD<'a> {
+    pub f1: &'a [u8],
+    pub f2: u16,
 }
 
-pub type Msg1Inner<'a> = (((u8, u16), &'a [u8]), &'a [u8]);
+pub type MsgDInner<'a> = (&'a [u8], u16);
 
-impl View for Msg1<'_> {
-    type V = SpecMsg1;
+impl View for MsgD<'_> {
+    type V = SpecMsgD;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg1 { a: self.a@, b: self.b@, c: self.c@, d: self.d@ }
+        SpecMsgD { f1: self.f1@, f2: self.f2@ }
     }
 }
 
-impl<'a> From<Msg1<'a>> for Msg1Inner<'a> {
-    fn ex_from(m: Msg1<'a>) -> Msg1Inner<'a> {
-        (((m.a, m.b), m.c), m.d)
+impl<'a> From<MsgD<'a>> for MsgDInner<'a> {
+    fn ex_from(m: MsgD<'a>) -> MsgDInner<'a> {
+        (m.f1, m.f2)
     }
 }
 
-impl<'a> From<Msg1Inner<'a>> for Msg1<'a> {
-    fn ex_from(m: Msg1Inner<'a>) -> Msg1<'a> {
-        let (((a, b), c), d) = m;
-        Msg1 { a, b, c, d }
+impl<'a> From<MsgDInner<'a>> for MsgD<'a> {
+    fn ex_from(m: MsgDInner<'a>) -> MsgD<'a> {
+        let (f1, f2) = m;
+        MsgD { f1, f2 }
     }
 }
 
-pub struct Msg1Mapper;
+pub struct MsgDMapper;
 
-impl View for Msg1Mapper {
+impl View for MsgDMapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -219,10 +209,10 @@ impl View for Msg1Mapper {
     }
 }
 
-impl SpecIso for Msg1Mapper {
-    type Src = SpecMsg1Inner;
+impl SpecIso for MsgDMapper {
+    type Src = SpecMsgDInner;
 
-    type Dst = SpecMsg1;
+    type Dst = SpecMsgD;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -231,99 +221,93 @@ impl SpecIso for Msg1Mapper {
     }
 }
 
-impl Iso for Msg1Mapper {
-    type Src<'a> = Msg1Inner<'a>;
+impl Iso for MsgDMapper {
+    type Src<'a> = MsgDInner<'a>;
 
-    type Dst<'a> = Msg1<'a>;
+    type Dst<'a> = MsgD<'a>;
 
-    type SrcOwned = Msg1OwnedInner;
+    type SrcOwned = MsgDOwnedInner;
 
-    type DstOwned = Msg1Owned;
+    type DstOwned = MsgDOwned;
 }
 
-pub struct Msg1Owned {
-    pub a: u8,
-    pub b: u16,
-    pub c: Vec<u8>,
-    pub d: Vec<u8>,
+pub struct MsgDOwned {
+    pub f1: Vec<u8>,
+    pub f2: u16,
 }
 
-pub type Msg1OwnedInner = (((u8, u16), Vec<u8>), Vec<u8>);
+pub type MsgDOwnedInner = (Vec<u8>, u16);
 
-impl View for Msg1Owned {
-    type V = SpecMsg1;
+impl View for MsgDOwned {
+    type V = SpecMsgD;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg1 { a: self.a@, b: self.b@, c: self.c@, d: self.d@ }
+        SpecMsgD { f1: self.f1@, f2: self.f2@ }
     }
 }
 
-impl From<Msg1Owned> for Msg1OwnedInner {
-    fn ex_from(m: Msg1Owned) -> Msg1OwnedInner {
-        (((m.a, m.b), m.c), m.d)
+impl From<MsgDOwned> for MsgDOwnedInner {
+    fn ex_from(m: MsgDOwned) -> MsgDOwnedInner {
+        (m.f1, m.f2)
     }
 }
 
-impl From<Msg1OwnedInner> for Msg1Owned {
-    fn ex_from(m: Msg1OwnedInner) -> Msg1Owned {
-        let (((a, b), c), d) = m;
-        Msg1Owned { a, b, c, d }
+impl From<MsgDOwnedInner> for MsgDOwned {
+    fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
+        let (f1, f2) = m;
+        MsgDOwned { f1, f2 }
     }
 }
 
-pub struct SpecMsg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
+pub struct SpecMsgB {
+    pub f1: SpecMsgD,
 }
 
-pub type SpecMsg2Inner = ((u8, u16), u32);
+pub type SpecMsgBInner = SpecMsgD;
 
-impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
-    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
-        ((m.a, m.b), m.c)
+impl SpecFrom<SpecMsgB> for SpecMsgBInner {
+    open spec fn spec_from(m: SpecMsgB) -> SpecMsgBInner {
+        m.f1
     }
 }
 
-impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
-    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
-        let ((a, b), c) = m;
-        SpecMsg2 { a, b, c }
+impl SpecFrom<SpecMsgBInner> for SpecMsgB {
+    open spec fn spec_from(m: SpecMsgBInner) -> SpecMsgB {
+        let f1 = m;
+        SpecMsgB { f1 }
     }
 }
 
-pub struct Msg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
+pub struct MsgB<'a> {
+    pub f1: MsgD<'a>,
 }
 
-pub type Msg2Inner = ((u8, u16), u32);
+pub type MsgBInner<'a> = MsgD<'a>;
 
-impl View for Msg2 {
-    type V = SpecMsg2;
+impl View for MsgB<'_> {
+    type V = SpecMsgB;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
+        SpecMsgB { f1: self.f1@ }
     }
 }
 
-impl From<Msg2> for Msg2Inner {
-    fn ex_from(m: Msg2) -> Msg2Inner {
-        ((m.a, m.b), m.c)
+impl<'a> From<MsgB<'a>> for MsgBInner<'a> {
+    fn ex_from(m: MsgB<'a>) -> MsgBInner<'a> {
+        m.f1
     }
 }
 
-impl From<Msg2Inner> for Msg2 {
-    fn ex_from(m: Msg2Inner) -> Msg2 {
-        let ((a, b), c) = m;
-        Msg2 { a, b, c }
+impl<'a> From<MsgBInner<'a>> for MsgB<'a> {
+    fn ex_from(m: MsgBInner<'a>) -> MsgB<'a> {
+        let f1 = m;
+        MsgB { f1 }
     }
 }
 
-pub struct Msg2Mapper;
+pub struct MsgBMapper;
 
-impl View for Msg2Mapper {
+impl View for MsgBMapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -331,10 +315,10 @@ impl View for Msg2Mapper {
     }
 }
 
-impl SpecIso for Msg2Mapper {
-    type Src = SpecMsg2Inner;
+impl SpecIso for MsgBMapper {
+    type Src = SpecMsgBInner;
 
-    type Dst = SpecMsg2;
+    type Dst = SpecMsgB;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -343,116 +327,228 @@ impl SpecIso for Msg2Mapper {
     }
 }
 
-impl Iso for Msg2Mapper {
-    type Src<'a> = Msg2Inner;
+impl Iso for MsgBMapper {
+    type Src<'a> = MsgBInner<'a>;
 
-    type Dst<'a> = Msg2;
+    type Dst<'a> = MsgB<'a>;
 
-    type SrcOwned = Msg2OwnedInner;
+    type SrcOwned = MsgBOwnedInner;
 
-    type DstOwned = Msg2Owned;
+    type DstOwned = MsgBOwned;
 }
 
-pub struct Msg2Owned {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
+pub struct MsgBOwned {
+    pub f1: MsgDOwned,
 }
 
-pub type Msg2OwnedInner = ((u8, u16), u32);
+pub type MsgBOwnedInner = MsgDOwned;
 
-impl View for Msg2Owned {
-    type V = SpecMsg2;
+impl View for MsgBOwned {
+    type V = SpecMsgB;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
+        SpecMsgB { f1: self.f1@ }
     }
 }
 
-impl From<Msg2Owned> for Msg2OwnedInner {
-    fn ex_from(m: Msg2Owned) -> Msg2OwnedInner {
-        ((m.a, m.b), m.c)
+impl From<MsgBOwned> for MsgBOwnedInner {
+    fn ex_from(m: MsgBOwned) -> MsgBOwnedInner {
+        m.f1
     }
 }
 
-impl From<Msg2OwnedInner> for Msg2Owned {
-    fn ex_from(m: Msg2OwnedInner) -> Msg2Owned {
-        let ((a, b), c) = m;
-        Msg2Owned { a, b, c }
+impl From<MsgBOwnedInner> for MsgBOwned {
+    fn ex_from(m: MsgBOwnedInner) -> MsgBOwned {
+        let f1 = m;
+        MsgBOwned { f1 }
     }
 }
 
-pub enum SpecMsg4V {
-    A(SpecMsg1),
-    B(SpecMsg2),
-    C(SpecMsg3),
+pub struct SpecMsgA {
+    pub f1: SpecMsgB,
+    pub f2: Seq<u8>,
 }
 
-pub type SpecMsg4VInner = Either<Either<SpecMsg1, SpecMsg2>, SpecMsg3>;
+pub type SpecMsgAInner = (SpecMsgB, Seq<u8>);
 
-impl SpecFrom<SpecMsg4V> for SpecMsg4VInner {
-    open spec fn spec_from(m: SpecMsg4V) -> SpecMsg4VInner {
+impl SpecFrom<SpecMsgA> for SpecMsgAInner {
+    open spec fn spec_from(m: SpecMsgA) -> SpecMsgAInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl SpecFrom<SpecMsgAInner> for SpecMsgA {
+    open spec fn spec_from(m: SpecMsgAInner) -> SpecMsgA {
+        let (f1, f2) = m;
+        SpecMsgA { f1, f2 }
+    }
+}
+
+pub struct MsgA<'a> {
+    pub f1: MsgB<'a>,
+    pub f2: &'a [u8],
+}
+
+pub type MsgAInner<'a> = (MsgB<'a>, &'a [u8]);
+
+impl View for MsgA<'_> {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl<'a> From<MsgA<'a>> for MsgAInner<'a> {
+    fn ex_from(m: MsgA<'a>) -> MsgAInner<'a> {
+        (m.f1, m.f2)
+    }
+}
+
+impl<'a> From<MsgAInner<'a>> for MsgA<'a> {
+    fn ex_from(m: MsgAInner<'a>) -> MsgA<'a> {
+        let (f1, f2) = m;
+        MsgA { f1, f2 }
+    }
+}
+
+pub struct MsgAMapper;
+
+impl View for MsgAMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgAMapper {
+    type Src = SpecMsgAInner;
+
+    type Dst = SpecMsgA;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgAMapper {
+    type Src<'a> = MsgAInner<'a>;
+
+    type Dst<'a> = MsgA<'a>;
+
+    type SrcOwned = MsgAOwnedInner;
+
+    type DstOwned = MsgAOwned;
+}
+
+pub struct MsgAOwned {
+    pub f1: MsgBOwned,
+    pub f2: Vec<u8>,
+}
+
+pub type MsgAOwnedInner = (MsgBOwned, Vec<u8>);
+
+impl View for MsgAOwned {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl From<MsgAOwned> for MsgAOwnedInner {
+    fn ex_from(m: MsgAOwned) -> MsgAOwnedInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl From<MsgAOwnedInner> for MsgAOwned {
+    fn ex_from(m: MsgAOwnedInner) -> MsgAOwned {
+        let (f1, f2) = m;
+        MsgAOwned { f1, f2 }
+    }
+}
+
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+}
+
+pub type SpecMsgCF4Inner = Either<Either<SpecContent0, u16>, u32>;
+
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
         match m {
-            SpecMsg4V::A(m) => Either::Left(Either::Left(m)),
-            SpecMsg4V::B(m) => Either::Left(Either::Right(m)),
-            SpecMsg4V::C(m) => Either::Right(m),
+            SpecMsgCF4::C0(m) => Either::Left(Either::Left(m)),
+            SpecMsgCF4::C1(m) => Either::Left(Either::Right(m)),
+            SpecMsgCF4::C2(m) => Either::Right(m),
         }
     }
 }
 
-impl SpecFrom<SpecMsg4VInner> for SpecMsg4V {
-    open spec fn spec_from(m: SpecMsg4VInner) -> SpecMsg4V {
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
         match m {
-            Either::Left(Either::Left(m)) => SpecMsg4V::A(m),
-            Either::Left(Either::Right(m)) => SpecMsg4V::B(m),
-            Either::Right(m) => SpecMsg4V::C(m),
+            Either::Left(Either::Left(m)) => SpecMsgCF4::C0(m),
+            Either::Left(Either::Right(m)) => SpecMsgCF4::C1(m),
+            Either::Right(m) => SpecMsgCF4::C2(m),
         }
     }
 }
 
-pub enum Msg4V<'a> {
-    A(Msg1<'a>),
-    B(Msg2),
-    C(Msg3<'a>),
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
 }
 
-pub type Msg4VInner<'a> = Either<Either<Msg1<'a>, Msg2>, Msg3<'a>>;
+pub type MsgCF4Inner<'a> = Either<Either<Content0<'a>, u16>, u32>;
 
-impl View for Msg4V<'_> {
-    type V = SpecMsg4V;
+impl View for MsgCF4<'_> {
+    type V = SpecMsgCF4;
 
     open spec fn view(&self) -> Self::V {
         match self {
-            Msg4V::A(m) => SpecMsg4V::A(m@),
-            Msg4V::B(m) => SpecMsg4V::B(m@),
-            Msg4V::C(m) => SpecMsg4V::C(m@),
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
         }
     }
 }
 
-impl<'a> From<Msg4V<'a>> for Msg4VInner<'a> {
-    fn ex_from(m: Msg4V<'a>) -> Msg4VInner<'a> {
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
         match m {
-            Msg4V::A(m) => Either::Left(Either::Left(m)),
-            Msg4V::B(m) => Either::Left(Either::Right(m)),
-            Msg4V::C(m) => Either::Right(m),
+            MsgCF4::C0(m) => Either::Left(Either::Left(m)),
+            MsgCF4::C1(m) => Either::Left(Either::Right(m)),
+            MsgCF4::C2(m) => Either::Right(m),
         }
     }
 }
 
-impl<'a> From<Msg4VInner<'a>> for Msg4V<'a> {
-    fn ex_from(m: Msg4VInner<'a>) -> Msg4V<'a> {
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
         match m {
-            Either::Left(Either::Left(m)) => Msg4V::A(m),
-            Either::Left(Either::Right(m)) => Msg4V::B(m),
-            Either::Right(m) => Msg4V::C(m),
+            Either::Left(Either::Left(m)) => MsgCF4::C0(m),
+            Either::Left(Either::Right(m)) => MsgCF4::C1(m),
+            Either::Right(m) => MsgCF4::C2(m),
         }
     }
 }
 
-pub struct Msg4VMapper;
+pub struct MsgCF4Mapper;
 
-impl View for Msg4VMapper {
+impl View for MsgCF4Mapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -460,10 +556,10 @@ impl View for Msg4VMapper {
     }
 }
 
-impl SpecIso for Msg4VMapper {
-    type Src = SpecMsg4VInner;
+impl SpecIso for MsgCF4Mapper {
+    type Src = SpecMsgCF4Inner;
 
-    type Dst = SpecMsg4V;
+    type Dst = SpecMsgCF4;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -472,107 +568,109 @@ impl SpecIso for Msg4VMapper {
     }
 }
 
-impl Iso for Msg4VMapper {
-    type Src<'a> = Msg4VInner<'a>;
+impl Iso for MsgCF4Mapper {
+    type Src<'a> = MsgCF4Inner<'a>;
 
-    type Dst<'a> = Msg4V<'a>;
+    type Dst<'a> = MsgCF4<'a>;
 
-    type SrcOwned = Msg4VOwnedInner;
+    type SrcOwned = MsgCF4OwnedInner;
 
-    type DstOwned = Msg4VOwned;
+    type DstOwned = MsgCF4Owned;
 }
 
-pub enum Msg4VOwned {
-    A(Msg1Owned),
-    B(Msg2Owned),
-    C(Msg3Owned),
+pub enum MsgCF4Owned {
+    C0(Content0Owned),
+    C1(u16),
+    C2(u32),
 }
 
-pub type Msg4VOwnedInner = Either<Either<Msg1Owned, Msg2Owned>, Msg3Owned>;
+pub type MsgCF4OwnedInner = Either<Either<Content0Owned, u16>, u32>;
 
-impl View for Msg4VOwned {
-    type V = SpecMsg4V;
+impl View for MsgCF4Owned {
+    type V = SpecMsgCF4;
 
     open spec fn view(&self) -> Self::V {
         match self {
-            Msg4VOwned::A(m) => SpecMsg4V::A(m@),
-            Msg4VOwned::B(m) => SpecMsg4V::B(m@),
-            Msg4VOwned::C(m) => SpecMsg4V::C(m@),
+            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
         }
     }
 }
 
-impl From<Msg4VOwned> for Msg4VOwnedInner {
-    fn ex_from(m: Msg4VOwned) -> Msg4VOwnedInner {
+impl From<MsgCF4Owned> for MsgCF4OwnedInner {
+    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
         match m {
-            Msg4VOwned::A(m) => Either::Left(Either::Left(m)),
-            Msg4VOwned::B(m) => Either::Left(Either::Right(m)),
-            Msg4VOwned::C(m) => Either::Right(m),
+            MsgCF4Owned::C0(m) => Either::Left(Either::Left(m)),
+            MsgCF4Owned::C1(m) => Either::Left(Either::Right(m)),
+            MsgCF4Owned::C2(m) => Either::Right(m),
         }
     }
 }
 
-impl From<Msg4VOwnedInner> for Msg4VOwned {
-    fn ex_from(m: Msg4VOwnedInner) -> Msg4VOwned {
+impl From<MsgCF4OwnedInner> for MsgCF4Owned {
+    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
         match m {
-            Either::Left(Either::Left(m)) => Msg4VOwned::A(m),
-            Either::Left(Either::Right(m)) => Msg4VOwned::B(m),
-            Either::Right(m) => Msg4VOwned::C(m),
+            Either::Left(Either::Left(m)) => MsgCF4Owned::C0(m),
+            Either::Left(Either::Right(m)) => MsgCF4Owned::C1(m),
+            Either::Right(m) => MsgCF4Owned::C2(m),
         }
     }
 }
 
-pub struct SpecMsg4 {
-    pub t: SpecAType,
-    pub v: SpecMsg4V,
+pub struct SpecMsgC {
+    pub f2: SpecContentType,
+    pub f3: u8,
+    pub f4: SpecMsgCF4,
 }
 
-pub type SpecMsg4Inner = (SpecAType, SpecMsg4V);
+pub type SpecMsgCInner = ((SpecContentType, u8), SpecMsgCF4);
 
-impl SpecFrom<SpecMsg4> for SpecMsg4Inner {
-    open spec fn spec_from(m: SpecMsg4) -> SpecMsg4Inner {
-        (m.t, m.v)
+impl SpecFrom<SpecMsgC> for SpecMsgCInner {
+    open spec fn spec_from(m: SpecMsgC) -> SpecMsgCInner {
+        ((m.f2, m.f3), m.f4)
     }
 }
 
-impl SpecFrom<SpecMsg4Inner> for SpecMsg4 {
-    open spec fn spec_from(m: SpecMsg4Inner) -> SpecMsg4 {
-        let (t, v) = m;
-        SpecMsg4 { t, v }
+impl SpecFrom<SpecMsgCInner> for SpecMsgC {
+    open spec fn spec_from(m: SpecMsgCInner) -> SpecMsgC {
+        let ((f2, f3), f4) = m;
+        SpecMsgC { f2, f3, f4 }
     }
 }
 
-pub struct Msg4<'a> {
-    pub t: AType,
-    pub v: Msg4V<'a>,
+pub struct MsgC<'a> {
+    pub f2: ContentType,
+    pub f3: u8,
+    pub f4: MsgCF4<'a>,
 }
 
-pub type Msg4Inner<'a> = (AType, Msg4V<'a>);
+pub type MsgCInner<'a> = ((ContentType, u8), MsgCF4<'a>);
 
-impl View for Msg4<'_> {
-    type V = SpecMsg4;
+impl View for MsgC<'_> {
+    type V = SpecMsgC;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg4 { t: self.t@, v: self.v@ }
+        SpecMsgC { f2: self.f2@, f3: self.f3@, f4: self.f4@ }
     }
 }
 
-impl<'a> From<Msg4<'a>> for Msg4Inner<'a> {
-    fn ex_from(m: Msg4<'a>) -> Msg4Inner<'a> {
-        (m.t, m.v)
+impl<'a> From<MsgC<'a>> for MsgCInner<'a> {
+    fn ex_from(m: MsgC<'a>) -> MsgCInner<'a> {
+        ((m.f2, m.f3), m.f4)
     }
 }
 
-impl<'a> From<Msg4Inner<'a>> for Msg4<'a> {
-    fn ex_from(m: Msg4Inner<'a>) -> Msg4<'a> {
-        let (t, v) = m;
-        Msg4 { t, v }
+impl<'a> From<MsgCInner<'a>> for MsgC<'a> {
+    fn ex_from(m: MsgCInner<'a>) -> MsgC<'a> {
+        let ((f2, f3), f4) = m;
+        MsgC { f2, f3, f4 }
     }
 }
 
-pub struct Msg4Mapper;
+pub struct MsgCMapper;
 
-impl View for Msg4Mapper {
+impl View for MsgCMapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -580,10 +678,10 @@ impl View for Msg4Mapper {
     }
 }
 
-impl SpecIso for Msg4Mapper {
-    type Src = SpecMsg4Inner;
+impl SpecIso for MsgCMapper {
+    type Src = SpecMsgCInner;
 
-    type Dst = SpecMsg4;
+    type Dst = SpecMsgC;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -592,51 +690,61 @@ impl SpecIso for Msg4Mapper {
     }
 }
 
-impl Iso for Msg4Mapper {
-    type Src<'a> = Msg4Inner<'a>;
+impl Iso for MsgCMapper {
+    type Src<'a> = MsgCInner<'a>;
 
-    type Dst<'a> = Msg4<'a>;
+    type Dst<'a> = MsgC<'a>;
 
-    type SrcOwned = Msg4OwnedInner;
+    type SrcOwned = MsgCOwnedInner;
 
-    type DstOwned = Msg4Owned;
+    type DstOwned = MsgCOwned;
 }
 
-pub struct Msg4Owned {
-    pub t: ATypeOwned,
-    pub v: Msg4VOwned,
+pub struct MsgCOwned {
+    pub f2: ContentTypeOwned,
+    pub f3: u8,
+    pub f4: MsgCF4Owned,
 }
 
-pub type Msg4OwnedInner = (ATypeOwned, Msg4VOwned);
+pub type MsgCOwnedInner = ((ContentTypeOwned, u8), MsgCF4Owned);
 
-impl View for Msg4Owned {
-    type V = SpecMsg4;
+impl View for MsgCOwned {
+    type V = SpecMsgC;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg4 { t: self.t@, v: self.v@ }
+        SpecMsgC { f2: self.f2@, f3: self.f3@, f4: self.f4@ }
     }
 }
 
-impl From<Msg4Owned> for Msg4OwnedInner {
-    fn ex_from(m: Msg4Owned) -> Msg4OwnedInner {
-        (m.t, m.v)
+impl From<MsgCOwned> for MsgCOwnedInner {
+    fn ex_from(m: MsgCOwned) -> MsgCOwnedInner {
+        ((m.f2, m.f3), m.f4)
     }
 }
 
-impl From<Msg4OwnedInner> for Msg4Owned {
-    fn ex_from(m: Msg4OwnedInner) -> Msg4Owned {
-        let (t, v) = m;
-        Msg4Owned { t, v }
+impl From<MsgCOwnedInner> for MsgCOwned {
+    fn ex_from(m: MsgCOwnedInner) -> MsgCOwned {
+        let ((f2, f3), f4) = m;
+        MsgCOwned { f2, f3, f4 }
     }
 }
 
-pub type ATypeCombinator = U8;
+pub type Content0Combinator = Bytes;
 
-pub type Msg3Combinator = BytesN<6>;
+pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
 
-pub struct Predicate5821512137558126895;
+pub exec const MSGD_F1: [u8; 4]
+    ensures
+        MSGD_F1@ == SPEC_MSGD_F1,
+{
+    let arr: [u8; 4] = [1;4];
+    assert(arr@ == SPEC_MSGD_F1);
+    arr
+}
 
-impl View for Predicate5821512137558126895 {
+pub struct BytesPredicate16235736133663645624;
+
+impl View for BytesPredicate16235736133663645624 {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -644,330 +752,416 @@ impl View for Predicate5821512137558126895 {
     }
 }
 
-impl SpecPred for Predicate5821512137558126895 {
-    type Input = u8;
+impl SpecPred for BytesPredicate16235736133663645624 {
+    type Input = Seq<u8>;
 
     open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = *i;
-        if (i >= 0 && i <= 10) || (i == 32) || (i >= 100) {
-            true
-        } else {
-            false
-        }
+        i == &SPEC_MSGD_F1
     }
 }
 
-impl Pred for Predicate5821512137558126895 {
-    type Input<'a> = u8;
+impl Pred for BytesPredicate16235736133663645624 {
+    type Input<'a> = &'a [u8];
 
-    type InputOwned = u8;
+    type InputOwned = Vec<u8>;
 
     fn apply(&self, i: &Self::Input<'_>) -> bool {
-        let i = *i;
-        if (i >= 0 && i <= 10) || (i == 32) || (i >= 100) {
-            true
-        } else {
-            false
-        }
+        compare_slice(i, MSGD_F1.as_slice())
     }
 }
 
-pub type Msg1Combinator = Mapped<
-    (((Refined<U8, Predicate5821512137558126895>, U16), BytesN<3>), Tail),
-    Msg1Mapper,
+pub const MSGD_F2: u16 = 4660;
+
+pub struct IntIs4660;
+
+impl View for IntIs4660 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecPred for IntIs4660 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        *i == 4660
+    }
+}
+
+impl Pred for IntIs4660 {
+    type Input<'a> = u16;
+
+    type InputOwned = u16;
+
+    fn apply(&self, i: &Self::Input<'_>) -> bool {
+        *i == 4660
+    }
+}
+
+pub type MsgDCombinator = Mapped<
+    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16, IntIs4660>),
+    MsgDMapper,
 >;
 
-pub type Msg2Combinator = Mapped<((U8, U16), U32), Msg2Mapper>;
+pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
 
-pub type Msg4VCombinator = Mapped<
-    OrdChoice<
-        OrdChoice<Cond<u8, u8, Msg1Combinator>, Cond<u8, u8, Msg2Combinator>>,
-        Cond<u8, u8, Msg3Combinator>,
+pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
+
+pub type ContentTypeCombinator = U8;
+
+pub type MsgCF4Combinator = AndThen<
+    Bytes,
+    Mapped<
+        OrdChoice<
+            OrdChoice<Cond<u8, u8, Content0Combinator>, Cond<u8, u8, U16>>,
+            Cond<u8, u8, U32>,
+        >,
+        MsgCF4Mapper,
     >,
-    Msg4VMapper,
 >;
 
-pub type Msg4Combinator = Mapped<SpecDepend<ATypeCombinator, Msg4VCombinator>, Msg4Mapper>;
+pub type MsgCCombinator = Mapped<
+    SpecDepend<(ContentTypeCombinator, U8), MsgCF4Combinator>,
+    MsgCMapper,
+>;
 
-pub open spec fn spec_a_type() -> ATypeCombinator {
-    U8
+pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
+    Bytes(num as usize)
 }
 
-pub fn a_type() -> (o: ATypeCombinator)
+pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
     ensures
-        o@ == spec_a_type(),
+        o@ == spec_content_0(num@),
 {
-    U8
+    Bytes(num as usize)
 }
 
-pub open spec fn spec_msg3() -> Msg3Combinator {
-    BytesN::<6>
-}
-
-pub fn msg3() -> (o: Msg3Combinator)
-    ensures
-        o@ == spec_msg3(),
-{
-    BytesN::<6>
-}
-
-pub open spec fn spec_msg1() -> Msg1Combinator {
+pub open spec fn spec_msg_d() -> MsgDCombinator {
     Mapped {
         inner: (
-            ((Refined { inner: U8, predicate: Predicate5821512137558126895 }, U16), BytesN::<3>),
-            Tail,
+            Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
+            Refined { inner: U16, predicate: IntIs4660 },
         ),
-        mapper: Msg1Mapper,
+        mapper: MsgDMapper,
     }
 }
 
-pub fn msg1() -> (o: Msg1Combinator)
+pub fn msg_d() -> (o: MsgDCombinator)
     ensures
-        o@ == spec_msg1(),
+        o@ == spec_msg_d(),
 {
     Mapped {
         inner: (
-            ((Refined { inner: U8, predicate: Predicate5821512137558126895 }, U16), BytesN::<3>),
-            Tail,
+            Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
+            Refined { inner: U16, predicate: IntIs4660 },
         ),
-        mapper: Msg1Mapper,
+        mapper: MsgDMapper,
     }
 }
 
-pub open spec fn spec_msg2() -> Msg2Combinator {
-    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
+pub open spec fn spec_msg_b() -> MsgBCombinator {
+    Mapped { inner: spec_msg_d(), mapper: MsgBMapper }
 }
 
-pub fn msg2() -> (o: Msg2Combinator)
+pub fn msg_b() -> (o: MsgBCombinator)
     ensures
-        o@ == spec_msg2(),
+        o@ == spec_msg_b(),
 {
-    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
+    Mapped { inner: msg_d(), mapper: MsgBMapper }
 }
 
-pub open spec fn spec_msg4_v(t: SpecAType) -> Msg4VCombinator {
-    Mapped {
-        inner: OrdChoice(
-            OrdChoice(
-                Cond { lhs: t, rhs: 0, inner: spec_msg1() },
-                Cond { lhs: t, rhs: 1, inner: spec_msg2() },
+pub open spec fn spec_msg_a() -> MsgACombinator {
+    Mapped { inner: (spec_msg_b(), Tail), mapper: MsgAMapper }
+}
+
+pub fn msg_a() -> (o: MsgACombinator)
+    ensures
+        o@ == spec_msg_a(),
+{
+    Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
+}
+
+pub open spec fn spec_content_type() -> ContentTypeCombinator {
+    U8
+}
+
+pub fn content_type() -> (o: ContentTypeCombinator)
+    ensures
+        o@ == spec_content_type(),
+{
+    U8
+}
+
+pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> MsgCF4Combinator {
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    Cond { lhs: f2, rhs: 0, inner: spec_content_0(f3) },
+                    Cond { lhs: f2, rhs: 1, inner: U16 },
+                ),
+                Cond { lhs: f2, rhs: 2, inner: U32 },
             ),
-            Cond { lhs: t, rhs: 2, inner: spec_msg3() },
-        ),
-        mapper: Msg4VMapper,
-    }
+            mapper: MsgCF4Mapper,
+        },
+    )
 }
 
-pub fn msg4_v<'a>(t: AType) -> (o: Msg4VCombinator)
+pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
     ensures
-        o@ == spec_msg4_v(t@),
+        o@ == spec_msg_c_f4(f2@, f3@),
 {
-    Mapped {
-        inner: OrdChoice(
-            OrdChoice(
-                Cond { lhs: t, rhs: 0, inner: msg1() },
-                Cond { lhs: t, rhs: 1, inner: msg2() },
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    Cond { lhs: f2, rhs: 0, inner: content_0(f3) },
+                    Cond { lhs: f2, rhs: 1, inner: U16 },
+                ),
+                Cond { lhs: f2, rhs: 2, inner: U32 },
             ),
-            Cond { lhs: t, rhs: 2, inner: msg3() },
-        ),
-        mapper: Msg4VMapper,
-    }
+            mapper: MsgCF4Mapper,
+        },
+    )
 }
 
-pub open spec fn parse_spec_a_type(i: Seq<u8>) -> Result<(usize, SpecAType), ()> {
-    spec_a_type().spec_parse(i)
+pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
+    spec_content_0(num).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_a_type(msg: SpecAType) -> Result<Seq<u8>, ()> {
-    spec_a_type().spec_serialize(msg)
+pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u8) -> Result<Seq<u8>, ()> {
+    spec_content_0(num).spec_serialize(msg)
 }
 
-pub fn parse_a_type(i: &[u8]) -> (o: Result<(usize, AType), ()>)
+pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_a_type(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
 {
-    a_type().parse(i)
+    content_0(num).parse(i)
 }
 
-pub fn serialize_a_type(msg: AType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u8) -> (o:
+    Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_a_type(msg@) matches Ok(buf)
+            &&& serialize_spec_content_0(msg@, num@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    a_type().serialize(msg, data, pos)
+    content_0(num).serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg3(i: Seq<u8>) -> Result<(usize, SpecMsg3), ()> {
-    spec_msg3().spec_parse(i)
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg3(msg: SpecMsg3) -> Result<Seq<u8>, ()> {
-    spec_msg3().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
 }
 
-pub fn parse_msg3(i: &[u8]) -> (o: Result<(usize, Msg3<'_>), ()>)
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg3(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
 {
-    msg3().parse(i)
+    msg_d().parse(i)
 }
 
-pub fn serialize_msg3(msg: Msg3<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg3(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg3().serialize(msg, data, pos)
+    msg_d().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg1(i: Seq<u8>) -> Result<(usize, SpecMsg1), ()> {
-    spec_msg1().spec_parse(i)
+pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
+    spec_msg_b().spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg1(msg: SpecMsg1) -> Result<Seq<u8>, ()> {
-    spec_msg1().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_b(msg: SpecMsgB) -> Result<Seq<u8>, ()> {
+    spec_msg_b().spec_serialize(msg)
 }
 
-pub fn parse_msg1(i: &[u8]) -> (o: Result<(usize, Msg1<'_>), ()>)
+pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg1(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_b(i@) matches Ok(r_) && r@ == r_,
 {
-    msg1().parse(i)
+    msg_b().parse(i)
 }
 
-pub fn serialize_msg1(msg: Msg1<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg1(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_b(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg1().serialize(msg, data, pos)
+    msg_b().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg2(i: Seq<u8>) -> Result<(usize, SpecMsg2), ()> {
-    spec_msg2().spec_parse(i)
+pub open spec fn parse_spec_msg_a(i: Seq<u8>) -> Result<(usize, SpecMsgA), ()> {
+    spec_msg_a().spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg2(msg: SpecMsg2) -> Result<Seq<u8>, ()> {
-    spec_msg2().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
+    spec_msg_a().spec_serialize(msg)
 }
 
-pub fn parse_msg2(i: &[u8]) -> (o: Result<(usize, Msg2), ()>)
+pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg2(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
 {
-    msg2().parse(i)
+    msg_a().parse(i)
 }
 
-pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg2(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_a(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg2().serialize(msg, data, pos)
+    msg_a().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg4_v(i: Seq<u8>, t: SpecAType) -> Result<(usize, SpecMsg4V), ()> {
-    spec_msg4_v(t).spec_parse(i)
+pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
+    spec_content_type().spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg4_v(msg: SpecMsg4V, t: SpecAType) -> Result<Seq<u8>, ()> {
-    spec_msg4_v(t).spec_serialize(msg)
+pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
+    spec_content_type().spec_serialize(msg)
 }
 
-pub fn parse_msg4_v(i: &[u8], t: AType) -> (o: Result<(usize, Msg4V<'_>), ()>)
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg4_v(i@, t@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
 {
-    msg4_v(t).parse(i)
+    content_type().parse(i)
 }
 
-pub fn serialize_msg4_v(msg: Msg4V<'_>, data: &mut Vec<u8>, pos: usize, t: AType) -> (o: Result<
+pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
     (),
 >)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg4_v(msg@, t@) matches Ok(buf)
+            &&& serialize_spec_content_type(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg4_v(t).serialize(msg, data, pos)
+    content_type().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg4(i: Seq<u8>) -> Result<(usize, SpecMsg4), ()> {
-    let fst = spec_a_type();
-    let snd = |deps|
-        {
-            let t = deps;
-            spec_msg4_v(t)
-        };
-    Mapped { inner: SpecDepend { fst, snd }, mapper: Msg4Mapper }.spec_parse(i)
+pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u8) -> Result<
+    (usize, SpecMsgCF4),
+    (),
+> {
+    spec_msg_c_f4(f2, f3).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg4(msg: SpecMsg4) -> Result<Seq<u8>, ()> {
-    let fst = spec_a_type();
-    let snd = |deps|
-        {
-            let t = deps;
-            spec_msg4_v(t)
-        };
-    Mapped { inner: SpecDepend { fst, snd }, mapper: Msg4Mapper }.spec_serialize(msg)
+pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f2: SpecContentType, f3: u8) -> Result<
+    Seq<u8>,
+    (),
+> {
+    spec_msg_c_f4(f2, f3).spec_serialize(msg)
 }
 
-pub fn parse_msg4(i: &[u8]) -> (o: Result<(usize, Msg4<'_>), ()>)
+pub fn parse_msg_c_f4(i: &[u8], f2: ContentType, f3: u8) -> (o: Result<(usize, MsgCF4<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg4(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f2@, f3@) matches Ok(r_) && r@ == r_,
 {
-    let ghost spec_snd = |deps|
-        {
-            let t = deps;
-            spec_msg4_v(t)
-        };
-    let fst = a_type();
-    let snd = |deps: AType| -> (o: Msg4VCombinator)
-        ensures
-            o@ == spec_snd(deps@),
-        {
-            let t = deps;
-            msg4_v(t)
-        };
-    Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: Msg4Mapper }.parse(i)
+    msg_c_f4(f2, f3).parse(i)
 }
 
-pub fn serialize_msg4(msg: Msg4<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_c_f4(
+    msg: MsgCF4<'_>,
+    data: &mut Vec<u8>,
+    pos: usize,
+    f2: ContentType,
+    f3: u8,
+) -> (o: Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg4(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_c_f4(msg@, f2@, f3@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_c_f4(f2, f3).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_c(i: Seq<u8>) -> Result<(usize, SpecMsgC), ()> {
+    let fst = (spec_content_type(), U8);
+    let snd = |deps|
+        {
+            let (f2, f3) = deps;
+            spec_msg_c_f4(f2, f3)
+        };
+    Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_c(msg: SpecMsgC) -> Result<Seq<u8>, ()> {
+    let fst = (spec_content_type(), U8);
+    let snd = |deps|
+        {
+            let (f2, f3) = deps;
+            spec_msg_c_f4(f2, f3)
+        };
+    Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_serialize(msg)
+}
+
+pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_c(i@) matches Ok(r_) && r@ == r_,
+{
+    let ghost spec_snd = |deps|
+        {
+            let (f2, f3) = deps;
+            spec_msg_c_f4(f2, f3)
+        };
+    let fst = (content_type(), U8);
+    let snd = |deps: (ContentType, u8)| -> (o: MsgCF4Combinator)
+        ensures
+            o@ == spec_snd(deps@),
+        {
+            let (f2, f3) = deps;
+            msg_c_f4(f2, f3)
+        };
+    Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.parse(i)
+}
+
+pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_c(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
     let ghost spec_snd = |deps|
         {
-            let t = deps;
-            spec_msg4_v(t)
+            let (f2, f3) = deps;
+            spec_msg_c_f4(f2, f3)
         };
-    let fst = a_type();
-    let snd = |deps: AType| -> (o: Msg4VCombinator)
+    let fst = (content_type(), U8);
+    let snd = |deps: (ContentType, u8)| -> (o: MsgCF4Combinator)
         ensures
             o@ == spec_snd(deps@),
         {
-            let t = deps;
-            msg4_v(t)
+            let (f2, f3) = deps;
+            msg_c_f4(f2, f3)
         };
-    Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: Msg4Mapper }.serialize(
+    Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.serialize(
         msg,
         data,
         pos,
     )
 }
+
 
 
 


### PR DESCRIPTION
Formats like
```
msg = {
  ...
  const a: u8 = 10,
  ...
  const b: [u8; 32] = [0; 32],
}
```
are now supported

