### PR TITLE
General `Cond` combinator

### DIFF
--- a/vest-dsl/src/vest.pest
+++ b/vest-dsl/src/vest.pest
@@ -56,8 +56,12 @@ wrap_prior      = { (const_combinator ~ ",")* }
 wrap_post       = { ("," ~ const_combinator)* }
 
 /// enum `combinator` for primitive types
-enum_combinator = { enum ~ "{" ~ enum_field+ ~ "}" }
-enum_field      = { variant_id ~ "=" ~ const_int ~ "," }
+// enum_combinator = { enum ~ "{" ~ enum_field+ ~ non_exhaustive_marker? ~ "}" }
+enum_combinator       =  { enum ~ "{" ~ (non_exhaustive_enum | exhaustive_enum) ~ "}" }
+exhaustive_enum       =  { enum_field+ }
+non_exhaustive_enum   =  { enum_field+ ~ non_exhaustive_marker }
+enum_field            =  { variant_id ~ "=" ~ const_int ~ "," }
+non_exhaustive_marker = _{ "..." }
 
 /// ordered choice `combinator`
 choice_combinator = { choose ~ ("(" ~ depend_id ~ ")")? ~ "{" ~ choice+ ~ "}" }
@@ -122,7 +126,7 @@ char  =  { '\u{00}'..'\u{FF}' }
 
 var_id     = @{ ASCII_ALPHA_LOWER ~ (ASCII_DIGIT | ASCII_ALPHA_LOWER | "_")* }
 const_id   = @{ ASCII_ALPHA_UPPER ~ (ASCII_DIGIT | ASCII_ALPHA_UPPER | "_")* }
-variant_id = @{ ASCII_ALPHA_UPPER ~ (ASCII_DIGIT | ASCII_ALPHA | "_")* }
+variant_id = @{ (ASCII_ALPHA_UPPER ~ (ASCII_DIGIT | ASCII_ALPHA | "_")*) | "_" }
 stream_id  = @{ "$" ~ ASCII_ALPHA_LOWER ~ (ASCII_DIGIT | ASCII_ALPHA_LOWER | "_")* }
 depend_id  = @{ "@" ~ ASCII_ALPHA_LOWER ~ (ASCII_DIGIT | ASCII_ALPHA_LOWER | "_")* }
 

--- a/vest-dsl/test/src/codegen.rs
+++ b/vest-dsl/test/src/codegen.rs
@@ -14,65 +14,20 @@ use vest::utils::*;
 use vstd::prelude::*;
 verus! {
 
-pub type SpecAType = u8;
-
-pub type AType = u8;
-
-pub type ATypeOwned = u8;
-
-pub struct SpecMsg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
+#[derive(Structural, Copy, Clone, PartialEq, Eq)]
+pub enum AType {
+    A = 0,
+    B = 1,
+    C = 2,
 }
 
-pub type SpecMsg2Inner = ((u8, u16), u32);
+pub type SpecAType = AType;
 
-impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
-    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
-        ((m.a, m.b), m.c)
-    }
-}
+pub type ATypeOwned = AType;
 
-impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
-    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
-        let ((a, b), c) = m;
-        SpecMsg2 { a, b, c }
-    }
-}
+pub type ATypeInner = u8;
 
-pub struct Msg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type Msg2Inner = ((u8, u16), u32);
-
-impl View for Msg2 {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
-    }
-}
-
-impl From<Msg2> for Msg2Inner {
-    fn ex_from(m: Msg2) -> Msg2Inner {
-        ((m.a, m.b), m.c)
-    }
-}
-
-impl From<Msg2Inner> for Msg2 {
-    fn ex_from(m: Msg2Inner) -> Msg2 {
-        let ((a, b), c) = m;
-        Msg2 { a, b, c }
-    }
-}
-
-pub struct Msg2Mapper;
-
-impl View for Msg2Mapper {
+impl View for AType {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -80,10 +35,70 @@ impl View for Msg2Mapper {
     }
 }
 
-impl SpecIso for Msg2Mapper {
-    type Src = SpecMsg2Inner;
+impl SpecTryFrom<ATypeInner> for AType {
+    type Error = ();
 
-    type Dst = SpecMsg2;
+    open spec fn spec_try_from(v: ATypeInner) -> Result<AType, ()> {
+        match v {
+            0u8 => Ok(AType::A),
+            1u8 => Ok(AType::B),
+            2u8 => Ok(AType::C),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SpecTryFrom<AType> for ATypeInner {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AType) -> Result<ATypeInner, ()> {
+        match v {
+            AType::A => Ok(0u8),
+            AType::B => Ok(1u8),
+            AType::C => Ok(2u8),
+        }
+    }
+}
+
+impl TryFrom<ATypeInner> for AType {
+    type Error = ();
+
+    fn ex_try_from(v: ATypeInner) -> Result<AType, ()> {
+        match v {
+            0u8 => Ok(AType::A),
+            1u8 => Ok(AType::B),
+            2u8 => Ok(AType::C),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<AType> for ATypeInner {
+    type Error = ();
+
+    fn ex_try_from(v: AType) -> Result<ATypeInner, ()> {
+        match v {
+            AType::A => Ok(0u8),
+            AType::B => Ok(1u8),
+            AType::C => Ok(2u8),
+        }
+    }
+}
+
+pub struct ATypeMapper;
+
+impl View for ATypeMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecTryFromInto for ATypeMapper {
+    type Src = ATypeInner;
+
+    type Dst = AType;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -92,43 +107,14 @@ impl SpecIso for Msg2Mapper {
     }
 }
 
-impl Iso for Msg2Mapper {
-    type Src<'a> = Msg2Inner;
+impl TryFromInto for ATypeMapper {
+    type Src<'a> = ATypeInner;
 
-    type Dst<'a> = Msg2;
+    type Dst<'a> = AType;
 
-    type SrcOwned = Msg2OwnedInner;
+    type SrcOwned = ATypeInner;
 
-    type DstOwned = Msg2Owned;
-}
-
-pub struct Msg2Owned {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type Msg2OwnedInner = ((u8, u16), u32);
-
-impl View for Msg2Owned {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
-    }
-}
-
-impl From<Msg2Owned> for Msg2OwnedInner {
-    fn ex_from(m: Msg2Owned) -> Msg2OwnedInner {
-        ((m.a, m.b), m.c)
-    }
-}
-
-impl From<Msg2OwnedInner> for Msg2Owned {
-    fn ex_from(m: Msg2OwnedInner) -> Msg2Owned {
-        let ((a, b), c) = m;
-        Msg2Owned { a, b, c }
-    }
+    type DstOwned = AType;
 }
 
 pub struct SpecMsg1 {
@@ -242,6 +228,117 @@ impl From<Msg1OwnedInner> for Msg1Owned {
     fn ex_from(m: Msg1OwnedInner) -> Msg1Owned {
         let (((a, b), c), d) = m;
         Msg1Owned { a, b, c, d }
+    }
+}
+
+pub struct SpecMsg2 {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+pub type SpecMsg2Inner = ((u8, u16), u32);
+
+impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
+    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
+        ((m.a, m.b), m.c)
+    }
+}
+
+impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
+    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
+        let ((a, b), c) = m;
+        SpecMsg2 { a, b, c }
+    }
+}
+
+pub struct Msg2 {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+pub type Msg2Inner = ((u8, u16), u32);
+
+impl View for Msg2 {
+    type V = SpecMsg2;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
+    }
+}
+
+impl From<Msg2> for Msg2Inner {
+    fn ex_from(m: Msg2) -> Msg2Inner {
+        ((m.a, m.b), m.c)
+    }
+}
+
+impl From<Msg2Inner> for Msg2 {
+    fn ex_from(m: Msg2Inner) -> Msg2 {
+        let ((a, b), c) = m;
+        Msg2 { a, b, c }
+    }
+}
+
+pub struct Msg2Mapper;
+
+impl View for Msg2Mapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for Msg2Mapper {
+    type Src = SpecMsg2Inner;
+
+    type Dst = SpecMsg2;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for Msg2Mapper {
+    type Src<'a> = Msg2Inner;
+
+    type Dst<'a> = Msg2;
+
+    type SrcOwned = Msg2OwnedInner;
+
+    type DstOwned = Msg2Owned;
+}
+
+pub struct Msg2Owned {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+pub type Msg2OwnedInner = ((u8, u16), u32);
+
+impl View for Msg2Owned {
+    type V = SpecMsg2;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
+    }
+}
+
+impl From<Msg2Owned> for Msg2OwnedInner {
+    fn ex_from(m: Msg2Owned) -> Msg2OwnedInner {
+        ((m.a, m.b), m.c)
+    }
+}
+
+impl From<Msg2OwnedInner> for Msg2Owned {
+    fn ex_from(m: Msg2OwnedInner) -> Msg2Owned {
+        let ((a, b), c) = m;
+        Msg2Owned { a, b, c }
     }
 }
 
@@ -499,9 +596,7 @@ impl From<Msg4OwnedInner> for Msg4Owned {
     }
 }
 
-pub type ATypeCombinator = U8;
-
-pub type Msg2Combinator = Mapped<((U8, U16), U32), Msg2Mapper>;
+pub type ATypeCombinator = TryMap<U8, ATypeMapper>;
 
 pub struct Predicate5821512137558126895;
 
@@ -546,38 +641,26 @@ pub type Msg1Combinator = Mapped<
     Msg1Mapper,
 >;
 
+pub type Msg2Combinator = Mapped<((U8, U16), U32), Msg2Mapper>;
+
 pub type Msg3Combinator = BytesN<6>;
 
 pub type Msg4VCombinator = Mapped<
-    OrdChoice<
-        OrdChoice<Cond<u8, u8, Msg1Combinator>, Cond<u8, u8, Msg2Combinator>>,
-        Cond<u8, u8, Msg3Combinator>,
-    >,
+    OrdChoice<OrdChoice<Cond<Msg1Combinator>, Cond<Msg2Combinator>>, Cond<Msg3Combinator>>,
     Msg4VMapper,
 >;
 
 pub type Msg4Combinator = Mapped<SpecDepend<ATypeCombinator, Msg4VCombinator>, Msg4Mapper>;
 
 pub open spec fn spec_a_type() -> ATypeCombinator {
-    U8
+    TryMap { inner: U8, mapper: ATypeMapper }
 }
 
 pub fn a_type() -> (o: ATypeCombinator)
     ensures
         o@ == spec_a_type(),
 {
-    U8
-}
-
-pub open spec fn spec_msg2() -> Msg2Combinator {
-    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
-}
-
-pub fn msg2() -> (o: Msg2Combinator)
-    ensures
-        o@ == spec_msg2(),
-{
-    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
+    TryMap { inner: U8, mapper: ATypeMapper }
 }
 
 pub open spec fn spec_msg1() -> Msg1Combinator {
@@ -603,6 +686,17 @@ pub fn msg1() -> (o: Msg1Combinator)
     }
 }
 
+pub open spec fn spec_msg2() -> Msg2Combinator {
+    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
+}
+
+pub fn msg2() -> (o: Msg2Combinator)
+    ensures
+        o@ == spec_msg2(),
+{
+    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
+}
+
 pub open spec fn spec_msg3() -> Msg3Combinator {
     BytesN::<6>
 }
@@ -618,10 +712,10 @@ pub open spec fn spec_msg4_v(t: SpecAType) -> Msg4VCombinator {
     Mapped {
         inner: OrdChoice(
             OrdChoice(
-                Cond { lhs: t, rhs: 0, inner: spec_msg1() },
-                Cond { lhs: t, rhs: 1, inner: spec_msg2() },
+                Cond { cond: t == AType::A, inner: spec_msg1() },
+                Cond { cond: t == AType::B, inner: spec_msg2() },
             ),
-            Cond { lhs: t, rhs: 2, inner: spec_msg3() },
+            Cond { cond: t == AType::C, inner: spec_msg3() },
         ),
         mapper: Msg4VMapper,
     }
@@ -634,10 +728,10 @@ pub fn msg4_v<'a>(t: AType) -> (o: Msg4VCombinator)
     Mapped {
         inner: OrdChoice(
             OrdChoice(
-                Cond { lhs: t, rhs: 0, inner: msg1() },
-                Cond { lhs: t, rhs: 1, inner: msg2() },
+                Cond { cond: t == AType::A, inner: msg1() },
+                Cond { cond: t == AType::B, inner: msg2() },
             ),
-            Cond { lhs: t, rhs: 2, inner: msg3() },
+            Cond { cond: t == AType::C, inner: msg3() },
         ),
         mapper: Msg4VMapper,
     }
@@ -668,31 +762,6 @@ pub fn serialize_a_type(msg: AType, data: &mut Vec<u8>, pos: usize) -> (o: Resul
     a_type().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg2(i: Seq<u8>) -> Result<(usize, SpecMsg2), ()> {
-    spec_msg2().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg2(msg: SpecMsg2) -> Result<Seq<u8>, ()> {
-    spec_msg2().spec_serialize(msg)
-}
-
-pub fn parse_msg2(i: &[u8]) -> (o: Result<(usize, Msg2), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg2(i@) matches Ok(r_) && r@ == r_,
-{
-    msg2().parse(i)
-}
-
-pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg2(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg2().serialize(msg, data, pos)
-}
-
 pub open spec fn parse_spec_msg1(i: Seq<u8>) -> Result<(usize, SpecMsg1), ()> {
     spec_msg1().spec_parse(i)
 }
@@ -716,6 +785,31 @@ pub fn serialize_msg1(msg: Msg1<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Resu
         },
 {
     msg1().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg2(i: Seq<u8>) -> Result<(usize, SpecMsg2), ()> {
+    spec_msg2().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg2(msg: SpecMsg2) -> Result<Seq<u8>, ()> {
+    spec_msg2().spec_serialize(msg)
+}
+
+pub fn parse_msg2(i: &[u8]) -> (o: Result<(usize, Msg2), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg2(i@) matches Ok(r_) && r@ == r_,
+{
+    msg2().parse(i)
+}
+
+pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg2(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg2().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg3(i: Seq<u8>) -> Result<(usize, SpecMsg3), ()> {

--- a/vest-dsl/test/src/elab.rs
+++ b/vest-dsl/test/src/elab.rs
@@ -14,12 +14,6 @@ use vest::utils::*;
 use vstd::prelude::*;
 verus! {
 
-pub type SpecContent0 = Seq<u8>;
-
-pub type Content0<'a> = &'a [u8];
-
-pub type Content0Owned = Vec<u8>;
-
 pub struct SpecMsgD {
     pub f1: Seq<u8>,
     pub f2: u16,
@@ -125,6 +119,169 @@ impl From<MsgDOwnedInner> for MsgDOwned {
     fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
         let (f1, f2) = m;
         MsgDOwned { f1, f2 }
+    }
+}
+
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
+
+pub type SpecContent0 = Seq<u8>;
+
+pub type Content0<'a> = &'a [u8];
+
+pub type Content0Owned = Vec<u8>;
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecMsgCF4Inner = Either<Either<Either<SpecContent0, u16>, u32>, Seq<u8>>;
+
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
+        match m {
+            SpecMsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
+            SpecMsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
+            SpecMsgCF4::C2(m) => Either::Left(Either::Right(m)),
+            SpecMsgCF4::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => SpecMsgCF4::C0(m),
+            Either::Left(Either::Left(Either::Right(m))) => SpecMsgCF4::C1(m),
+            Either::Left(Either::Right(m)) => SpecMsgCF4::C2(m),
+            Either::Right(m) => SpecMsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
+    Unrecognized(&'a [u8]),
+}
+
+pub type MsgCF4Inner<'a> = Either<Either<Either<Content0<'a>, u16>, u32>, &'a [u8]>;
+
+impl View for MsgCF4<'_> {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
+        match m {
+            MsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
+            MsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
+            MsgCF4::C2(m) => Either::Left(Either::Right(m)),
+            MsgCF4::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => MsgCF4::C0(m),
+            Either::Left(Either::Left(Either::Right(m))) => MsgCF4::C1(m),
+            Either::Left(Either::Right(m)) => MsgCF4::C2(m),
+            Either::Right(m) => MsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub struct MsgCF4Mapper;
+
+impl View for MsgCF4Mapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgCF4Mapper {
+    type Src = SpecMsgCF4Inner;
+
+    type Dst = SpecMsgCF4;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgCF4Mapper {
+    type Src<'a> = MsgCF4Inner<'a>;
+
+    type Dst<'a> = MsgCF4<'a>;
+
+    type SrcOwned = MsgCF4OwnedInner;
+
+    type DstOwned = MsgCF4Owned;
+}
+
+pub enum MsgCF4Owned {
+    C0(Content0Owned),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Vec<u8>),
+}
+
+pub type MsgCF4OwnedInner = Either<Either<Either<Content0Owned, u16>, u32>, Vec<u8>>;
+
+impl View for MsgCF4Owned {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl From<MsgCF4Owned> for MsgCF4OwnedInner {
+    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
+        match m {
+            MsgCF4Owned::C0(m) => Either::Left(Either::Left(Either::Left(m))),
+            MsgCF4Owned::C1(m) => Either::Left(Either::Left(Either::Right(m))),
+            MsgCF4Owned::C2(m) => Either::Left(Either::Right(m)),
+            MsgCF4Owned::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl From<MsgCF4OwnedInner> for MsgCF4Owned {
+    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => MsgCF4Owned::C0(m),
+            Either::Left(Either::Left(Either::Right(m))) => MsgCF4Owned::C1(m),
+            Either::Left(Either::Right(m)) => MsgCF4Owned::C2(m),
+            Either::Right(m) => MsgCF4Owned::Unrecognized(m),
+        }
     }
 }
 
@@ -341,152 +498,6 @@ impl From<MsgAOwnedInner> for MsgAOwned {
     }
 }
 
-pub type SpecContentType = u8;
-
-pub type ContentType = u8;
-
-pub type ContentTypeOwned = u8;
-
-pub enum SpecMsgCF4 {
-    C0(SpecContent0),
-    C1(u16),
-    C2(u32),
-}
-
-pub type SpecMsgCF4Inner = Either<Either<SpecContent0, u16>, u32>;
-
-impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
-    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
-        match m {
-            SpecMsgCF4::C0(m) => Either::Left(Either::Left(m)),
-            SpecMsgCF4::C1(m) => Either::Left(Either::Right(m)),
-            SpecMsgCF4::C2(m) => Either::Right(m),
-        }
-    }
-}
-
-impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
-    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
-        match m {
-            Either::Left(Either::Left(m)) => SpecMsgCF4::C0(m),
-            Either::Left(Either::Right(m)) => SpecMsgCF4::C1(m),
-            Either::Right(m) => SpecMsgCF4::C2(m),
-        }
-    }
-}
-
-pub enum MsgCF4<'a> {
-    C0(Content0<'a>),
-    C1(u16),
-    C2(u32),
-}
-
-pub type MsgCF4Inner<'a> = Either<Either<Content0<'a>, u16>, u32>;
-
-impl View for MsgCF4<'_> {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
-    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
-        match m {
-            MsgCF4::C0(m) => Either::Left(Either::Left(m)),
-            MsgCF4::C1(m) => Either::Left(Either::Right(m)),
-            MsgCF4::C2(m) => Either::Right(m),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
-    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
-        match m {
-            Either::Left(Either::Left(m)) => MsgCF4::C0(m),
-            Either::Left(Either::Right(m)) => MsgCF4::C1(m),
-            Either::Right(m) => MsgCF4::C2(m),
-        }
-    }
-}
-
-pub struct MsgCF4Mapper;
-
-impl View for MsgCF4Mapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for MsgCF4Mapper {
-    type Src = SpecMsgCF4Inner;
-
-    type Dst = SpecMsgCF4;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for MsgCF4Mapper {
-    type Src<'a> = MsgCF4Inner<'a>;
-
-    type Dst<'a> = MsgCF4<'a>;
-
-    type SrcOwned = MsgCF4OwnedInner;
-
-    type DstOwned = MsgCF4Owned;
-}
-
-pub enum MsgCF4Owned {
-    C0(Content0Owned),
-    C1(u16),
-    C2(u32),
-}
-
-pub type MsgCF4OwnedInner = Either<Either<Content0Owned, u16>, u32>;
-
-impl View for MsgCF4Owned {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
-        }
-    }
-}
-
-impl From<MsgCF4Owned> for MsgCF4OwnedInner {
-    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
-        match m {
-            MsgCF4Owned::C0(m) => Either::Left(Either::Left(m)),
-            MsgCF4Owned::C1(m) => Either::Left(Either::Right(m)),
-            MsgCF4Owned::C2(m) => Either::Right(m),
-        }
-    }
-}
-
-impl From<MsgCF4OwnedInner> for MsgCF4Owned {
-    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
-        match m {
-            Either::Left(Either::Left(m)) => MsgCF4Owned::C0(m),
-            Either::Left(Either::Right(m)) => MsgCF4Owned::C1(m),
-            Either::Right(m) => MsgCF4Owned::C2(m),
-        }
-    }
-}
-
 pub struct SpecMsgC {
     pub f2: SpecContentType,
     pub f3: u8,
@@ -598,8 +609,6 @@ impl From<MsgCOwnedInner> for MsgCOwned {
     }
 }
 
-pub type Content0Combinator = Bytes;
-
 pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
 
 pub exec const MSGD_F1: [u8; 4]
@@ -674,38 +683,26 @@ pub type MsgDCombinator = Mapped<
     MsgDMapper,
 >;
 
-pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
-
-pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
-
 pub type ContentTypeCombinator = U8;
+
+pub type Content0Combinator = Bytes;
 
 pub type MsgCF4Combinator = AndThen<
     Bytes,
     Mapped<
-        OrdChoice<
-            OrdChoice<Cond<u8, u8, Content0Combinator>, Cond<u8, u8, U16>>,
-            Cond<u8, u8, U32>,
-        >,
+        OrdChoice<OrdChoice<OrdChoice<Cond<Content0Combinator>, Cond<U16>>, Cond<U32>>, Cond<Tail>>,
         MsgCF4Mapper,
     >,
 >;
+
+pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
+
+pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
 
 pub type MsgCCombinator = Mapped<
     SpecDepend<(ContentTypeCombinator, U8), MsgCF4Combinator>,
     MsgCMapper,
 >;
-
-pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
-    Bytes(num as usize)
-}
-
-pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
-    ensures
-        o@ == spec_content_0(num@),
-{
-    Bytes(num as usize)
-}
 
 pub open spec fn spec_msg_d() -> MsgDCombinator {
     Mapped {
@@ -730,6 +727,69 @@ pub fn msg_d() -> (o: MsgDCombinator)
     }
 }
 
+pub open spec fn spec_content_type() -> ContentTypeCombinator {
+    U8
+}
+
+pub fn content_type() -> (o: ContentTypeCombinator)
+    ensures
+        o@ == spec_content_type(),
+{
+    U8
+}
+
+pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
+    Bytes(num as usize)
+}
+
+pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
+    ensures
+        o@ == spec_content_0(num@),
+{
+    Bytes(num as usize)
+}
+
+pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator {
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    OrdChoice(
+                        Cond { cond: f2 == 0, inner: spec_content_0(f3) },
+                        Cond { cond: f2 == 1, inner: U16 },
+                    ),
+                    Cond { cond: f2 == 2, inner: U32 },
+                ),
+                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
+    ensures
+        o@ == spec_msg_c_f4(f3@, f2@),
+{
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    OrdChoice(
+                        Cond { cond: f2 == 0, inner: content_0(f3) },
+                        Cond { cond: f2 == 1, inner: U16 },
+                    ),
+                    Cond { cond: f2 == 2, inner: U32 },
+                ),
+                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
 pub open spec fn spec_msg_b() -> MsgBCombinator {
     Mapped { inner: spec_msg_d(), mapper: MsgBMapper }
 }
@@ -752,50 +812,57 @@ pub fn msg_a() -> (o: MsgACombinator)
     Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
 }
 
-pub open spec fn spec_content_type() -> ContentTypeCombinator {
-    U8
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
 }
 
-pub fn content_type() -> (o: ContentTypeCombinator)
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
+}
+
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
     ensures
-        o@ == spec_content_type(),
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
 {
-    U8
+    msg_d().parse(i)
 }
 
-pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> MsgCF4Combinator {
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    Cond { lhs: f2, rhs: 0, inner: spec_content_0(f3) },
-                    Cond { lhs: f2, rhs: 1, inner: U16 },
-                ),
-                Cond { lhs: f2, rhs: 2, inner: U32 },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
-pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
     ensures
-        o@ == spec_msg_c_f4(f2@, f3@),
-{
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    Cond { lhs: f2, rhs: 0, inner: content_0(f3) },
-                    Cond { lhs: f2, rhs: 1, inner: U16 },
-                ),
-                Cond { lhs: f2, rhs: 2, inner: U32 },
-            ),
-            mapper: MsgCF4Mapper,
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
-    )
+{
+    msg_d().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
+    spec_content_type().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
+    spec_content_type().spec_serialize(msg)
+}
+
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
+{
+    content_type().parse(i)
+}
+
+pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    (),
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_content_type(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    content_type().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
@@ -824,29 +891,41 @@ pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, nu
     content_0(num).serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
-    spec_msg_d().spec_parse(i)
+pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f3: u8, f2: SpecContentType) -> Result<
+    (usize, SpecMsgCF4),
+    (),
+> {
+    spec_msg_c_f4(f3, f2).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
-    spec_msg_d().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f3: u8, f2: SpecContentType) -> Result<
+    Seq<u8>,
+    (),
+> {
+    spec_msg_c_f4(f3, f2).spec_serialize(msg)
 }
 
-pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
+pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<(usize, MsgCF4<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f3@, f2@) matches Ok(r_) && r@ == r_,
 {
-    msg_d().parse(i)
+    msg_c_f4(f3, f2).parse(i)
 }
 
-pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_c_f4(
+    msg: MsgCF4<'_>,
+    data: &mut Vec<u8>,
+    pos: usize,
+    f3: u8,
+    f2: ContentType,
+) -> (o: Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_c_f4(msg@, f3@, f2@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg_d().serialize(msg, data, pos)
+    msg_c_f4(f3, f2).serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
@@ -899,77 +978,12 @@ pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
     msg_a().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
-    spec_content_type().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
-    spec_content_type().spec_serialize(msg)
-}
-
-pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
-{
-    content_type().parse(i)
-}
-
-pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    (),
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_content_type(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    content_type().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u8) -> Result<
-    (usize, SpecMsgCF4),
-    (),
-> {
-    spec_msg_c_f4(f2, f3).spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f2: SpecContentType, f3: u8) -> Result<
-    Seq<u8>,
-    (),
-> {
-    spec_msg_c_f4(f2, f3).spec_serialize(msg)
-}
-
-pub fn parse_msg_c_f4(i: &[u8], f2: ContentType, f3: u8) -> (o: Result<(usize, MsgCF4<'_>), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f2@, f3@) matches Ok(r_) && r@ == r_,
-{
-    msg_c_f4(f2, f3).parse(i)
-}
-
-pub fn serialize_msg_c_f4(
-    msg: MsgCF4<'_>,
-    data: &mut Vec<u8>,
-    pos: usize,
-    f2: ContentType,
-    f3: u8,
-) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_c_f4(msg@, f2@, f3@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_c_f4(f2, f3).serialize(msg, data, pos)
-}
-
 pub open spec fn parse_spec_msg_c(i: Seq<u8>) -> Result<(usize, SpecMsgC), ()> {
     let fst = (spec_content_type(), U8);
     let snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_parse(i)
 }
@@ -979,7 +993,7 @@ pub open spec fn serialize_spec_msg_c(msg: SpecMsgC) -> Result<Seq<u8>, ()> {
     let snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_serialize(msg)
 }
@@ -991,7 +1005,7 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
     let ghost spec_snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     let fst = (content_type(), U8);
     let snd = |deps: (ContentType, u8)| -> (o: MsgCF4Combinator)
@@ -999,7 +1013,7 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
             o@ == spec_snd(deps@),
         {
             let (f2, f3) = deps;
-            msg_c_f4(f2, f3)
+            msg_c_f4(f3, f2)
         };
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.parse(i)
 }
@@ -1014,7 +1028,7 @@ pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
     let ghost spec_snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     let fst = (content_type(), U8);
     let snd = |deps: (ContentType, u8)| -> (o: MsgCF4Combinator)
@@ -1022,7 +1036,7 @@ pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
             o@ == spec_snd(deps@),
         {
             let (f2, f3) = deps;
-            msg_c_f4(f2, f3)
+            msg_c_f4(f3, f2)
         };
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.serialize(
         msg,

--- a/vest-dsl/test/src/elab.vest
+++ b/vest-dsl/test/src/elab.vest
@@ -16,6 +16,7 @@ content_type = enum {
   C0 = 0,
   C1 = 1,
   C2 = 2,
+  ...
 }
 
 msg_c = {
@@ -25,6 +26,7 @@ msg_c = {
     C0 => content_0(@f3),
     C1 => u16,
     C2 => u32,
+    _ => Tail,
   },
 }
 

--- a/vest-dsl/test/src/lib.rs
+++ b/vest-dsl/test/src/lib.rs
@@ -1,2 +1,3 @@
 mod codegen;
 mod elab;
+mod test;

--- a/vest-dsl/test/src/struct.rs
+++ b/vest-dsl/test/src/struct.rs
@@ -6,284 +6,275 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 verus! {
-    /// won't work for serializers
-    pub struct Stream<'a> {
-        pub data: &'a [u8], // the input data
-        pub start: usize, // the index, in range [0, data.len())
-    }
 
-    pub struct SerializeStream {
-        pub data: Vec<u8>,
-        pub start: usize,
-    }
-
-    pub struct SpecStream {
-        pub data: Seq<u8>,
-        pub start: int, // the index, in range [0, data.len())
-    }
-
-    impl<'a> DView for Stream<'a> {
-        type V = SpecStream;
-        open spec fn dview(&self) -> SpecStream {
-            SpecStream {
-                data: self.data.dview(),
-                start: self.start as int,
-            }
-        }
-    }
-
-    impl DView for SerializeStream {
-        type V = SpecStream;
-        open spec fn dview(&self) -> SpecStream {
-            SpecStream {
-                data: self.data.dview(),
-                start: self.start as int,
-            }
-        }
-    }
-
-    #[derive(PartialEq, Eq)]
-    pub enum ParseError {
-        Eof,
-        NotEnoughData,
-        NegativeIndex,
-        IntegerOverflow,
-        ConstMismatch,
-    }
-
-    #[derive(PartialEq, Eq)]
-    pub enum SerializeError {
-        NotEnoughSpace,
-        NegativeIndex,
-        IntegerOverflow,
-        RepeatNMismatch, // for spec_serialize_repeat_n
-        TailLengthMismatch, // for spec_serialize_tail
-        ConstMismatch, // for const serializers
-        BytesLengthMismatch, // for spec_serialize_bytes
-    }
-
-    pub type ParseResult<'a, Output> = Result<(Stream<'a>, usize, Output), ParseError>;
-    pub type SpecParseResult<Output> = Result<(SpecStream, nat, Output), ParseError>;
-
-    pub type SerializeResult = Result<(usize, usize), SerializeError>; // (new start position, number of bytes written)
-    pub type SpecSerializeResult = Result<(SpecStream, nat), SerializeError>;
-
-    /// opaque type abstraction over raw bytes
-    pub struct SecBytes(Vec<u8>);
-
-    impl DView for SecBytes {
-        type V = Seq<u8>;
-        closed spec fn dview(&self) -> Self::V
-        {
-            self.0.dview()
-        }
-    }
-
-    impl SecBytes {
-
-        pub fn length(&self) -> (res: usize)
-            ensures
-                res == self.dview().len()
-        {
-            self.0.length()
-        }
-
-        /// memcpy the secret bytes from `self.0[i..j]` to a new secret bytes
-        pub fn subrange(&self, i: usize, j: usize) -> (res: Self)
-            requires
-                0 <= i <= j <= self.dview().len()
-            ensures
-                res.dview() == self.dview().subrange(i as int, j as int)
-        {
-            Self(slice_to_vec(slice_subrange(vec_as_slice(&self.0), i, j))) // (&self.0[i..j]).to_vec()
-        }
-
-        pub fn append(&mut self, other: &mut Self)
-            ensures
-                self.dview() == old(self).dview() + old(other).dview()
-        {
-            vec_append(&mut self.0, &mut other.0);
-        }
-    }
-
-    pub struct SecStream {
-        pub data : SecBytes,
-        pub start : usize
-    }
-
-    impl DView for SecStream {
-        type V = SpecStream;
-        open spec fn dview(&self) -> SpecStream {
-            SpecStream {
-                data: self.data.dview(),
-                start: self.start as int,
-            }
-        }
-    }
-
-    pub type SecParseResult<Sec> = Result<(SecStream, usize, Sec), ParseError>;
-    pub type SecSerializeResult = Result<(SecStream, usize), SerializeError>;
-
-    #[verifier(external)]
-    impl<'a> std::fmt::Debug for Stream<'a> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "Stream {{ data: {:?}, start: {} }}", self.data, self.start)
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SerializeStream {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SerializeStream {{ data: {:?}, start: {} }}", self.data, self.start)
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SecStream {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SecStream {{ data: {:?}, start: {} }}", self.data, self.start)
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SecBytes {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SecBytes {{ {:?} }}", self.0)
-        }
-    }
-
-    #[verifier(external_body)]
-    impl<'a> std::clone::Clone for Stream<'a> {
-        fn clone(&self) -> (res: Self)
-            ensures
-                self.data == res.data,
-                self.start == res.start
-        {
-            Self {
-                data: self.data.clone(),
-                start: self.start,
-            }
-        }
-    }
-
-    impl<'a> std::clone::Clone for SerializeStream {
-        #[verifier(external_body)]
-        fn clone(&self) -> (res: Self)
-            ensures
-                self.data == res.data,
-                self.start == res.start
-        {
-            Self {
-                data: self.data.clone(),
-                start: self.start,
-            }
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for ParseError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::Eof => write!(f, "Eof"),
-                Self::NotEnoughData => write!(f, "NotEnoughData"),
-                Self::NegativeIndex => write!(f, "Other"),
-                Self::IntegerOverflow => write!(f, "IntegerOverflow"),
-                Self::ConstMismatch => write!(f, "ConstMismatch"),
-            }
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SerializeError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::NotEnoughSpace => write!(f, "NotEnoughSpace"),
-                Self::NegativeIndex => write!(f, "NegativeIndex"),
-                Self::RepeatNMismatch => write!(f, "RepeatNMismatch"),
-                Self::IntegerOverflow => write!(f, "IntegerOverflow"),
-                Self::TailLengthMismatch => write!(f, "TailLengthMismatch"),
-                Self::ConstMismatch => write!(f, "ConstMismatch"),
-                Self::BytesLengthMismatch => write!(f, "BytesLengthMismatch"),
-            }
-        }
-    }
-
-    pub enum Either<A, B> {
-        Left(A),
-        Right(B),
-    }
-
-    impl<A, B> DView for Either<A, B>
-        where
-            A: DView,
-            B: DView,
-    {
-        type V = Either<A::V, B::V>;
-        open spec fn dview(&self) -> Either<A::V, B::V> {
-            match self {
-                Self::Left(a) => Either::Left(a.dview()),
-                Self::Right(b) => Either::Right(b.dview()),
-            }
-        }
-    }
-
-    #[verifier(external)]
-    impl<A,B> std::fmt::Debug for Either<A, B>
-        where
-            A: std::fmt::Debug,
-            B: std::fmt::Debug,
-    {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::Left(a) => write!(f, "Left({:?})", a),
-                Self::Right(b) => write!(f, "Right({:?})", b),
-            }
-        }
-    }
-
+/// won't work for serializers
+pub struct Stream<'a> {
+    pub data: &'a [u8],  // the input data
+    pub start: usize,  // the index, in range [0, data.len())
 }
 
+pub struct SerializeStream {
+    pub data: Vec<u8>,
+    pub start: usize,
+}
+
+pub struct SpecStream {
+    pub data: Seq<u8>,
+    pub start: int,  // the index, in range [0, data.len())
+}
+
+impl<'a> DView for Stream<'a> {
+    type V = SpecStream;
+
+    open spec fn dview(&self) -> SpecStream {
+        SpecStream { data: self.data.dview(), start: self.start as int }
+    }
+}
+
+impl DView for SerializeStream {
+    type V = SpecStream;
+
+    open spec fn dview(&self) -> SpecStream {
+        SpecStream { data: self.data.dview(), start: self.start as int }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum ParseError {
+    Eof,
+    NotEnoughData,
+    NegativeIndex,
+    IntegerOverflow,
+    ConstMismatch,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum SerializeError {
+    NotEnoughSpace,
+    NegativeIndex,
+    IntegerOverflow,
+    RepeatNMismatch,  // for spec_serialize_repeat_n
+    TailLengthMismatch,  // for spec_serialize_tail
+    ConstMismatch,  // for const serializers
+    BytesLengthMismatch,  // for spec_serialize_bytes
+}
+
+pub type ParseResult<'a, Output> = Result<(Stream<'a>, usize, Output), ParseError>;
+
+pub type SpecParseResult<Output> = Result<(SpecStream, nat, Output), ParseError>;
+
+pub type SerializeResult = Result<(usize, usize), SerializeError>;
+  // (new start position, number of bytes written)
+pub type SpecSerializeResult = Result<(SpecStream, nat), SerializeError>;
+
+/// opaque type abstraction over raw bytes
+pub struct SecBytes(Vec<u8>);
+
+impl DView for SecBytes {
+    type V = Seq<u8>;
+
+    closed spec fn dview(&self) -> Self::V {
+        self.0.dview()
+    }
+}
+
+impl SecBytes {
+    pub fn length(&self) -> (res: usize)
+        ensures
+            res == self.dview().len(),
+    {
+        self.0.length()
+    }
+
+    /// memcpy the secret bytes from `self.0[i..j]` to a new secret bytes
+    pub fn subrange(&self, i: usize, j: usize) -> (res: Self)
+        requires
+            0 <= i <= j <= self.dview().len(),
+        ensures
+            res.dview() == self.dview().subrange(i as int, j as int),
+    {
+        Self(
+            slice_to_vec(slice_subrange(vec_as_slice(&self.0), i, j)),
+        )  // (&self.0[i..j]).to_vec()
+
+    }
+
+    pub fn append(&mut self, other: &mut Self)
+        ensures
+            self.dview() == old(self).dview() + old(other).dview(),
+    {
+        vec_append(&mut self.0, &mut other.0);
+    }
+}
+
+pub struct SecStream {
+    pub data: SecBytes,
+    pub start: usize,
+}
+
+impl DView for SecStream {
+    type V = SpecStream;
+
+    open spec fn dview(&self) -> SpecStream {
+        SpecStream { data: self.data.dview(), start: self.start as int }
+    }
+}
+
+pub type SecParseResult<Sec> = Result<(SecStream, usize, Sec), ParseError>;
+
+pub type SecSerializeResult = Result<(SecStream, usize), SerializeError>;
+
+#[verifier(external)]
+impl<'a> std::fmt::Debug for Stream<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Stream {{ data: {:?}, start: {} }}", self.data, self.start)
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SerializeStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SerializeStream {{ data: {:?}, start: {} }}", self.data, self.start)
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SecStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecStream {{ data: {:?}, start: {} }}", self.data, self.start)
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SecBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecBytes {{ {:?} }}", self.0)
+    }
+}
+
+#[verifier(external_body)]
+impl<'a> std::clone::Clone for Stream<'a> {
+    fn clone(&self) -> (res: Self)
+        ensures
+            self.data == res.data,
+            self.start == res.start,
+    {
+        Self { data: self.data.clone(), start: self.start }
+    }
+}
+
+impl<'a> std::clone::Clone for SerializeStream {
+    #[verifier(external_body)]
+    fn clone(&self) -> (res: Self)
+        ensures
+            self.data == res.data,
+            self.start == res.start,
+    {
+        Self { data: self.data.clone(), start: self.start }
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Eof => write!(f, "Eof"),
+            Self::NotEnoughData => write!(f, "NotEnoughData"),
+            Self::NegativeIndex => write!(f, "Other"),
+            Self::IntegerOverflow => write!(f, "IntegerOverflow"),
+            Self::ConstMismatch => write!(f, "ConstMismatch"),
+        }
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SerializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotEnoughSpace => write!(f, "NotEnoughSpace"),
+            Self::NegativeIndex => write!(f, "NegativeIndex"),
+            Self::RepeatNMismatch => write!(f, "RepeatNMismatch"),
+            Self::IntegerOverflow => write!(f, "IntegerOverflow"),
+            Self::TailLengthMismatch => write!(f, "TailLengthMismatch"),
+            Self::ConstMismatch => write!(f, "ConstMismatch"),
+            Self::BytesLengthMismatch => write!(f, "BytesLengthMismatch"),
+        }
+    }
+}
+
+pub enum Either<A, B> {
+    Left(A),
+    Right(B),
+}
+
+impl<A, B> DView for Either<A, B> where A: DView, B: DView {
+    type V = Either<A::V, B::V>;
+
+    open spec fn dview(&self) -> Either<A::V, B::V> {
+        match self {
+            Self::Left(a) => Either::Left(a.dview()),
+            Self::Right(b) => Either::Right(b.dview()),
+        }
+    }
+}
+
+#[verifier(external)]
+impl<A, B> std::fmt::Debug for Either<A, B> where A: std::fmt::Debug, B: std::fmt::Debug {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Left(a) => write!(f, "Left({:?})", a),
+            Self::Right(b) => write!(f, "Right({:?})", b),
+        }
+    }
+}
+
+} // verus!
 verus! {
 
-    /// deep view of an exec type
-    pub trait DView {
-        type V;
-        spec fn dview(&self) -> Self::V;
-    }
+/// deep view of an exec type
+pub trait DView {
+    type V;
 
-    impl<A: DView> DView for &A {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
-    }
+    spec fn dview(&self) -> Self::V;
+}
 
-    impl<A: DView> DView for alloc::boxed::Box<A> {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
-    }
+impl<A: DView> DView for &A {
+    type V = A::V;
 
-    impl<A: DView> DView for alloc::rc::Rc<A> {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
     }
+}
 
-    impl<A: DView> DView for alloc::sync::Arc<A> {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
+impl<A: DView> DView for alloc::boxed::Box<A> {
+    type V = A::V;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
     }
+}
 
-    macro_rules! declare_identity_view {
+impl<A: DView> DView for alloc::rc::Rc<A> {
+    type V = A::V;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
+    }
+}
+
+impl<A: DView> DView for alloc::sync::Arc<A> {
+    type V = A::V;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
+    }
+}
+
+macro_rules! declare_identity_view {
         ($t:ty) => {
             #[cfg_attr(verus_keep_ghost, verifier::verify)]
             impl DView for $t {
@@ -299,22 +290,35 @@ verus! {
         }
     }
 
-    declare_identity_view!(());
-    declare_identity_view!(bool);
-    declare_identity_view!(u8);
-    declare_identity_view!(u16);
-    declare_identity_view!(u32);
-    declare_identity_view!(u64);
-    declare_identity_view!(u128);
-    declare_identity_view!(usize);
-    declare_identity_view!(i8);
-    declare_identity_view!(i16);
-    declare_identity_view!(i32);
-    declare_identity_view!(i64);
-    declare_identity_view!(i128);
-    declare_identity_view!(isize);
+declare_identity_view!(());
 
-    macro_rules! declare_tuple_view {
+declare_identity_view!(bool);
+
+declare_identity_view!(u8);
+
+declare_identity_view!(u16);
+
+declare_identity_view!(u32);
+
+declare_identity_view!(u64);
+
+declare_identity_view!(u128);
+
+declare_identity_view!(usize);
+
+declare_identity_view!(i8);
+
+declare_identity_view!(i16);
+
+declare_identity_view!(i32);
+
+declare_identity_view!(i64);
+
+declare_identity_view!(i128);
+
+declare_identity_view!(isize);
+
+macro_rules! declare_tuple_view {
         ([$($n:tt)*], [$($a:ident)*]) => {
             #[cfg_attr(verus_keep_ghost, verifier::verify)]
             impl<$($a: DView, )*> DView for ($($a, )*) {
@@ -329,1840 +333,1939 @@ verus! {
         }
     }
 
-    declare_tuple_view!([0], [A0]);
-    declare_tuple_view!([0 1], [A0 A1]);
-    declare_tuple_view!([0 1 2], [A0 A1 A2]);
-    declare_tuple_view!([0 1 2 3], [A0 A1 A2 A3]);
+declare_tuple_view!([0], [A0]);
 
-    /// deep view of a Vec
-    impl<T: DView> DView for Vec<T> {
-        type V = Seq<T::V>;
-        open spec fn dview(&self) -> Self::V;
-    }
+declare_tuple_view!([0 1], [A0 A1]);
 
-    #[verifier::external]
-    pub trait VecAdditionalExecFns<T> {
-        fn set(&mut self, i: usize, value: T);
-        fn set_and_swap(&mut self, i: usize, value: &mut T);
-        fn length(&self) -> usize;
-    }
+declare_tuple_view!([0 1 2], [A0 A1 A2]);
 
-    impl<T: DView> VecAdditionalExecFns<T> for Vec<T> {
-        /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
+declare_tuple_view!([0 1 2 3], [A0 A1 A2 A3]);
 
-        #[verifier::external_body]
-        fn set(&mut self, i: usize, value: T)
-            requires
-                i < old(self).dview().len(),
-            ensures
-                self.dview() == old(self).dview().update(i as int, value.dview()),
-        {
-            self[i] = value;
-        }
+/// deep view of a Vec
+impl<T: DView> DView for Vec<T> {
+    type V = Seq<T::V>;
 
-        /// Replacement for `swap(&mut self[i], &mut value)` (which Verus does not support for technical reasons)
-
-        #[verifier::external_body]
-        fn set_and_swap(&mut self, i: usize, value: &mut T)
-            requires
-                i < old(self).dview().len(),
-            ensures
-                value.dview() == old(self).dview().index(i as int)
-        {
-            core::mem::swap(&mut self[i], value);
-        }
-
-        #[verifier::external_body]
-        fn length(&self) -> (res: usize)
-            ensures
-                res == spec_vec_len(self)
-        {
-            self.len()
-        }
-    }
-
-    #[verifier::external_body]
-    pub fn vec_index<T: DView>(vec: &Vec<T>, i: usize) -> (element: &T)
-        requires i < vec.dview().len(),
-        ensures element.dview() == vec.dview().index(i as int)
-    {
-        &vec[i]
-    }
-
-    #[verifier::external_body]
-    pub fn vec_as_slice<T: DView>(vec: &Vec<T>) -> (slice: &[T])
-        ensures slice.dview() == vec.dview()
-    {
-        vec.as_slice()
-    }
-
-    #[verifier::external_body]
-    pub fn vec_push<T: DView>(vec: &mut Vec<T>, value: T)
-        ensures vec.dview() == old(vec).dview().push(value.dview())
-    {
-        vec.push(value);
-    }
-
-    #[verifier::external_body]
-    pub fn vec_new<T: DView>() -> (v: Vec<T>)
-        ensures
-            v.dview() == Seq::<T::V>::empty(),
-    {
-        Vec::<T>::new()
-    }
-
-    #[verifier::external_body]
-    pub fn vec_append<T: DView>(vec: &mut Vec<T>, other: &mut Vec<T>)
-        ensures
-            vec.dview() == old(vec).dview() + old(other).dview(),
-    {
-        vec.append(other)
-    }
-
-    pub open spec fn spec_vec_len<T: DView>(v: &Vec<T>) -> usize;
-
-    #[verifier(external_body)]
-    #[verifier(broadcast_forall)]
-    pub proof fn axiom_spec_len<T: DView>(v: &Vec<T>)
-        ensures
-            #[trigger] spec_vec_len(v) == v.dview().len()
-    {}
-
-
-    impl<T: DView> DView for [T] {
-        type V = Seq<T::V>;
-        open spec fn dview(&self) -> Self::V;
-    }
-
-    impl<T: DView> DView for &[T] {
-        type V = Seq<T::V>;
-        #[verifier::inline]
-        open spec fn dview(&self) -> Self::V {
-            (*self).dview()
-        }
-    }
-
-    #[verifier::external]
-    pub trait SliceAdditionalExecFns<T> {
-        fn set(&mut self, i: usize, value: T);
-        fn length(&self) -> usize;
-    }
-
-    impl<T: DView> SliceAdditionalExecFns<T> for [T] {
-
-        /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
-        #[verifier::external_body]
-        fn set(&mut self, i: usize, value: T)
-            requires
-                i < old(self).dview().len(),
-            ensures
-                self.dview() == old(self).dview().update(i as int, value.dview()),
-        {
-            self[i] = value;
-        }
-
-        #[verifier::external_body]
-        fn length(&self) -> (length: usize)
-            ensures
-                length >= 0,
-                length == self.dview().len()
-        {
-            self.len()
-        }
-
-    }
-
-
-    #[verifier(external_body)]
-    pub exec fn slice_index_get<T: DView>(slice: &[T], i: usize) -> (out: &T)
-        requires 0 <= i < slice.dview().len(),
-        ensures out.dview() == slice.dview().index(i as int),
-    {
-        &slice[i]
-    }
-
-    #[verifier(external_body)]
-    pub exec fn slice_to_vec<T: Copy + DView>(slice: &[T]) -> (out: Vec<T>)
-        ensures out.dview() == slice.dview()
-    {
-        slice.to_vec()
-    }
-
-    #[verifier(external_body)]
-    pub exec fn slice_subrange<T: DView, 'a>(slice: &'a [T], i: usize, j: usize) -> (out: &'a [T])
-        requires 0 <= i <= j <= slice.dview().len()
-        ensures out.dview() == slice.dview().subrange(i as int, j as int)
-    {
-        &slice[i .. j]
-    }
-
-    #[verifier(external_body)]
-    pub exec fn swap_with_slice<T: DView>(left: &mut [T], right: &mut [T])
-        requires
-            old(left).dview().len() == old(right).dview().len(),
-        ensures
-            left.dview() == old(right).dview(),
-            right.dview() == old(left).dview(),
-    {
-        left.swap_with_slice(right)
-    }
-
+    open spec fn dview(&self) -> Self::V;
 }
 
-verus! {
-    /// A *well-behaved parser* should
-    /// 1. keep the input data unchanged
-    /// 2. the new start position should be the addition of the old start position and the number of consumed bytes
-    /// 3. the old and new start positions should be in range
-    pub open spec fn prop_parse_well_behaved_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        s: SpecStream) -> bool
+#[verifier::external]
+pub trait VecAdditionalExecFns<T> {
+    fn set(&mut self, i: usize, value: T);
+
+    fn set_and_swap(&mut self, i: usize, value: &mut T);
+
+    fn length(&self) -> usize;
+}
+
+impl<T: DView> VecAdditionalExecFns<T> for Vec<T> {
+    /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
+    #[verifier::external_body]
+    fn set(&mut self, i: usize, value: T)
+        requires
+            i < old(self).dview().len(),
+        ensures
+            self.dview() == old(self).dview().update(i as int, value.dview()),
     {
-        match parser(s) {
-            Ok((sout, n, _)) => {
-                &&& sout.data == s.data
-                &&& s.start + n == sout.start
-                &&& 0 <= s.start <= sout.start <= s.data.len()
-            }
-            Err(_) => true, // vacuously true
-        }
+        self[i] = value;
     }
 
-    /// A *well-behaved serializer* should
-    /// 1. keep the length of the input data unchanged
-    /// 2. keep the input data prior to the start position unchanged
-    /// 3. keep the input data following serialized data unchanged
-    /// 4. the new start position should be the addition of the old start position and the number of serialized bytes
-    /// 5. the old and new start positions should be in range
-    pub open spec fn prop_serialize_well_behaved_on<R>(
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-s: SpecStream, v: R) -> bool
+    /// Replacement for `swap(&mut self[i], &mut value)` (which Verus does not support for technical reasons)
+    #[verifier::external_body]
+    fn set_and_swap(&mut self, i: usize, value: &mut T)
+        requires
+            i < old(self).dview().len(),
+        ensures
+            value.dview() == old(self).dview().index(i as int),
     {
-        if let Ok((sout, n)) = serializer(s, v) {
-            &&& sout.data.len() == s.data.len()
-            &&& sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)
-            &&& sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(s.start + n, s.data.len() as int)
+        core::mem::swap(&mut self[i], value);
+    }
+
+    #[verifier::external_body]
+    fn length(&self) -> (res: usize)
+        ensures
+            res == spec_vec_len(self),
+    {
+        self.len()
+    }
+}
+
+#[verifier::external_body]
+pub fn vec_index<T: DView>(vec: &Vec<T>, i: usize) -> (element: &T)
+    requires
+        i < vec.dview().len(),
+    ensures
+        element.dview() == vec.dview().index(i as int),
+{
+    &vec[i]
+}
+
+#[verifier::external_body]
+pub fn vec_as_slice<T: DView>(vec: &Vec<T>) -> (slice: &[T])
+    ensures
+        slice.dview() == vec.dview(),
+{
+    vec.as_slice()
+}
+
+#[verifier::external_body]
+pub fn vec_push<T: DView>(vec: &mut Vec<T>, value: T)
+    ensures
+        vec.dview() == old(vec).dview().push(value.dview()),
+{
+    vec.push(value);
+}
+
+#[verifier::external_body]
+pub fn vec_new<T: DView>() -> (v: Vec<T>)
+    ensures
+        v.dview() == Seq::<T::V>::empty(),
+{
+    Vec::<T>::new()
+}
+
+#[verifier::external_body]
+pub fn vec_append<T: DView>(vec: &mut Vec<T>, other: &mut Vec<T>)
+    ensures
+        vec.dview() == old(vec).dview() + old(other).dview(),
+{
+    vec.append(other)
+}
+
+pub open spec fn spec_vec_len<T: DView>(v: &Vec<T>) -> usize;
+
+#[verifier(external_body)]
+#[verifier(broadcast_forall)]
+pub proof fn axiom_spec_len<T: DView>(v: &Vec<T>)
+    ensures
+        #[trigger] spec_vec_len(v) == v.dview().len(),
+{
+}
+
+impl<T: DView> DView for [T] {
+    type V = Seq<T::V>;
+
+    open spec fn dview(&self) -> Self::V;
+}
+
+impl<T: DView> DView for &[T] {
+    type V = Seq<T::V>;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> Self::V {
+        (*self).dview()
+    }
+}
+
+#[verifier::external]
+pub trait SliceAdditionalExecFns<T> {
+    fn set(&mut self, i: usize, value: T);
+
+    fn length(&self) -> usize;
+}
+
+impl<T: DView> SliceAdditionalExecFns<T> for [T] {
+    /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
+    #[verifier::external_body]
+    fn set(&mut self, i: usize, value: T)
+        requires
+            i < old(self).dview().len(),
+        ensures
+            self.dview() == old(self).dview().update(i as int, value.dview()),
+    {
+        self[i] = value;
+    }
+
+    #[verifier::external_body]
+    fn length(&self) -> (length: usize)
+        ensures
+            length >= 0,
+            length == self.dview().len(),
+    {
+        self.len()
+    }
+}
+
+#[verifier(external_body)]
+pub exec fn slice_index_get<T: DView>(slice: &[T], i: usize) -> (out: &T)
+    requires
+        0 <= i < slice.dview().len(),
+    ensures
+        out.dview() == slice.dview().index(i as int),
+{
+    &slice[i]
+}
+
+#[verifier(external_body)]
+pub exec fn slice_to_vec<T: Copy + DView>(slice: &[T]) -> (out: Vec<T>)
+    ensures
+        out.dview() == slice.dview(),
+{
+    slice.to_vec()
+}
+
+#[verifier(external_body)]
+pub exec fn slice_subrange<T: DView, 'a>(slice: &'a [T], i: usize, j: usize) -> (out: &'a [T])
+    requires
+        0 <= i <= j <= slice.dview().len(),
+    ensures
+        out.dview() == slice.dview().subrange(i as int, j as int),
+{
+    &slice[i..j]
+}
+
+#[verifier(external_body)]
+pub exec fn swap_with_slice<T: DView>(left: &mut [T], right: &mut [T])
+    requires
+        old(left).dview().len() == old(right).dview().len(),
+    ensures
+        left.dview() == old(right).dview(),
+        right.dview() == old(left).dview(),
+{
+    left.swap_with_slice(right)
+}
+
+} // verus!
+verus! {
+
+/// A *well-behaved parser* should
+/// 1. keep the input data unchanged
+/// 2. the new start position should be the addition of the old start position and the number of consumed bytes
+/// 3. the old and new start positions should be in range
+pub open spec fn prop_parse_well_behaved_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    s: SpecStream,
+) -> bool {
+    match parser(s) {
+        Ok((sout, n, _)) => {
+            &&& sout.data == s.data
             &&& s.start + n == sout.start
             &&& 0 <= s.start <= sout.start <= s.data.len()
-        } else {
-            true // vacuously true
-        }
+        },
+        Err(_) => true,  // vacuously true
     }
-
-    pub open spec fn prop_serialize_deterministic_on<R>(
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-        s1: SpecStream, s2: SpecStream, v: R) -> bool
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer(s1, v), serializer(s2, v)) {
-            n1 == n2 && sout1.data.subrange(s1.start, s1.start + n1) == sout2.data.subrange(s2.start, s2.start + n2)
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_strong_prefix_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        s1: SpecStream,
-        s2: SpecStream) -> bool
-    {
-        if let Ok((sout1, n, x1)) = parser(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + n <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = parser(s2) {
-                    n == m && x1 == x2
-                } else {
-                    false
-                }
-            } else {
-                true // vacuously true
-            }
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_correct_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-        s: SpecStream, v: R) -> bool
-    {
-        if let Ok((sout, n)) = serializer(s, v) {
-            if let Ok((_, m, res)) = parser(SpecStream {start: s.start, ..sout}) {
-                n == m && v == res
-            } else {
-                false
-            }
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_serialize_inverse_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-        s: SpecStream) -> bool
-    {
-        if let Ok((ss, m, res)) = parser(s) {
-            if let Ok((sout, n)) = serializer(s, res) {
-                m == n && sout.data == s.data
-            } else {
-                false
-            }
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_nonmalleable_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        s1: SpecStream,
-        s2: SpecStream) -> bool
-    {
-        if let (Ok((sout1, n, x1)), Ok((sout2, m, x2))) = (parser(s1), parser(s2)) {
-            x1 == x2 ==> n == m && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + m)
-        } else {
-            true // vacuously true
-        }
-    }
-
-    /// An `exec` parser is equivalent to a `spec` parser if
-    ///
-    /// 1. on the same input stream, they both success and produce the same result,
-    /// including the output stream, the number of consumed bytes and the result value
-    /// 2. or they both fail and throw the same error.
-    pub open spec fn prop_parse_exec_spec_equiv_on<T: DView>(
-        s: Stream,
-        res: ParseResult<T>,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-    {
-        match spec_parser(s.dview()) {
-            Ok((sout, sn, sx)) => {
-                if let Ok((s, n, x)) = res {
-                    &&& s.dview() == sout
-                    &&& n == sn
-                    &&& x.dview() == sx
-                } else {
-                    false
-                }
-            }
-            Err(e) => {
-                if let Err(e2) = res {
-                    e == e2
-                } else {
-                    false
-                }
-            }
-        }
-    }
-
-    /// An `exec` serializer is equivalent to a `spec` serializer if
-    ///
-    /// 1. on the same input stream and value, they both success and produce the same result
-    /// 2. or they both fail and throw the same error.
-    pub open spec fn prop_serialize_exec_spec_equiv_on<T>(
-        old_data: Seq<u8>, start: usize, new_data: Seq<u8>,
-        v: T,
-        res: SerializeResult,
-        spec_serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        match spec_serializer(SpecStream {
-            data: old_data,
-            start: start as int,
-        }, v) {
-            Ok((sout, sn)) => {
-                &&& res.is_ok()
-                &&& res.unwrap().1 == sn
-                &&& res.unwrap().0 as int == sout.start
-                &&& new_data == sout.data
-            }
-            Err(e) => res.is_err() && res.unwrap_err() == e
-        }
-    }
-
-    // prevent the body from seen
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_well_behaved<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>) -> bool
-    {
-        forall |s: SpecStream| prop_parse_well_behaved_on(parser, s)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_serialize_well_behaved<T>(serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        forall |s: SpecStream, v: T| prop_serialize_well_behaved_on(serializer, s, v)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_serialize_deterministic<R>(serializer: spec_fn(SpecStream, R) -> SpecSerializeResult) -> bool
-    {
-        forall |s1: SpecStream, s2: SpecStream, v: R| prop_serialize_deterministic_on(serializer, s1, s2, v)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_strong_prefix<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>) -> bool
-    {
-        forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(parser, s1, s2)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_correct<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        forall |s: SpecStream, v: T| s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_serialize_inverse<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        forall |s: SpecStream| prop_parse_serialize_inverse_on(parser, serializer, s)
-    }
-
-    #[verifier(opaque)]
-    /// this property can actually be derived from the parse_serialize_inverse property (with deterministic serializers)
-    /// ∀ s. serialize(parse(s)) == s
-    /// ==>
-    /// ∀ s1 s2.
-    /// &&& serialize(parse(s1)) == s1 && serialize(parse(s2)) == s2
-    /// &&& (parse(s1) == parse(s2) <==> serialize(parse(s1)) == serialize(parse(s2)) ==> s1 == s2)
-    pub open spec fn prop_parse_nonmalleable<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>) -> bool
-    {
-        forall |s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2)
-    }
-
-    pub proof fn lemma_parse_serialize_inverse_implies_nonmalleable<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult)
-        requires
-            prop_parse_serialize_inverse(parser, serializer),
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_parse_nonmalleable(parser)
-    {
-        reveal(prop_parse_serialize_inverse);
-        reveal(prop_parse_nonmalleable);
-        reveal(prop_serialize_deterministic);
-        assert forall |s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2) by {
-            lemma_parse_serialize_inverse_on(parser, serializer, s1);
-            lemma_parse_serialize_inverse_on(parser, serializer, s2);
-            if let (Ok((sout1, n1, x1)), Ok((sout2, n2, x2))) = (parser(s1), parser(s2)) {
-                if x1 == x2 {
-                    lemma_serialize_deterministic_on(serializer, s1, s2, x1);
-                    assert(n1 == n2);
-                    assert(s1.data.subrange(s1.start, s1.start + n1) =~= s2.data.subrange(s2.start, s2.start + n2));
-                }
-            }
-        }
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_exec_spec_equiv<'a, T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-        where
-            P: FnOnce(Stream<'a>) -> ParseResult<T>,
-            T: DView,
-    {
-        &&& forall |s| #[trigger] exec_parser.requires((s,))
-        &&& forall |s, res| #[trigger] exec_parser.ensures((s,), res) ==> prop_parse_exec_spec_equiv_on(s, res, spec_parser)
-    }
-
-    // #[verifier(opaque)]
-    // pub open spec fn prop_serialize_exec_spec_equiv<T, P>(
-    //     exec_serializer: P,
-    //     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
-    //     where
-    //         P: FnOnce(SerializeStream, T) -> SerializeResult,
-    //         T: std::fmt::Debug + DView,
-    // {
-    //     &&& forall |s, v| #[trigger] exec_serializer.requires((s, v))
-    //     &&& forall |s, v, res| #[trigger] exec_serializer.ensures((s, v), res) ==> prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
-    // }
-
-    // for performance boost
-    pub proof fn lemma_parse_well_behaved_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser)
-        ensures
-            prop_parse_well_behaved_on(parser, s)
-    {
-        reveal(prop_parse_well_behaved);
-    }
-
-    pub proof fn lemma_serialize_well_behaved_on<T>(serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s: SpecStream, v: T)
-        requires
-            prop_serialize_well_behaved(serializer)
-        ensures
-            prop_serialize_well_behaved_on(serializer, s, v)
-    {
-        reveal(prop_serialize_well_behaved);
-    }
-
-    pub proof fn lemma_serialize_deterministic_on<T>(serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s1: SpecStream, s2: SpecStream, v: T)
-        requires
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_serialize_deterministic_on(serializer, s1, s2, v)
-    {
-        reveal(prop_serialize_deterministic);
-    }
-
-    pub proof fn lemma_parse_strong_prefix_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, s1: SpecStream, s2: SpecStream)
-        requires
-            prop_parse_strong_prefix(parser)
-        ensures
-            prop_parse_strong_prefix_on(parser, s1, s2)
-    {
-        reveal(prop_parse_strong_prefix);
-    }
-
-    pub proof fn lemma_parse_correct_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s: SpecStream, v: T)
-        requires
-            prop_parse_correct(parser, serializer)
-        ensures
-            s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v)
-    {
-        reveal(prop_parse_correct);
-    }
-
-    pub proof fn lemma_parse_serialize_inverse_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s: SpecStream)
-        requires
-            prop_parse_serialize_inverse(parser, serializer)
-        ensures
-            prop_parse_serialize_inverse_on(parser, serializer, s)
-    {
-        reveal(prop_parse_serialize_inverse);
-    }
-
-    pub proof fn lemma_parse_nonmalleable_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s1: SpecStream, s2: SpecStream)
-        requires
-            prop_parse_nonmalleable(parser)
-        ensures
-            prop_parse_nonmalleable_on(parser, s1, s2)
-    {
-        reveal(prop_parse_nonmalleable);
-    }
-
-    pub proof fn lemma_parse_exec_spec_equiv_on<'a, T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
-        s: Stream, res: ParseResult<T>)
-        where
-            P: FnOnce(Stream<'a>) -> ParseResult<T>,
-            T: DView,
-        requires
-            prop_parse_exec_spec_equiv(exec_parser, spec_parser),
-            exec_parser.ensures((s,), res)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, spec_parser)
-    {
-        reveal(prop_parse_exec_spec_equiv);
-    }
-
-    // pub proof fn lemma_serialize_exec_spec_equiv_on<T, P>(
-    //     exec_serializer: P,
-    //     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
-    //     s: SerializeStream, v: T, res: SerializeResult)
-    //     where
-    //         P: FnOnce(SerializeStream, T) -> SerializeResult,
-    //         T: std::fmt::Debug + DView,
-    //     requires
-    //         prop_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
-    //         exec_serializer.ensures((s, v), res)
-    //     ensures
-    //         prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
-    // {
-    //     reveal(prop_serialize_exec_spec_equiv);
-    // }
 }
 
+/// A *well-behaved serializer* should
+/// 1. keep the length of the input data unchanged
+/// 2. keep the input data prior to the start position unchanged
+/// 3. keep the input data following serialized data unchanged
+/// 4. the new start position should be the addition of the old start position and the number of serialized bytes
+/// 5. the old and new start positions should be in range
+pub open spec fn prop_serialize_well_behaved_on<R>(
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s: SpecStream,
+    v: R,
+) -> bool {
+    if let Ok((sout, n)) = serializer(s, v) {
+        &&& sout.data.len() == s.data.len()
+        &&& sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)
+        &&& sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(
+            s.start + n,
+            s.data.len() as int,
+        )
+        &&& s.start + n == sout.start
+        &&& 0 <= s.start <= sout.start <= s.data.len()
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_serialize_deterministic_on<R>(
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+    v: R,
+) -> bool {
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer(s1, v), serializer(s2, v)) {
+        n1 == n2 && sout1.data.subrange(s1.start, s1.start + n1) == sout2.data.subrange(
+            s2.start,
+            s2.start + n2,
+        )
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_strong_prefix_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    s1: SpecStream,
+    s2: SpecStream,
+) -> bool {
+    if let Ok((sout1, n, x1)) = parser(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX && 0 <= s2.start <= s2.start
+            + n <= s2.data.len() <= usize::MAX && s1.data.subrange(s1.start, s1.start + n)
+            == s2.data.subrange(s2.start, s2.start + n) {
+            if let Ok((sout2, m, x2)) = parser(s2) {
+                n == m && x1 == x2
+            } else {
+                false
+            }
+        } else {
+            true  // vacuously true
+
+        }
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_correct_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s: SpecStream,
+    v: R,
+) -> bool {
+    if let Ok((sout, n)) = serializer(s, v) {
+        if let Ok((_, m, res)) = parser(SpecStream { start: s.start, ..sout }) {
+            n == m && v == res
+        } else {
+            false
+        }
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_serialize_inverse_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s: SpecStream,
+) -> bool {
+    if let Ok((ss, m, res)) = parser(s) {
+        if let Ok((sout, n)) = serializer(s, res) {
+            m == n && sout.data == s.data
+        } else {
+            false
+        }
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_nonmalleable_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    s1: SpecStream,
+    s2: SpecStream,
+) -> bool {
+    if let (Ok((sout1, n, x1)), Ok((sout2, m, x2))) = (parser(s1), parser(s2)) {
+        x1 == x2 ==> n == m && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + m,
+        )
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+/// An `exec` parser is equivalent to a `spec` parser if
+///
+/// 1. on the same input stream, they both success and produce the same result,
+/// including the output stream, the number of consumed bytes and the result value
+/// 2. or they both fail and throw the same error.
+pub open spec fn prop_parse_exec_spec_equiv_on<T: DView>(
+    s: Stream,
+    res: ParseResult<T>,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool {
+    match spec_parser(s.dview()) {
+        Ok((sout, sn, sx)) => {
+            if let Ok((s, n, x)) = res {
+                &&& s.dview() == sout
+                &&& n == sn
+                &&& x.dview() == sx
+            } else {
+                false
+            }
+        },
+        Err(e) => {
+            if let Err(e2) = res {
+                e == e2
+            } else {
+                false
+            }
+        },
+    }
+}
+
+/// An `exec` serializer is equivalent to a `spec` serializer if
+///
+/// 1. on the same input stream and value, they both success and produce the same result
+/// 2. or they both fail and throw the same error.
+pub open spec fn prop_serialize_exec_spec_equiv_on<T>(
+    old_data: Seq<u8>,
+    start: usize,
+    new_data: Seq<u8>,
+    v: T,
+    res: SerializeResult,
+    spec_serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    match spec_serializer(SpecStream { data: old_data, start: start as int }, v) {
+        Ok((sout, sn)) => {
+            &&& res.is_ok()
+            &&& res.unwrap().1 == sn
+            &&& res.unwrap().0 as int == sout.start
+            &&& new_data == sout.data
+        },
+        Err(e) => res.is_err() && res.unwrap_err() == e,
+    }
+}
+
+// prevent the body from seen
+#[verifier(opaque)]
+pub open spec fn prop_parse_well_behaved<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+) -> bool {
+    forall|s: SpecStream| prop_parse_well_behaved_on(parser, s)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_serialize_well_behaved<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    forall|s: SpecStream, v: T| prop_serialize_well_behaved_on(serializer, s, v)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_serialize_deterministic<R>(
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+) -> bool {
+    forall|s1: SpecStream, s2: SpecStream, v: R|
+        prop_serialize_deterministic_on(serializer, s1, s2, v)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_strong_prefix<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+) -> bool {
+    forall|s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(parser, s1, s2)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_correct<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    forall|s: SpecStream, v: T|
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_serialize_inverse<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    forall|s: SpecStream| prop_parse_serialize_inverse_on(parser, serializer, s)
+}
+
+#[verifier(opaque)]
+/// this property can actually be derived from the parse_serialize_inverse property (with deterministic serializers)
+/// ∀ s. serialize(parse(s)) == s
+/// ==>
+/// ∀ s1 s2.
+/// &&& serialize(parse(s1)) == s1 && serialize(parse(s2)) == s2
+/// &&& (parse(s1) == parse(s2) <==> serialize(parse(s1)) == serialize(parse(s2)) ==> s1 == s2)
+pub open spec fn prop_parse_nonmalleable<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+) -> bool {
+    forall|s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2)
+}
+
+pub proof fn lemma_parse_serialize_inverse_implies_nonmalleable<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+)
+    requires
+        prop_parse_serialize_inverse(parser, serializer),
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_parse_nonmalleable(parser),
+{
+    reveal(prop_parse_serialize_inverse);
+    reveal(prop_parse_nonmalleable);
+    reveal(prop_serialize_deterministic);
+    assert forall|s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2) by {
+        lemma_parse_serialize_inverse_on(parser, serializer, s1);
+        lemma_parse_serialize_inverse_on(parser, serializer, s2);
+        if let (Ok((sout1, n1, x1)), Ok((sout2, n2, x2))) = (parser(s1), parser(s2)) {
+            if x1 == x2 {
+                lemma_serialize_deterministic_on(serializer, s1, s2, x1);
+                assert(n1 == n2);
+                assert(s1.data.subrange(s1.start, s1.start + n1) =~= s2.data.subrange(
+                    s2.start,
+                    s2.start + n2,
+                ));
+            }
+        }
+    }
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_exec_spec_equiv<'a, T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool where P: FnOnce(Stream<'a>) -> ParseResult<T>, T: DView {
+    &&& forall|s| #[trigger] exec_parser.requires((s,))
+    &&& forall|s, res| #[trigger]
+        exec_parser.ensures((s,), res) ==> prop_parse_exec_spec_equiv_on(s, res, spec_parser)
+}
+
+// #[verifier(opaque)]
+// pub open spec fn prop_serialize_exec_spec_equiv<T, P>(
+//     exec_serializer: P,
+//     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
+//     where
+//         P: FnOnce(SerializeStream, T) -> SerializeResult,
+//         T: std::fmt::Debug + DView,
+// {
+//     &&& forall |s, v| #[trigger] exec_serializer.requires((s, v))
+//     &&& forall |s, v, res| #[trigger] exec_serializer.ensures((s, v), res) ==> prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
+// }
+// for performance boost
+pub proof fn lemma_parse_well_behaved_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser),
+    ensures
+        prop_parse_well_behaved_on(parser, s),
+{
+    reveal(prop_parse_well_behaved);
+}
+
+pub proof fn lemma_serialize_well_behaved_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s: SpecStream,
+    v: T,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+    ensures
+        prop_serialize_well_behaved_on(serializer, s, v),
+{
+    reveal(prop_serialize_well_behaved);
+}
+
+pub proof fn lemma_serialize_deterministic_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+    v: T,
+)
+    requires
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_serialize_deterministic_on(serializer, s1, s2, v),
+{
+    reveal(prop_serialize_deterministic);
+}
+
+pub proof fn lemma_parse_strong_prefix_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    s1: SpecStream,
+    s2: SpecStream,
+)
+    requires
+        prop_parse_strong_prefix(parser),
+    ensures
+        prop_parse_strong_prefix_on(parser, s1, s2),
+{
+    reveal(prop_parse_strong_prefix);
+}
+
+pub proof fn lemma_parse_correct_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s: SpecStream,
+    v: T,
+)
+    requires
+        prop_parse_correct(parser, serializer),
+    ensures
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v),
+{
+    reveal(prop_parse_correct);
+}
+
+pub proof fn lemma_parse_serialize_inverse_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s: SpecStream,
+)
+    requires
+        prop_parse_serialize_inverse(parser, serializer),
+    ensures
+        prop_parse_serialize_inverse_on(parser, serializer, s),
+{
+    reveal(prop_parse_serialize_inverse);
+}
+
+pub proof fn lemma_parse_nonmalleable_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+)
+    requires
+        prop_parse_nonmalleable(parser),
+    ensures
+        prop_parse_nonmalleable_on(parser, s1, s2),
+{
+    reveal(prop_parse_nonmalleable);
+}
+
+pub proof fn lemma_parse_exec_spec_equiv_on<'a, T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+    s: Stream,
+    res: ParseResult<T>,
+) where P: FnOnce(Stream<'a>) -> ParseResult<T>, T: DView
+    requires
+        prop_parse_exec_spec_equiv(exec_parser, spec_parser),
+        exec_parser.ensures((s,), res),
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, spec_parser),
+{
+    reveal(prop_parse_exec_spec_equiv);
+}
+
+// pub proof fn lemma_serialize_exec_spec_equiv_on<T, P>(
+//     exec_serializer: P,
+//     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+//     s: SerializeStream, v: T, res: SerializeResult)
+//     where
+//         P: FnOnce(SerializeStream, T) -> SerializeResult,
+//         T: std::fmt::Debug + DView,
+//     requires
+//         prop_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
+//         exec_serializer.ensures((s, v), res)
+//     ensures
+//         prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
+// {
+//     reveal(prop_serialize_exec_spec_equiv);
+// }
+} // verus!
 verus! {
 
-    pub open spec fn spec_parse_u8_le(s: SpecStream) -> (res: SpecParseResult<u8>)
-        recommends
-            0 <= s.start < s.data.len(),
-            s.data.len() >= 1
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
-                SpecStream {
-                    start: s.start + 1,
-                    ..s
-                },
-                1,
-                s.data[s.start],
-            ))
-        }
+pub open spec fn spec_parse_u8_le(s: SpecStream) -> (res: SpecParseResult<u8>)
+    recommends
+        0 <= s.start < s.data.len(),
+        s.data.len() >= 1,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok((SpecStream { start: s.start + 1, ..s }, 1, s.data[s.start]))
     }
+}
 
-    pub open spec fn spec_parse_u16_le(s: SpecStream) -> (res: SpecParseResult<u16>)
-        recommends
-            0 <= s.start < s.data.len() - 1,
-            s.data.len() >= 2
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
+pub open spec fn spec_parse_u16_le(s: SpecStream) -> (res: SpecParseResult<u16>)
+    recommends
+        0 <= s.start < s.data.len() - 1,
+        s.data.len() >= 2,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + 2, ..s },
+                2,
+                spec_u16_from_le_bytes(s.data.subrange(s.start, s.start + 2)),
+            ),
+        )
+    }
+}
+
+pub open spec fn spec_parse_u32_le(s: SpecStream) -> (res: SpecParseResult<u32>)
+    recommends
+        0 <= s.start < s.data.len() - 3,
+        s.data.len() >= 4,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + 4, ..s },
+                4,
+                spec_u32_from_le_bytes(s.data.subrange(s.start, s.start + 4)),
+            ),
+        )
+    }
+}
+
+pub open spec fn spec_parse_u64_le(s: SpecStream) -> (res: SpecParseResult<u64>)
+    recommends
+        0 <= s.start < s.data.len() - 7,
+        s.data.len() >= 8,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + 8, ..s },
+                8,
+                spec_u64_from_le_bytes(s.data.subrange(s.start, s.start + 8)),
+            ),
+        )
+    }
+}
+
+pub open spec fn spec_serialize_u8_le(s: SpecStream, v: u8) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len(),
+        s.data.len() >= 1,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 1 || s.start >= s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        Ok((SpecStream { data: s.data.update(s.start, v), start: s.start + 1 }, 1))
+    }
+}
+
+pub open spec fn spec_serialize_u16_le(s: SpecStream, v: u16) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len() - 1,
+        s.data.len() >= 2,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let data = spec_u16_to_le_bytes(v);
+        Ok(
+            (
                 SpecStream {
+                    data: s.data.update(s.start, data[0]).update(s.start + 1, data[1]),
                     start: s.start + 2,
-                    ..s
                 },
                 2,
-                spec_u16_from_le_bytes(
-                    s.data.subrange(s.start, s.start + 2)
-                )
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_parse_u32_le(s: SpecStream) -> (res: SpecParseResult<u32>)
-        recommends
-            0 <= s.start < s.data.len() - 3,
-            s.data.len() >= 4
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
+pub open spec fn spec_serialize_u32_le(s: SpecStream, v: u32) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len() - 3,
+        s.data.len() >= 4,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let data = spec_u32_to_le_bytes(v);
+        Ok(
+            (
                 SpecStream {
+                    data: s.data.update(s.start, data[0]).update(s.start + 1, data[1]).update(
+                        s.start + 2,
+                        data[2],
+                    ).update(s.start + 3, data[3]),
                     start: s.start + 4,
-                    ..s
                 },
                 4,
-                spec_u32_from_le_bytes(
-                    s.data.subrange(s.start, s.start + 4)
-                )
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_parse_u64_le(s: SpecStream) -> (res: SpecParseResult<u64>)
-        recommends
-            0 <= s.start < s.data.len() - 7,
-            s.data.len() >= 8
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
+pub open spec fn spec_serialize_u64_le(s: SpecStream, v: u64) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len() - 7,
+        s.data.len() >= 8,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let data = spec_u64_to_le_bytes(v);
+        Ok(
+            (
                 SpecStream {
+                    data: s.data.update(s.start, data[0]).update(s.start + 1, data[1]).update(
+                        s.start + 2,
+                        data[2],
+                    ).update(s.start + 3, data[3]).update(s.start + 4, data[4]).update(
+                        s.start + 5,
+                        data[5],
+                    ).update(s.start + 6, data[6]).update(s.start + 7, data[7]),
                     start: s.start + 8,
-                    ..s
                 },
                 8,
-                spec_u64_from_le_bytes(
-                    s.data.subrange(s.start, s.start + 8)
-                )
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_serialize_u8_le(s: SpecStream, v: u8) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len(),
-            s.data.len() >= 1
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 1 || s.start >= s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, v),
-                    start: s.start + 1,
-                },
-                1
-            ))
-        }
+pub exec fn parse_u8_le(s: Stream) -> (res: ParseResult<u8>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let v = *slice_index_get(s.data, s.start);  // &s.data[s.start];
+        Ok((Stream { start: s.start + 1, ..s }, 1, v))
     }
+}
 
-    pub open spec fn spec_serialize_u16_le(s: SpecStream, v: u16) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len() - 1,
-            s.data.len() >= 2
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let data = spec_u16_to_le_bytes(v);
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, data[0])
-                                .update(s.start + 1, data[1]),
-                    start: s.start + 2,
-                },
-                2
-            ))
-        }
+pub exec fn parse_u16_le(s: Stream) -> (res: ParseResult<u16>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u16_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 2 || s.start >= s.data.length() - 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(s.data, s.start, s.start + 2);  // &s.data[s.start..s.start + 2];
+        let v = u16_from_le_bytes(data);
+        Ok((Stream { start: s.start + 2, ..s }, 2, v))
     }
+}
 
-    pub open spec fn spec_serialize_u32_le(s: SpecStream, v: u32) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len() - 3,
-            s.data.len() >= 4
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let data = spec_u32_to_le_bytes(v);
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, data[0])
-                                .update(s.start + 1, data[1])
-                                .update(s.start + 2, data[2])
-                                .update(s.start + 3, data[3]),
-                    start: s.start + 4,
-                },
-                4
-            ))
-        }
+pub exec fn parse_u32_le(s: Stream) -> (res: ParseResult<u32>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u32_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 4 || s.start >= s.data.length() - 3 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(s.data, s.start, s.start + 4);  // &s.data[s.start..s.start + 4];
+        let v = u32_from_le_bytes(data);
+        Ok((Stream { start: s.start + 4, ..s }, 4, v))
     }
+}
 
-    pub open spec fn spec_serialize_u64_le(s: SpecStream, v: u64) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len() - 7,
-            s.data.len() >= 8
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let data = spec_u64_to_le_bytes(v);
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, data[0])
-                                .update(s.start + 1, data[1])
-                                .update(s.start + 2, data[2])
-                                .update(s.start + 3, data[3])
-                                .update(s.start + 4, data[4])
-                                .update(s.start + 5, data[5])
-                                .update(s.start + 6, data[6])
-                                .update(s.start + 7, data[7]),
-                    start: s.start + 8,
-                },
-                8
-            ))
-        }
+pub exec fn parse_u64_le(s: Stream) -> (res: ParseResult<u64>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u64_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 8 || s.start >= s.data.length() - 7 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(&s.data, s.start, s.start + 8);  // &s.data[s.start..s.start + 8];
+        let v = u64_from_le_bytes(data);
+        Ok((Stream { start: s.start + 8, ..s }, 8, v))
     }
+}
 
-
-    pub exec fn parse_u8_le(s: Stream) -> (res: ParseResult<u8>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let v = *slice_index_get(s.data, s.start); // &s.data[s.start];
-            Ok((
-                Stream {
-                    start: s.start + 1,
-                    ..s
-                },
-                1,
-                v
-            ))
-        }
+pub exec fn serialize_u8_le(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u8_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 1 || start >= data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        data.set(start, v);
+        Ok((start + 1, 1))
     }
+}
 
-    pub exec fn parse_u16_le(s: Stream) -> (res: ParseResult<u16>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u16_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 2 || s.start >= s.data.length() - 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(s.data, s.start, s.start + 2); // &s.data[s.start..s.start + 2];
-            let v = u16_from_le_bytes(data);
-            Ok((
-                Stream {
-                    start: s.start + 2,
-                    ..s
-                },
-                2,
-                v
-            ))
-        }
+pub exec fn serialize_u16_le(data: &mut [u8], start: usize, v: u16) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u16_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 2 || start >= data.length() - 1 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let bytes = u16_to_le_bytes(v);
+        data.set(start, *vec_index(&bytes, 0));  // data[start] = bytes[0];
+        data.set(start + 1, *vec_index(&bytes, 1));  // data[start + 1] = bytes[1];
+        Ok((start + 2, 2))
     }
+}
 
-    pub exec fn parse_u32_le(s: Stream) -> (res: ParseResult<u32>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u32_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 4 || s.start >= s.data.length() - 3 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(s.data, s.start, s.start + 4); // &s.data[s.start..s.start + 4];
-            let v = u32_from_le_bytes(data);
-            Ok((
-                Stream {
-                    start: s.start + 4,
-                    ..s
-                },
-                4,
-                v
-            ))
-        }
+pub exec fn serialize_u32_le(data: &mut [u8], start: usize, v: u32) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u32_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 4 || start >= data.length() - 3 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let bytes = u32_to_le_bytes(v);
+        data.set(start, *vec_index(&bytes, 0));  // data[start] = bytes[0];
+        data.set(start + 1, *vec_index(&bytes, 1));  // data[start + 1] = bytes[1];
+        data.set(start + 2, *vec_index(&bytes, 2));  // data[start + 2] = bytes[2];
+        data.set(start + 3, *vec_index(&bytes, 3));  // data[start + 3] = bytes[3];
+        Ok((start + 4, 4))
     }
+}
 
-    pub exec fn parse_u64_le(s: Stream) -> (res: ParseResult<u64>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u64_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 8 || s.start >= s.data.length() - 7 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(&s.data, s.start, s.start + 8); // &s.data[s.start..s.start + 8];
-            let v = u64_from_le_bytes(data);
-            Ok((
-                Stream {
-                    start: s.start + 8,
-                    ..s
-                },
-                8,
-                v
-            ))
-        }
+pub exec fn serialize_u64_le(data: &mut [u8], start: usize, v: u64) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u64_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 8 || start >= data.length() - 7 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let bytes = u64_to_le_bytes(v);
+        data.set(start, *vec_index(&bytes, 0));
+        data.set(start + 1, *vec_index(&bytes, 1));
+        data.set(start + 2, *vec_index(&bytes, 2));
+        data.set(start + 3, *vec_index(&bytes, 3));
+        data.set(start + 4, *vec_index(&bytes, 4));
+        data.set(start + 5, *vec_index(&bytes, 5));
+        data.set(start + 6, *vec_index(&bytes, 6));
+        data.set(start + 7, *vec_index(&bytes, 7));
+        Ok((start + 8, 8))
     }
+}
 
-    pub exec fn serialize_u8_le(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u8_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 1 || start >= data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            data.set(start, v);
-            Ok((
-                start + 1,
-                1
-            ))
-        }
+pub proof fn lemma_parse_u8_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u8_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le, s) by {
+        lemma_parse_u8_le_well_behaved_on(s)
     }
+}
 
-    pub exec fn serialize_u16_le(data: &mut [u8], start: usize, v: u16) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u16_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 2 || start >= data.length() - 1  {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let bytes = u16_to_le_bytes(v);
-            data.set(start, *vec_index(&bytes, 0)); // data[start] = bytes[0];
-            data.set(start + 1, *vec_index(&bytes, 1)); // data[start + 1] = bytes[1];
-            Ok((
-                start + 2,
-                2
-            ))
-        }
+pub proof fn lemma_parse_u16_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u16_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u16_le, s) by {
+        lemma_parse_u16_le_well_behaved_on(s)
     }
+}
 
-    pub exec fn serialize_u32_le(data: &mut [u8], start: usize, v: u32) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u32_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 4 || start >= data.length() - 3  {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let bytes = u32_to_le_bytes(v);
-            data.set(start, *vec_index(&bytes, 0)); // data[start] = bytes[0];
-            data.set(start + 1, *vec_index(&bytes, 1)); // data[start + 1] = bytes[1];
-            data.set(start + 2, *vec_index(&bytes, 2)); // data[start + 2] = bytes[2];
-            data.set(start + 3, *vec_index(&bytes, 3)); // data[start + 3] = bytes[3];
-            Ok((
-                start + 4,
-                4
-            ))
-        }
+pub proof fn lemma_parse_u32_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u32_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u32_le, s) by {
+        lemma_parse_u32_le_well_behaved_on(s)
     }
+}
 
-    pub exec fn serialize_u64_le(data: &mut [u8], start: usize, v: u64) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u64_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 8 || start >= data.length() - 7  {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let bytes = u64_to_le_bytes(v);
-            data.set(start, *vec_index(&bytes, 0));
-            data.set(start + 1, *vec_index(&bytes, 1));
-            data.set(start + 2, *vec_index(&bytes, 2));
-            data.set(start + 3, *vec_index(&bytes, 3));
-            data.set(start + 4, *vec_index(&bytes, 4));
-            data.set(start + 5, *vec_index(&bytes, 5));
-            data.set(start + 6, *vec_index(&bytes, 6));
-            data.set(start + 7, *vec_index(&bytes, 7));
-            Ok((
-                start + 8,
-                8
-            ))
-        }
+pub proof fn lemma_parse_u64_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u64_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u64_le, s) by {
+        lemma_parse_u64_le_well_behaved_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u8_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le, s) by {
-            lemma_parse_u8_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u8_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u8>);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le, s, v) by {
+        lemma_serialize_u8_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u16_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u16_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u16_le, s) by {
-            lemma_parse_u16_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u16_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u16>);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u16_le, s, v) by {
+        lemma_serialize_u16_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u32_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u32_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u32_le, s) by {
-            lemma_parse_u32_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u32_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u32>);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u32_le, s, v) by {
+        lemma_serialize_u32_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u64_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u64_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u64_le, s) by {
-            lemma_parse_u64_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u64_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u64>);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u64_le, s, v) by {
+        lemma_serialize_u64_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u8>);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le, s, v) by {
-            lemma_serialize_u8_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u8_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u8>);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u8_le, s1, s2, v) by {
+        lemma_serialize_u8_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u16>);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u16_le, s, v) by {
-            lemma_serialize_u16_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u16_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u16>);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u16_le, s1, s2, v) by {
+        lemma_serialize_u16_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u32_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u32>);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u32_le, s, v) by {
-            lemma_serialize_u32_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u32_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u32>);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u32_le, s1, s2, v) by {
+        lemma_serialize_u32_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u64_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u64>);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u64_le, s, v) by {
-            lemma_serialize_u64_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u64_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u64>);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u64_le, s1, s2, v) by {
+        lemma_serialize_u64_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u8>);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u8_le, s1, s2, v) by {
-            lemma_serialize_u8_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u8_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u8_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le, s1, s2) by {
+        lemma_parse_u8_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u16>);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u16_le, s1, s2, v) by {
-            lemma_serialize_u16_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u16_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u16_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u16_le, s1, s2) by {
+        lemma_parse_u16_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_serialize_u32_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u32>);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u32_le, s1, s2, v) by {
-            lemma_serialize_u32_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u32_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u32_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u32_le, s1, s2) by {
+        lemma_parse_u32_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_serialize_u64_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u64>);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u64_le, s1, s2, v) by {
-            lemma_serialize_u64_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u64_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u64_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u64_le, s1, s2) by {
+        lemma_parse_u64_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u8_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le, s1, s2) by {
-            lemma_parse_u8_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u8_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_parse_correct::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u8_le, spec_serialize_u8_le, s, v) by {
+        lemma_parse_u8_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u16_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u16_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u16_le, s1, s2) by {
-            lemma_parse_u16_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u16_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_parse_correct::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u16_le, spec_serialize_u16_le, s, v) by {
+        lemma_parse_u16_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u32_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u32_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u32_le, s1, s2) by {
-            lemma_parse_u32_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u32_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_parse_correct::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u32_le, spec_serialize_u32_le, s, v) by {
+        lemma_parse_u32_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u64_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u64_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u64_le, s1, s2) by {
-            lemma_parse_u64_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u64_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_parse_correct::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u64_le, spec_serialize_u64_le, s, v) by {
+        lemma_parse_u64_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_parse_correct::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u8_le, spec_serialize_u8_le, s, v) by {
-            lemma_parse_u8_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u8_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u8_le, spec_serialize_u8_le, s) by {
+        lemma_parse_u8_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u16_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_parse_correct::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u16_le, spec_serialize_u16_le, s, v) by {
-            lemma_parse_u16_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u16_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u16_le, spec_serialize_u16_le, s) by {
+        lemma_parse_u16_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u32_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_parse_correct::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u32_le, spec_serialize_u32_le, s, v) by {
-            lemma_parse_u32_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u32_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u32_le, spec_serialize_u32_le, s) by {
+        lemma_parse_u32_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u64_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_parse_correct::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u64_le, spec_serialize_u64_le, s, v) by {
-            lemma_parse_u64_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u64_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u64_le, spec_serialize_u64_le, s) by {
+        lemma_parse_u64_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u8_le, spec_serialize_u8_le, s) by {
-            lemma_parse_u8_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u8_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u8_le(s)),
+{
+    lemma_parse_u8_le_serialize_inverse();
+    lemma_serialize_u8_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u8_le(s),
+        |s, v| spec_serialize_u8_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u16_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u16_le, spec_serialize_u16_le, s) by {
-            lemma_parse_u16_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u16_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u16_le(s)),
+{
+    lemma_parse_u16_le_serialize_inverse();
+    lemma_serialize_u16_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u16_le(s),
+        |s, v| spec_serialize_u16_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u32_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u32_le, spec_serialize_u32_le, s) by {
-            lemma_parse_u32_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u32_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u32_le(s)),
+{
+    lemma_parse_u32_le_serialize_inverse();
+    lemma_serialize_u32_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u32_le(s),
+        |s, v| spec_serialize_u32_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u64_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u64_le, spec_serialize_u64_le, s) by {
-            lemma_parse_u64_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u64_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u64_le(s)),
+{
+    lemma_parse_u64_le_serialize_inverse();
+    lemma_serialize_u64_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u64_le(s),
+        |s, v| spec_serialize_u64_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u8_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u8_le(s))
-    {
-        lemma_parse_u8_le_serialize_inverse();
-        lemma_serialize_u8_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v));
-    }
+pub proof fn lemma_parse_u8_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u8_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u16_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u16_le(s))
-    {
-        lemma_parse_u16_le_serialize_inverse();
-        lemma_serialize_u16_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v));
-    }
+pub proof fn lemma_parse_u16_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u16_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u32_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u32_le(s))
-    {
-        lemma_parse_u32_le_serialize_inverse();
-        lemma_serialize_u32_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v));
-    }
+pub proof fn lemma_parse_u32_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u32_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u64_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u64_le(s))
-    {
-        lemma_parse_u64_le_serialize_inverse();
-        lemma_serialize_u64_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v));
-    }
+pub proof fn lemma_parse_u64_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u64_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u8_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u8_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u16_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u16_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u32_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u32_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u64_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u64_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u8_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u8_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u8_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u8_le(s2) {
-                    assert(n == 1);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            s1.data[s1.start]; {}
-                            s1.data.subrange(s1.start, s1.start + 1)[0]; {}
-                            s2.data.subrange(s2.start, s2.start + 1)[0]; {}
-                            s2.data[s2.start]; {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u8_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u8_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u8_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u8_le(s2) {
+                assert(n == 1);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        s1.data[s1.start]; {}
+                        s1.data.subrange(s1.start, s1.start + 1)[0]; {}
+                        s2.data.subrange(s2.start, s2.start + 1)[0]; {}
+                        s2.data[s2.start]; {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u16_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u16_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u16_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u16_le(s2) {
-                    assert(n == 2);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            spec_u16_from_le_bytes(s1.data.subrange(s1.start, s1.start + 2)); {}
-                            spec_u16_from_le_bytes(s2.data.subrange(s2.start, s2.start + 2)); {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u16_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u16_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u16_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u16_le(s2) {
+                assert(n == 2);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        spec_u16_from_le_bytes(s1.data.subrange(s1.start, s1.start + 2)); {}
+                        spec_u16_from_le_bytes(s2.data.subrange(s2.start, s2.start + 2)); {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u32_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u32_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u32_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u32_le(s2) {
-                    assert(n == 4);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            spec_u32_from_le_bytes(s1.data.subrange(s1.start, s1.start + 4)); {}
-                            spec_u32_from_le_bytes(s2.data.subrange(s2.start, s2.start + 4)); {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u32_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u32_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u32_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u32_le(s2) {
+                assert(n == 4);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        spec_u32_from_le_bytes(s1.data.subrange(s1.start, s1.start + 4)); {}
+                        spec_u32_from_le_bytes(s2.data.subrange(s2.start, s2.start + 4)); {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u64_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u64_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u64_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u64_le(s2) {
-                    assert(n == 8);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            spec_u64_from_le_bytes(s1.data.subrange(s1.start, s1.start + 8)); {}
-                            spec_u64_from_le_bytes(s2.data.subrange(s2.start, s2.start + 8)); {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u64_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u64_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u64_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u64_le(s2) {
+                assert(n == 8);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        spec_u64_from_le_bytes(s1.data.subrange(s1.start, s1.start + 8)); {}
+                        spec_u64_from_le_bytes(s2.data.subrange(s2.start, s2.start + 8)); {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_well_behaved_on(s: SpecStream, v: u8)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u8_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u8_le(s, v) {
-            assert(n == 1 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 1, s.data.len() as int) =~= s.data.subrange(s.start + 1, s.data.len() as int));
-        }
+pub proof fn lemma_serialize_u8_le_well_behaved_on(s: SpecStream, v: u8)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u8_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u8_le(s, v) {
+        assert(n == 1 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 1, s.data.len() as int) =~= s.data.subrange(
+            s.start + 1,
+            s.data.len() as int,
+        ));
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_well_behaved_on(s: SpecStream, v: u16)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u16_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
+pub proof fn lemma_serialize_u16_le_well_behaved_on(s: SpecStream, v: u16)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u16_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
+        lemma_auto_spec_u16_to_from_le_bytes();
+        assert(n == 2 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 2, s.data.len() as int) =~= s.data.subrange(
+            s.start + 2,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u32_le_well_behaved_on(s: SpecStream, v: u32)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u32_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
+        lemma_auto_spec_u32_to_from_le_bytes();
+        assert(n == 4 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 4, s.data.len() as int) =~= s.data.subrange(
+            s.start + 4,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u64_le_well_behaved_on(s: SpecStream, v: u64)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u64_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
+        lemma_auto_spec_u64_to_from_le_bytes();
+        assert(n == 8 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 8, s.data.len() as int) =~= s.data.subrange(
+            s.start + 8,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u8_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u8)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u8_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u8_le(s1, v),
+        spec_serialize_u8_le(s2, v),
+    ) {
+        assert(n1 == 1 && n2 == 1);
+        assert(sout1.data.subrange(s1.start, s1.start + 1) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 1,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u16_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u16)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u16_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u16_le(s1, v),
+        spec_serialize_u16_le(s2, v),
+    ) {
+        lemma_auto_spec_u16_to_from_le_bytes();
+        assert(n1 == 2 && n2 == 2);
+        assert(sout1.data.subrange(s1.start, s1.start + 2) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 2,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u32_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u32)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u32_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u32_le(s1, v),
+        spec_serialize_u32_le(s2, v),
+    ) {
+        lemma_auto_spec_u32_to_from_le_bytes();
+        assert(n1 == 4 && n2 == 4);
+        assert(sout1.data.subrange(s1.start, s1.start + 4) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 4,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u64_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u64)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u64_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u64_le(s1, v),
+        spec_serialize_u64_le(s2, v),
+    ) {
+        lemma_auto_spec_u64_to_from_le_bytes();
+        assert(n1 == 8 && n2 == 8);
+        assert(sout1.data.subrange(s1.start, s1.start + 8) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 8,
+        ));
+    }
+}
+
+pub proof fn lemma_parse_u8_le_correct_on(s: SpecStream, v: u8)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v), s, v),
+{
+}
+
+pub proof fn lemma_parse_u16_le_correct_on(s: SpecStream, v: u16)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
+        assert(sout.data.len() == s.data.len()) by { lemma_serialize_u16_le_well_behaved_on(s, v) }
+        if let Ok((_, m, res)) = spec_parse_u16_le(SpecStream { start: s.start, ..sout }) {
             lemma_auto_spec_u16_to_from_le_bytes();
-            assert(n == 2 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 2, s.data.len() as int) =~= s.data.subrange(s.start + 2, s.data.len() as int));
+            assert(n == m);
+            assert(res == spec_u16_from_le_bytes(sout.data.subrange(s.start, s.start + 2)));
+            assert(sout.data.subrange(s.start, s.start + 2) =~= spec_u16_to_le_bytes(v));
+            assert(v =~= res);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u32_le_well_behaved_on(s: SpecStream, v: u32)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u32_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
+pub proof fn lemma_parse_u32_le_correct_on(s: SpecStream, v: u32)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
+        assert(sout.data.len() == s.data.len()) by { lemma_serialize_u32_le_well_behaved_on(s, v) }
+        if let Ok((_, m, res)) = spec_parse_u32_le(SpecStream { start: s.start, ..sout }) {
             lemma_auto_spec_u32_to_from_le_bytes();
-            assert(n == 4 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 4, s.data.len() as int) =~= s.data.subrange(s.start + 4, s.data.len() as int));
+            assert(n == m);
+            assert(res == spec_u32_from_le_bytes(sout.data.subrange(s.start, s.start + 4)));
+            assert(sout.data.subrange(s.start, s.start + 4) =~= spec_u32_to_le_bytes(v));
+            assert(v =~= res);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u64_le_well_behaved_on(s: SpecStream, v: u64)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u64_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
+pub proof fn lemma_parse_u64_le_correct_on(s: SpecStream, v: u64)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
+        assert(sout.data.len() == s.data.len()) by { lemma_serialize_u64_le_well_behaved_on(s, v) }
+        if let Ok((_, m, res)) = spec_parse_u64_le(SpecStream { start: s.start, ..sout }) {
             lemma_auto_spec_u64_to_from_le_bytes();
-            assert(n == 8 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 8, s.data.len() as int) =~= s.data.subrange(s.start + 8, s.data.len() as int));
+            assert(n == m);
+            assert(res == spec_u64_from_le_bytes(sout.data.subrange(s.start, s.start + 8)));
+            assert(sout.data.subrange(s.start, s.start + 8) =~= spec_u64_to_le_bytes(v));
+            assert(v =~= res);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u8)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u8_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u8_le(s1, v), spec_serialize_u8_le(s2, v)) {
-            assert(n1 == 1 && n2 == 1);
-            assert(sout1.data.subrange(s1.start, s1.start + 1) =~= sout2.data.subrange(s2.start, s2.start + 1));
+pub proof fn lemma_parse_u8_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u8_le(s),
+            |s, v| spec_serialize_u8_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u8_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u8_le(s, res) {
+            assert(n == m && sout.data =~= s.data);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u16)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u16_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u16_le(s1, v), spec_serialize_u16_le(s2, v)) {
-            lemma_auto_spec_u16_to_from_le_bytes();
-            assert(n1 == 2 && n2 == 2);
-            assert(sout1.data.subrange(s1.start, s1.start + 2) =~= sout2.data.subrange(s2.start, s2.start + 2));
-        }
-    }
-
-    pub proof fn lemma_serialize_u32_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u32)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u32_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u32_le(s1, v), spec_serialize_u32_le(s2, v)) {
-            lemma_auto_spec_u32_to_from_le_bytes();
-            assert(n1 == 4 && n2 == 4);
-            assert(sout1.data.subrange(s1.start, s1.start + 4) =~= sout2.data.subrange(s2.start, s2.start + 4));
-        }
-    }
-
-    pub proof fn lemma_serialize_u64_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u64)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u64_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u64_le(s1, v), spec_serialize_u64_le(s2, v)) {
-            lemma_auto_spec_u64_to_from_le_bytes();
-            assert(n1 == 8 && n2 == 8);
-            assert(sout1.data.subrange(s1.start, s1.start + 8) =~= sout2.data.subrange(s2.start, s2.start + 8));
-        }
-    }
-
-    pub proof fn lemma_parse_u8_le_correct_on(s: SpecStream, v: u8)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v), s, v)
-    {}
-
-    pub proof fn lemma_parse_u16_le_correct_on(s: SpecStream, v: u16)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
-            assert(sout.data.len() == s.data.len()) by { lemma_serialize_u16_le_well_behaved_on(s, v)}
-            if let Ok((_, m, res)) = spec_parse_u16_le(SpecStream {start: s.start, ..sout}) {
+pub proof fn lemma_parse_u16_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u16_le(s),
+            |s, v| spec_serialize_u16_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u16_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u16_le(s, res) {
+            assert(n == m && sout.data =~= s.data) by {
                 lemma_auto_spec_u16_to_from_le_bytes();
-                assert(n == m);
-                assert(res == spec_u16_from_le_bytes(sout.data.subrange(s.start, s.start + 2)));
-                assert(sout.data.subrange(s.start, s.start + 2) =~= spec_u16_to_le_bytes(v));
-                assert(v =~= res);
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u32_le_correct_on(s: SpecStream, v: u32)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
-            assert(sout.data.len() == s.data.len()) by { lemma_serialize_u32_le_well_behaved_on(s, v)}
-            if let Ok((_, m, res)) = spec_parse_u32_le(SpecStream {start: s.start, ..sout}) {
+pub proof fn lemma_parse_u32_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u32_le(s),
+            |s, v| spec_serialize_u32_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u32_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u32_le(s, res) {
+            assert(n == m && sout.data =~= s.data) by {
                 lemma_auto_spec_u32_to_from_le_bytes();
-                assert(n == m);
-                assert(res == spec_u32_from_le_bytes(sout.data.subrange(s.start, s.start + 4)));
-                assert(sout.data.subrange(s.start, s.start + 4) =~= spec_u32_to_le_bytes(v));
-                assert(v =~= res);
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u64_le_correct_on(s: SpecStream, v: u64)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
-            assert(sout.data.len() == s.data.len()) by { lemma_serialize_u64_le_well_behaved_on(s, v)}
-            if let Ok((_, m, res)) = spec_parse_u64_le(SpecStream {start: s.start, ..sout}) {
+pub proof fn lemma_parse_u64_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u64_le(s),
+            |s, v| spec_serialize_u64_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u64_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u64_le(s, res) {
+            assert(n == m && sout.data =~= s.data) by {
                 lemma_auto_spec_u64_to_from_le_bytes();
-                assert(n == m);
-                assert(res == spec_u64_from_le_bytes(sout.data.subrange(s.start, s.start + 8)));
-                assert(sout.data.subrange(s.start, s.start + 8) =~= spec_u64_to_le_bytes(v));
-                assert(v =~= res);
             }
         }
     }
-
-    pub proof fn lemma_parse_u8_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u8_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u8_le(s, res) {
-                assert(n == m && sout.data =~= s.data);
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_u16_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u16_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u16_le(s, res) {
-                assert(n == m && sout.data =~= s.data) by {
-                    lemma_auto_spec_u16_to_from_le_bytes();
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_u32_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u32_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u32_le(s, res) {
-                assert(n == m && sout.data =~= s.data) by {
-                    lemma_auto_spec_u32_to_from_le_bytes();
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_u64_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u64_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u64_le(s, res) {
-                assert(n == m && sout.data =~= s.data) by {
-                    lemma_auto_spec_u64_to_from_le_bytes();
-                }
-            }
-        }
-    }
+}
 
 // Conversion between u16 and little-endian byte sequences
-
-pub closed spec fn spec_u16_to_le_bytes(x: u16) -> Seq<u8>
-{
-  seq![
-    (x & 0xff) as u8,
-    ((x >> 8) & 0xff) as u8
-  ]
+pub closed spec fn spec_u16_to_le_bytes(x: u16) -> Seq<u8> {
+    seq![(x & 0xff) as u8, ((x >> 8) & 0xff) as u8]
 }
 
 pub closed spec fn spec_u16_from_le_bytes(s: Seq<u8>) -> u16
-  recommends s.len() == 2
+    recommends
+        s.len() == 2,
 {
-  (s[0] as u16) |
-  (s[1] as u16) << 8
+    (s[0] as u16) | (s[1] as u16) << 8
 }
 
 pub proof fn lemma_auto_spec_u16_to_from_le_bytes()
-  ensures
-    forall |x: u16|
-    {
-      &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
-      &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
-    },
-    forall |s: Seq<u8>|
-      s.len() == 2 ==> #[trigger] spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s,
+    ensures
+        forall|x: u16|
+            {
+                &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
+                &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
+            },
+        forall|s: Seq<u8>|
+            s.len() == 2 ==> #[trigger] spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s,
 {
-  assert forall |x: u16|  {
-    &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
-    &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
-  } by {
-    let s = spec_u16_to_le_bytes(x);
-    assert({
-      &&& x & 0xff < 256
-      &&& (x >> 8) & 0xff < 256
-    }) by (bit_vector);
+    assert forall|x: u16|
+        {
+            &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
+            &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
+        } by {
+        let s = spec_u16_to_le_bytes(x);
+        assert({
+            &&& x & 0xff < 256
+            &&& (x >> 8) & 0xff < 256
+        }) by (bit_vector);
 
-    assert(x == (
-      (x & 0xff) |
-      ((x >> 8) & 0xff) << 8)) by (bit_vector);
-  };
+        assert(x == ((x & 0xff) | ((x >> 8) & 0xff) << 8)) by (bit_vector);
+    };
 
-  assert forall |s: Seq<u8>| s.len() == 2 implies #[trigger] spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s by {
-    let x = spec_u16_from_le_bytes(s);
-    let s0 = s[0] as u16;
-    let s1 = s[1] as u16;
+    assert forall|s: Seq<u8>| s.len() == 2 implies #[trigger] spec_u16_to_le_bytes(
+        spec_u16_from_le_bytes(s),
+    ) == s by {
+        let x = spec_u16_from_le_bytes(s);
+        let s0 = s[0] as u16;
+        let s1 = s[1] as u16;
 
-    assert(
-      (
-        (x == s0 | s1 << 8) &&
-        (s0 < 256) &&
-        (s1 < 256)
-      ) ==>
-      s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff)
-    ) by (bit_vector);
+        assert(((x == s0 | s1 << 8) && (s0 < 256) && (s1 < 256)) ==> s0 == (x & 0xff) && s1 == ((x
+            >> 8) & 0xff)) by (bit_vector);
 
-    assert_seqs_equal!(spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s);
-  }
+        assert_seqs_equal!(spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s);
+    }
 }
 
 #[verifier(external_body)]
-pub exec fn u16_from_le_bytes(s: &[u8]) -> (x:u16)
-  requires s.dview().len() == 2,
-  ensures x == spec_u16_from_le_bytes(s.dview()),
+pub exec fn u16_from_le_bytes(s: &[u8]) -> (x: u16)
+    requires
+        s.dview().len() == 2,
+    ensures
+        x == spec_u16_from_le_bytes(s.dview()),
 {
-  use core::convert::TryInto;
-  u16::from_le_bytes(s.try_into().unwrap())
+    use core::convert::TryInto;
+    u16::from_le_bytes(s.try_into().unwrap())
 }
-
 
 #[verifier(external_body)]
 pub exec fn u16_to_le_bytes(x: u16) -> (s: alloc::vec::Vec<u8>)
-  ensures
-    s.dview() == spec_u16_to_le_bytes(x),
-    s.dview().len() == 2,
+    ensures
+        s.dview() == spec_u16_to_le_bytes(x),
+        s.dview().len() == 2,
 {
-  x.to_le_bytes().to_vec()
+    x.to_le_bytes().to_vec()
 }
 
 // Conversion between u32 and little-endian byte sequences
-
-pub closed spec fn spec_u32_to_le_bytes(x: u32) -> Seq<u8>
-{
-  seq![
-    (x & 0xff) as u8,
-    ((x >> 8) & 0xff) as u8,
-    ((x >> 16) & 0xff) as u8,
-    ((x >> 24) & 0xff) as u8,
-  ]
+pub closed spec fn spec_u32_to_le_bytes(x: u32) -> Seq<u8> {
+    seq![
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+    ]
 }
 
 pub closed spec fn spec_u32_from_le_bytes(s: Seq<u8>) -> u32
-  recommends s.len() == 4
+    recommends
+        s.len() == 4,
 {
-  (s[0] as u32) |
-  (s[1] as u32) << 8 |
-  (s[2] as u32) << 16 |
-  (s[3] as u32) << 24
+    (s[0] as u32) | (s[1] as u32) << 8 | (s[2] as u32) << 16 | (s[3] as u32) << 24
 }
 
 #[verifier::spinoff_prover]
 pub proof fn lemma_auto_spec_u32_to_from_le_bytes()
-  ensures
-    forall |x: u32|
-    {
-      &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
-      &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
-    },
-    forall |s: Seq<u8>|
-      s.len() == 4 ==> #[trigger] spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s,
+    ensures
+        forall|x: u32|
+            {
+                &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
+                &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
+            },
+        forall|s: Seq<u8>|
+            s.len() == 4 ==> #[trigger] spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s,
 {
-  assert forall |x: u32|  {
-    &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
-    &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
-  } by {
-    let s = spec_u32_to_le_bytes(x);
-    assert({
-      &&& x & 0xff < 256
-      &&& (x >> 8) & 0xff < 256
-      &&& (x >> 16) & 0xff < 256
-      &&& (x >> 24) & 0xff < 256
-    }) by (bit_vector);
+    assert forall|x: u32|
+        {
+            &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
+            &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
+        } by {
+        let s = spec_u32_to_le_bytes(x);
+        assert({
+            &&& x & 0xff < 256
+            &&& (x >> 8) & 0xff < 256
+            &&& (x >> 16) & 0xff < 256
+            &&& (x >> 24) & 0xff < 256
+        }) by (bit_vector);
 
-    assert(x == (
-      (x & 0xff) |
-      ((x >> 8) & 0xff) << 8 |
-      ((x >> 16) & 0xff) << 16 |
-      ((x >> 24) & 0xff) << 24)) by (bit_vector);
-  };
+        assert(x == ((x & 0xff) | ((x >> 8) & 0xff) << 8 | ((x >> 16) & 0xff) << 16 | ((x >> 24)
+            & 0xff) << 24)) by (bit_vector);
+    };
 
-  assert forall |s: Seq<u8>| s.len() == 4 implies #[trigger] spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s by {
-    let x = spec_u32_from_le_bytes(s);
-    let s0 = s[0] as u32;
-    let s1 = s[1] as u32;
-    let s2 = s[2] as u32;
-    let s3 = s[3] as u32;
+    assert forall|s: Seq<u8>| s.len() == 4 implies #[trigger] spec_u32_to_le_bytes(
+        spec_u32_from_le_bytes(s),
+    ) == s by {
+        let x = spec_u32_from_le_bytes(s);
+        let s0 = s[0] as u32;
+        let s1 = s[1] as u32;
+        let s2 = s[2] as u32;
+        let s3 = s[3] as u32;
 
-    assert(
-      (
-        (x == s0 | s1 << 8 | s2 << 16 | s3 << 24) &&
-        (s0 < 256) &&
-        (s1 < 256) &&
-        (s2 < 256) &&
-        (s3 < 256)
-      ) ==>
-      s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff) && s2 == ((x >> 16) & 0xff) && s3 == ((x >> 24) & 0xff)
-    ) by (bit_vector);
+        assert(((x == s0 | s1 << 8 | s2 << 16 | s3 << 24) && (s0 < 256) && (s1 < 256) && (s2 < 256)
+            && (s3 < 256)) ==> s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff) && s2 == ((x >> 16)
+            & 0xff) && s3 == ((x >> 24) & 0xff)) by (bit_vector);
 
-    assert_seqs_equal!(spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s);
-  }
+        assert_seqs_equal!(spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s);
+    }
 }
 
 #[verifier(external_body)]
-pub exec fn u32_from_le_bytes(s: &[u8]) -> (x:u32)
-  requires s.dview().len() == 4,
-  ensures x == spec_u32_from_le_bytes(s.dview()),
+pub exec fn u32_from_le_bytes(s: &[u8]) -> (x: u32)
+    requires
+        s.dview().len() == 4,
+    ensures
+        x == spec_u32_from_le_bytes(s.dview()),
 {
-  use core::convert::TryInto;
-  u32::from_le_bytes(s.try_into().unwrap())
+    use core::convert::TryInto;
+    u32::from_le_bytes(s.try_into().unwrap())
 }
-
 
 #[verifier(external_body)]
 pub exec fn u32_to_le_bytes(x: u32) -> (s: alloc::vec::Vec<u8>)
-  ensures
-    s.dview() == spec_u32_to_le_bytes(x),
-    s.dview().len() == 4,
+    ensures
+        s.dview() == spec_u32_to_le_bytes(x),
+        s.dview().len() == 4,
 {
-  x.to_le_bytes().to_vec()
+    x.to_le_bytes().to_vec()
 }
 
 // Conversion between u64 and little-endian byte sequences
-
-pub closed spec fn spec_u64_to_le_bytes(x: u64) -> Seq<u8>
-{
-  seq![
-    (x & 0xff) as u8,
-    ((x >> 8) & 0xff) as u8,
-    ((x >> 16) & 0xff) as u8,
-    ((x >> 24) & 0xff) as u8,
-    ((x >> 32) & 0xff) as u8,
-    ((x >> 40) & 0xff) as u8,
-    ((x >> 48) & 0xff) as u8,
-    ((x >> 56) & 0xff) as u8,
-  ]
+pub closed spec fn spec_u64_to_le_bytes(x: u64) -> Seq<u8> {
+    seq![
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+        ((x >> 32) & 0xff) as u8,
+        ((x >> 40) & 0xff) as u8,
+        ((x >> 48) & 0xff) as u8,
+        ((x >> 56) & 0xff) as u8,
+    ]
 }
 
 pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
-  recommends s.len() == 8
+    recommends
+        s.len() == 8,
 {
-  (s[0] as u64) |
-  (s[1] as u64) << 8 |
-  (s[2] as u64) << 16 |
-  (s[3] as u64) << 24 |
-  (s[4] as u64) << 32 |
-  (s[5] as u64) << 40 |
-  (s[6] as u64) << 48 |
-  (s[7] as u64) << 56
+    (s[0] as u64) | (s[1] as u64) << 8 | (s[2] as u64) << 16 | (s[3] as u64) << 24 | (s[4] as u64)
+        << 32 | (s[5] as u64) << 40 | (s[6] as u64) << 48 | (s[7] as u64) << 56
 }
 
 pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
-  ensures
-    forall |x: u64|
-      #![trigger spec_u64_to_le_bytes(x)]
-    {
-      &&& spec_u64_to_le_bytes(x).len() == 8
-      &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
-    },
-    forall |s: Seq<u8>|
-      #![trigger spec_u64_to_le_bytes(spec_u64_from_le_bytes(s))]
-      s.len() == 8 ==> spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s,
+    ensures
+        forall|x: u64|
+            #![trigger spec_u64_to_le_bytes(x)]
+            {
+                &&& spec_u64_to_le_bytes(x).len() == 8
+                &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
+            },
+        forall|s: Seq<u8>|
+            #![trigger spec_u64_to_le_bytes(spec_u64_from_le_bytes(s))]
+            s.len() == 8 ==> spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s,
 {
-  assert forall |x: u64|  {
-    &&& #[trigger] spec_u64_to_le_bytes(x).len() == 8
-    &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
-  } by {
-    let s = spec_u64_to_le_bytes(x);
-    assert({
-      &&& x & 0xff < 256
-      &&& (x >> 8) & 0xff < 256
-      &&& (x >> 16) & 0xff < 256
-      &&& (x >> 24) & 0xff < 256
-      &&& (x >> 32) & 0xff < 256
-      &&& (x >> 40) & 0xff < 256
-      &&& (x >> 48) & 0xff < 256
-      &&& (x >> 56) & 0xff < 256
-    }) by (bit_vector);
+    assert forall|x: u64|
+        {
+            &&& #[trigger] spec_u64_to_le_bytes(x).len() == 8
+            &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
+        } by {
+        let s = spec_u64_to_le_bytes(x);
+        assert({
+            &&& x & 0xff < 256
+            &&& (x >> 8) & 0xff < 256
+            &&& (x >> 16) & 0xff < 256
+            &&& (x >> 24) & 0xff < 256
+            &&& (x >> 32) & 0xff < 256
+            &&& (x >> 40) & 0xff < 256
+            &&& (x >> 48) & 0xff < 256
+            &&& (x >> 56) & 0xff < 256
+        }) by (bit_vector);
 
-    assert(x == (
-      (x & 0xff) |
-      ((x >> 8) & 0xff) << 8 |
-      ((x >> 16) & 0xff) << 16 |
-      ((x >> 24) & 0xff) << 24 |
-      ((x >> 32) & 0xff) << 32 |
-      ((x >> 40) & 0xff) << 40 |
-      ((x >> 48) & 0xff) << 48 |
-      ((x >> 56) & 0xff) << 56)) by (bit_vector);
-  };
+        assert(x == ((x & 0xff) | ((x >> 8) & 0xff) << 8 | ((x >> 16) & 0xff) << 16 | ((x >> 24)
+            & 0xff) << 24 | ((x >> 32) & 0xff) << 32 | ((x >> 40) & 0xff) << 40 | ((x >> 48) & 0xff)
+            << 48 | ((x >> 56) & 0xff) << 56)) by (bit_vector);
+    };
 
-  assert forall |s: Seq<u8>| s.len() == 8 implies #[trigger] spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s by {
-    let x = spec_u64_from_le_bytes(s);
-    let s0 = s[0] as u64;
-    let s1 = s[1] as u64;
-    let s2 = s[2] as u64;
-    let s3 = s[3] as u64;
-    let s4 = s[4] as u64;
-    let s5 = s[5] as u64;
-    let s6 = s[6] as u64;
-    let s7 = s[7] as u64;
+    assert forall|s: Seq<u8>| s.len() == 8 implies #[trigger] spec_u64_to_le_bytes(
+        spec_u64_from_le_bytes(s),
+    ) == s by {
+        let x = spec_u64_from_le_bytes(s);
+        let s0 = s[0] as u64;
+        let s1 = s[1] as u64;
+        let s2 = s[2] as u64;
+        let s3 = s[3] as u64;
+        let s4 = s[4] as u64;
+        let s5 = s[5] as u64;
+        let s6 = s[6] as u64;
+        let s7 = s[7] as u64;
 
-    assert(
-      (
-        (x == s0 | s1 << 8 | s2 << 16 | s3 << 24 | s4 << 32 | s5 << 40 | s6 << 48 | s7 << 56) &&
-        (s0 < 256) &&
-        (s1 < 256) &&
-        (s2 < 256) &&
-        (s3 < 256) &&
-        (s4 < 256) &&
-        (s5 < 256) &&
-        (s6 < 256) &&
-        (s7 < 256)
-      ) ==>
-      s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff) && s2 == ((x >> 16) & 0xff) && s3 == ((x >> 24) & 0xff) && s4 == ((x >> 32) & 0xff) && s5 == ((x >> 40) & 0xff) && s6 == ((x >> 48) & 0xff) && s7 == ((x >> 56) & 0xff)
-    ) by (bit_vector);
+        assert(((x == s0 | s1 << 8 | s2 << 16 | s3 << 24 | s4 << 32 | s5 << 40 | s6 << 48 | s7
+            << 56) && (s0 < 256) && (s1 < 256) && (s2 < 256) && (s3 < 256) && (s4 < 256) && (s5
+            < 256) && (s6 < 256) && (s7 < 256)) ==> s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff)
+            && s2 == ((x >> 16) & 0xff) && s3 == ((x >> 24) & 0xff) && s4 == ((x >> 32) & 0xff)
+            && s5 == ((x >> 40) & 0xff) && s6 == ((x >> 48) & 0xff) && s7 == ((x >> 56) & 0xff))
+            by (bit_vector);
 
-    assert_seqs_equal!(spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s);
-  }
+        assert_seqs_equal!(spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s);
+    }
 }
 
 #[verifier(external_body)]
-pub exec fn u64_from_le_bytes(s: &[u8]) -> (x:u64)
-  requires s.dview().len() == 8,
-  ensures x == spec_u64_from_le_bytes(s.dview()),
+pub exec fn u64_from_le_bytes(s: &[u8]) -> (x: u64)
+    requires
+        s.dview().len() == 8,
+    ensures
+        x == spec_u64_from_le_bytes(s.dview()),
 {
-  use core::convert::TryInto;
-  u64::from_le_bytes(s.try_into().unwrap())
+    use core::convert::TryInto;
+    u64::from_le_bytes(s.try_into().unwrap())
 }
-
 
 #[verifier(external_body)]
 pub exec fn u64_to_le_bytes(x: u64) -> (s: alloc::vec::Vec<u8>)
-  ensures
-    s.dview() == spec_u64_to_le_bytes(x),
-    s.dview().len() == 8,
+    ensures
+        s.dview() == spec_u64_to_le_bytes(x),
+        s.dview().len() == 8,
 {
-  x.to_le_bytes().to_vec()
+    x.to_le_bytes().to_vec()
 }
 
-
-} // verus
-
+} // verus!
+// verus
 verus! {
 
-    pub open spec fn spec_parse_pair<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>) ->
-        spec_fn(SpecStream) -> SpecParseResult<(R1,R2)>
-    {
-        move |s| match parser1(s) {
+pub open spec fn spec_parse_pair<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+) -> spec_fn(SpecStream) -> SpecParseResult<(R1, R2)> {
+    move |s|
+        match parser1(s) {
             Ok((s, n, r1)) => match parser2(s) {
                 Ok((s, m, r2)) => {
                     if n + m > usize::MAX {
@@ -2170,19 +2273,19 @@ verus! {
                     } else {
                         Ok((s, n + m, (r1, r2)))
                     }
-                }
+                },
                 Err(e) => Err(e),
             },
             Err(e) => Err(e),
         }
-    }
+}
 
-    pub open spec fn spec_serialize_pair<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult) ->
-        spec_fn(SpecStream, (T1, T2)) -> SpecSerializeResult
-    {
-        move |s, v: (T1, T2)| match serializer1(s, v.0) {
+pub open spec fn spec_serialize_pair<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, (T1, T2)) -> SpecSerializeResult {
+    move |s, v: (T1, T2)|
+        match serializer1(s, v.0) {
             Ok((s, n)) => match serializer2(s, v.1) {
                 Ok((s, m)) => {
                     if n + m > usize::MAX {
@@ -2190,406 +2293,411 @@ verus! {
                     } else {
                         Ok((s, n + m))
                     }
-                }
+                },
                 Err(e) => Err(e),
             },
             Err(e) => Err(e),
         }
-    }
+}
 
-    pub exec fn parse_pair<'a, P1, P2, R1, R2>(
-        exec_parser1: P1,
-        exec_parser2: P2,
-        Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
-        Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
-        s: Stream<'a>) -> (res: ParseResult<'a, (R1,R2)>)
-        where
-            R1: DView,
-            R2: DView,
-            P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
-            P2: FnOnce(Stream<'a>) -> ParseResult<R2>,
-        requires
-            prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
-            prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2))
-    {
-        proof { reveal(prop_parse_exec_spec_equiv); }
-        let res1 = exec_parser1(s);
-        proof { lemma_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1); }
-        match res1 {
-            Ok((s1, n1, r1)) => {
-                let res2 = exec_parser2(s1);
-                proof { lemma_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2); }
-                match res2 {
-                    Ok((s2, n2, r2)) => {
-                        if n1 > usize::MAX - n2 {
-                            Err(ParseError::IntegerOverflow)
-                        } else {
-                            Ok((s2, n1 + n2, (r1, r2)))
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
+pub exec fn parse_pair<'a, P1, P2, R1, R2>(
+    exec_parser1: P1,
+    exec_parser2: P2,
+    Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
+    Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
+    s: Stream<'a>,
+) -> (res: ParseResult<'a, (R1, R2)>) where
+    R1: DView,
+    R2: DView,
+    P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
+    P2: FnOnce(Stream<'a>) -> ParseResult<R2>,
+
+    requires
+        prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
+        prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+{
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let res1 = exec_parser1(s);
+    proof {
+        lemma_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1);
+    }
+    match res1 {
+        Ok((s1, n1, r1)) => {
+            let res2 = exec_parser2(s1);
+            proof {
+                lemma_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2);
             }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub proof fn lemma_parse_pair_correct<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2),
-            prop_parse_well_behaved(parser1),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_correct(parser1, serializer1),
-            prop_parse_correct(parser2, serializer2)
-        ensures
-            prop_parse_correct(spec_parse_pair(parser1, parser2),
-                                spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_parse_correct);
-        assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> prop_parse_correct_on(spec_parse_pair(parser1, parser2), spec_serialize_pair(serializer1, serializer2), s, v) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_pair_correct_on(parser1, parser2, serializer1, serializer2, s, v);
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_pair_serialize_inverse<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_serialize_well_behaved(serializer1),
-            prop_parse_serialize_inverse(parser1, serializer1),
-            prop_parse_serialize_inverse(parser2, serializer2)
-        ensures
-            prop_parse_serialize_inverse(spec_parse_pair(parser1, parser2),
-                                    spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_parse_serialize_inverse);
-        assert forall |s: SpecStream| prop_parse_serialize_inverse_on(spec_parse_pair(parser1, parser2),
-        spec_serialize_pair(serializer1, serializer2), s) by {
-            lemma_parse_pair_serialize_inverse_on(parser1, parser2, serializer1, serializer2, s);
-        }
-    }
-
-    pub proof fn lemma_parse_pair_well_behaved<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2)
-        ensures
-            prop_parse_well_behaved(spec_parse_pair(parser1, parser2))
-    {
-        reveal(prop_parse_well_behaved);
-        assert forall |s: SpecStream| prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s) by {
-            lemma_parse_pair_well_behaved_on(parser1, parser2, s);
-        }
-    }
-
-    pub proof fn lemma_serialize_pair_well_behaved<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_well_behaved(spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_serialize_well_behaved);
-        assert forall |s: SpecStream, v: (T1, T2)| prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v) by {
-            lemma_serialize_pair_well_behaved_on(serializer1, serializer2, s, v);
-        }
-    }
-
-    pub proof fn lemma_serialize_pair_deterministic<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_serialize_deterministic(serializer1),
-            prop_serialize_deterministic(serializer2),
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_deterministic(spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_serialize_deterministic);
-        assert forall |s1, s2, v| prop_serialize_deterministic_on(spec_serialize_pair(serializer1, serializer2), s1, s2, v) by {
-            lemma_serialize_pair_deterministic_on(serializer1, serializer2, s1, s2, v);
-        }
-    }
-
-    pub proof fn lemma_parse_pair_strong_prefix<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_strong_prefix(parser2),
-        ensures
-            prop_parse_strong_prefix(spec_parse_pair(parser1, parser2))
-    {
-        reveal(prop_parse_strong_prefix);
-        assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2) by {
-            lemma_parse_pair_strong_prefix_on(parser1, parser2, s1, s2);
-        }
-    }
-
-    pub proof fn lemma_parse_pair_well_behaved_on<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2)
-        ensures
-            prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s)
-    {
-        if let Ok((s1, n1, _)) = parser1(s) {
-            assert(
-                s1.data == s.data &&
-                s1.start == s.start + n1 &&
-                0 <= s.start <= s1.start <= s.data.len()) by {
-                    lemma_parse_well_behaved_on(parser1, s);
-                }
-            if let Ok((s2, n2, _)) = parser2(s1) {
-                assert(
-                    s2.data == s1.data &&
-                    s2.start == s1.start + n2 &&
-                    0 <= s1.start <= s2.start <= s1.data.len()) by {
-                        lemma_parse_well_behaved_on(parser2, s1);
+            match res2 {
+                Ok((s2, n2, r2)) => {
+                    if n1 > usize::MAX - n2 {
+                        Err(ParseError::IntegerOverflow)
+                    } else {
+                        Ok((s2, n1 + n2, (r1, r2)))
                     }
-                if let Ok((sout, n, _)) = spec_parse_pair(parser1, parser2)(s) {
-                    assert(n == n1 + n2);
-                }
+                },
+                Err(e) => Err(e),
             }
+        },
+        Err(e) => Err(e),
+    }
+}
+
+pub proof fn lemma_parse_pair_correct<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+        prop_parse_well_behaved(parser1),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_correct(parser1, serializer1),
+        prop_parse_correct(parser2, serializer2),
+    ensures
+        prop_parse_correct(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+        ),
+{
+    reveal(prop_parse_correct);
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+            v,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_pair_correct_on(parser1, parser2, serializer1, serializer2, s, v);
         }
     }
+}
 
-    pub proof fn lemma_serialize_pair_well_behaved_on<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s: SpecStream, v: (T1, T2))
-        requires
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v)
-    {
-        lemma_serialize_well_behaved_on(serializer1, s, v.0);
-        if let Ok((s1, n1)) = serializer1(s, v.0) {
-            assert(
-                s1.data.len() == s.data.len()
-                && 0 <= s.start <= s1.start <= s.data.len()
-                && s1.start == s.start + n1
-                && s1.data.subrange(0, s.start) == s.data.subrange(0, s.start)
-                && s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(s.start + n1, s.data.len() as int));
-            lemma_serialize_well_behaved_on(serializer2, s1, v.1);
-            if let Ok((s2, n2)) = serializer2(s1, v.1) {
-                assert(
-                    s2.data.len() == s1.data.len()
-                    && 0 <= s1.start <= s2.start <= s1.data.len()
-                    && s2.start == s1.start + n2
-                    && s2.data.subrange(0, s1.start) == s1.data.subrange(0, s1.start)
-                    && s2.data.subrange(s1.start + n2, s1.data.len() as int) == s1.data.subrange(s1.start + n2, s1.data.len() as int));
-                if let Ok((sout, n)) = spec_serialize_pair(serializer1, serializer2)(s, v) {
-                    // assert(n == n1 + n2);
-                    // assert(s2 == sout);
-                    assert(sout.data.len() == s.data.len());
-                    assert(0 <= s.start <= sout.start <= s.data.len());
-                    assert(sout.start == s.start + n);
-                    assert(sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
-                        assert(s2.data.subrange(0, s1.start).subrange(0, s.start) =~= s2.data.subrange(0, s.start));
-                        assert(s1.data.subrange(0, s1.start).subrange(0, s.start) =~= s1.data.subrange(0, s.start));
-                    }
-                    assert(sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(s.start + n, s.data.len() as int)) by {
-                        assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s1.data.subrange(s.start + n, s.data.len() as int));
-                        assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s.data.subrange(s.start + n, s.data.len() as int));
-                    }
-                }
-            }
-        }
+pub proof fn lemma_parse_pair_serialize_inverse<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_serialize_well_behaved(serializer1),
+        prop_parse_serialize_inverse(parser1, serializer1),
+        prop_parse_serialize_inverse(parser2, serializer2),
+    ensures
+        prop_parse_serialize_inverse(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+        ),
+{
+    reveal(prop_parse_serialize_inverse);
+    assert forall|s: SpecStream|
+        prop_parse_serialize_inverse_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+        ) by {
+        lemma_parse_pair_serialize_inverse_on(parser1, parser2, serializer1, serializer2, s);
     }
+}
 
-    pub proof fn lemma_serialize_pair_deterministic_on<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s1: SpecStream, s2: SpecStream, v: (T1, T2))
-        requires
-            prop_serialize_deterministic(serializer1),
-            prop_serialize_deterministic(serializer2),
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_deterministic_on(spec_serialize_pair(serializer1, serializer2), s1, s2, v)
-    {
-        lemma_serialize_deterministic_on(serializer1, s1, s2, v.0);
-        lemma_serialize_well_behaved_on(serializer1, s1, v.0);
-        lemma_serialize_well_behaved_on(serializer1, s2, v.0);
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer1(s1, v.0), serializer1(s2, v.0)) {
-            lemma_serialize_deterministic_on(serializer2, sout1, sout2, v.1);
-            lemma_serialize_well_behaved_on(serializer2, sout1, v.1);
-            lemma_serialize_well_behaved_on(serializer2, sout2, v.1);
-            if let (Ok((sout3, n3)), Ok((sout4, n4))) = (serializer2(sout1, v.1), serializer2(sout2, v.1)) {
-                assert(n1 + n3 == n2 + n4);
-                assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout4.data.subrange(s2.start, s2.start + n2 + n4)) by {
-                    assert(sout1.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1) =~= sout1.data.subrange(s1.start, s1.start + n1));
-                    assert(sout2.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2) =~= sout2.data.subrange(s2.start, s2.start + n2));
-                    assert(sout3.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1) =~= sout3.data.subrange(s1.start, s1.start + n1));
-                    assert(sout4.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2) =~= sout4.data.subrange(s2.start, s2.start + n2));
-
-                    assert(sout3.data.subrange(s1.start, s1.start + n1) =~= sout4.data.subrange(s2.start, s2.start + n2));
-                    assert(sout3.data.subrange(s1.start + n1, s1.start + n1 + n3) == sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
-
-                    assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout3.data.subrange(s1.start, s1.start + n1) + sout3.data.subrange(s1.start + n1, s1.start + n1 + n3));
-                    assert(sout4.data.subrange(s2.start, s2.start + n2 + n4) =~= sout4.data.subrange(s2.start, s2.start + n2) + sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
-                }
-            }
-        }
+pub proof fn lemma_parse_pair_well_behaved<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+    ensures
+        prop_parse_well_behaved(spec_parse_pair(parser1, parser2)),
+{
+    reveal(prop_parse_well_behaved);
+    assert forall|s: SpecStream|
+        prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s) by {
+        lemma_parse_pair_well_behaved_on(parser1, parser2, s);
     }
+}
 
-    pub proof fn lemma_parse_pair_strong_prefix_on<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
-        s1: SpecStream, s2: SpecStream)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_strong_prefix(parser2),
-        ensures
-            prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_pair(parser1, parser2)(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + n <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                // assert(parser1(s1).is_ok());
-                if let Ok((p1s1, n1, p1x1)) = parser1(s1) {
-                    // assert(parser2(p1s1).is_ok());
-                    if let Ok((p2s1, n2, p2x1)) = parser2(p1s1) {
-                        assert(s1.data.subrange(s1.start, s1.start + n1) == s2.data.subrange(s2.start, s2.start + n1)) by {
-                            assert(s1.data.subrange(s1.start, s1.start + n).subrange(0, n1 as int) =~= s1.data.subrange(s1.start, s1.start + n1));
-                            assert(s2.data.subrange(s2.start, s2.start + n).subrange(0, n1 as int) =~= s2.data.subrange(s2.start, s2.start + n1));
-                        }
-                        lemma_parse_strong_prefix_on(parser1, s1, s2);
-                        // assert(parser1(s2).is_ok());
-                        if let Ok((p1s2, m1, p1x2)) = parser1(s2) {
-                            lemma_parse_well_behaved_on(parser1, s1);
-                            lemma_parse_well_behaved_on(parser1, s2);
-                            // assert(p1s1.data == s1.data);
-                            // assert(p1s2.data == s2.data);
-                            // assert(p1s1.start == s1.start + n1);
-                            // assert(p1s2.start == s2.start + n1);
-                            // assert(n == n1 + n2);
-                            assert(s1.data.subrange(s1.start + n1, s1.start + n1 + n2) == s2.data.subrange(s2.start + n1, s2.start + n1 + n2)) by {
-                                assert(s1.data.subrange(s1.start, s1.start + n).subrange(n1 as int, n as int) =~= s1.data.subrange(s1.start + n1, s1.start + n1 + n2));
-                                assert(s2.data.subrange(s2.start, s2.start + n).subrange(n1 as int, n as int) =~= s2.data.subrange(s2.start + n1, s2.start + n1 + n2));
-                            }
-                            assert(p1s1.data.subrange(p1s1.start, p1s1.start + n2) == p1s2.data.subrange(p1s2.start, p1s2.start + n2));
-                            lemma_parse_strong_prefix_on(parser2, p1s1, p1s2);
-                            // assert(parser2(p1s2).is_ok());
-                            if let Ok((p2s2, m2, p2x2)) = parser2(p1s2) {
-                                if let Ok((sout2, m, x2)) = spec_parse_pair(parser1, parser2)(s2) {
-                                    assert(m == n && x2 == x1);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+pub proof fn lemma_serialize_pair_well_behaved<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_well_behaved(spec_serialize_pair(serializer1, serializer2)),
+{
+    reveal(prop_serialize_well_behaved);
+    assert forall|s: SpecStream, v: (T1, T2)|
+        prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v) by {
+        lemma_serialize_pair_well_behaved_on(serializer1, serializer2, s, v);
     }
+}
 
-    pub proof fn lemma_parse_pair_correct_on<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s: SpecStream, v: (T1, T2))
-        requires
-            s.data.len() <= usize::MAX,
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2),
-            prop_parse_well_behaved(parser1),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_correct(parser1, serializer1),
-            prop_parse_correct(parser2, serializer2)
-        ensures
-            prop_parse_correct_on(spec_parse_pair(parser1, parser2),
-                                spec_serialize_pair(serializer1, serializer2), s, v)
-    {
-        if let Ok((s1, n1)) = serializer1(s, v.0) {
-            if let Ok((s2, n2)) = serializer2(s1, v.1) {
-                lemma_serialize_well_behaved_on(serializer1, s, v.0);
-                lemma_serialize_well_behaved_on(serializer2, s1, v.1);
-                lemma_parse_correct_on(parser1, serializer1, s, v.0);
-                if let Ok((s_c1, n_c1, r_c1)) = parser1(SpecStream {start: s.start, ..s1}) {
-                    assert(n1 == n_c1 && r_c1 == v.0);
-                    assert(s1.data.subrange(s.start, s.start + n_c1) == s2.data.subrange(s.start, s.start + n_c1)) by {
-                        assert(s1.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1) =~= s1.data.subrange(s.start, s.start + n1));
-                        assert(s2.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1) =~= s2.data.subrange(s.start, s.start + n1));
-                    }
-                    lemma_parse_strong_prefix_on(parser1, SpecStream {start: s.start, ..s1}, SpecStream {start: s.start, ..s2});
-                    if let Ok((s3, m1, res1)) = parser1(SpecStream {start: s.start, ..s2}) {
-                        assert(m1 == n_c1 && res1 == r_c1);
-                        assert(m1 == n1 && res1 == v.0); // crucial fact 1
-                        lemma_parse_well_behaved_on(parser1, SpecStream {start: s.start, ..s2});
-                        assert(s3.data == s2.data && s3.start == s.start + m1); // crucial fact 2 (s3 == SpecStream {start: s1.start, ..s2})
-                        lemma_parse_correct_on(parser2, serializer2, s1, v.1);
-                        // if let Ok((s_c2, n_c2, r_c2)) = parser2(SpecStream {start: s1.start, ..s2}) {
-                            // assert(n2 == n_c2 && r_c2 == v.1);
-                            if let Ok((s4, m2, res2)) = parser2(s3) {
-                                // assert(m2 == n_c2 && res2 == r_c2);
-                                assert(m1 + m2 == n1 + n2);
-                                assert(res1 == v.0 && res2 == v.1);
-                            }
-                        // }
-                    }
-                }
-            }
-        }
+pub proof fn lemma_serialize_pair_deterministic<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_serialize_deterministic(serializer1),
+        prop_serialize_deterministic(serializer2),
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_deterministic(spec_serialize_pair(serializer1, serializer2)),
+{
+    reveal(prop_serialize_deterministic);
+    assert forall|s1, s2, v|
+        prop_serialize_deterministic_on(
+            spec_serialize_pair(serializer1, serializer2),
+            s1,
+            s2,
+            v,
+        ) by {
+        lemma_serialize_pair_deterministic_on(serializer1, serializer2, s1, s2, v);
     }
+}
 
-    pub proof fn lemma_parse_pair_serialize_inverse_on<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_serialize_well_behaved(serializer1),
-            prop_parse_serialize_inverse(parser1, serializer1),
-            prop_parse_serialize_inverse(parser2, serializer2)
-        ensures
-            prop_parse_serialize_inverse_on(spec_parse_pair(parser1, parser2),
-                                    spec_serialize_pair(serializer1, serializer2), s)
-    {
-        if let Ok((s1, n1, x1)) = parser1(s) {
-            if let Ok((s2, n2, x2)) = parser2(s1) {
-                lemma_parse_well_behaved_on(parser1, s);
+pub proof fn lemma_parse_pair_strong_prefix<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_strong_prefix(parser2),
+    ensures
+        prop_parse_strong_prefix(spec_parse_pair(parser1, parser2)),
+{
+    reveal(prop_parse_strong_prefix);
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2) by {
+        lemma_parse_pair_strong_prefix_on(parser1, parser2, s1, s2);
+    }
+}
+
+pub proof fn lemma_parse_pair_well_behaved_on<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+    ensures
+        prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s),
+{
+    if let Ok((s1, n1, _)) = parser1(s) {
+        assert(s1.data == s.data && s1.start == s.start + n1 && 0 <= s.start <= s1.start
+            <= s.data.len()) by {
+            lemma_parse_well_behaved_on(parser1, s);
+        }
+        if let Ok((s2, n2, _)) = parser2(s1) {
+            assert(s2.data == s1.data && s2.start == s1.start + n2 && 0 <= s1.start <= s2.start
+                <= s1.data.len()) by {
                 lemma_parse_well_behaved_on(parser2, s1);
-                lemma_parse_serialize_inverse_on(parser1, serializer1, s);
-                lemma_serialize_well_behaved_on(serializer1, s, x1);
-                if let Ok((s3, m1)) = serializer1(s, x1) {
-                    assert(m1 == n1 && s3.data == s.data);
-                    lemma_parse_serialize_inverse_on(parser2, serializer2, s1);
-                    if let Ok((s4, m2)) = serializer2(s3, x2) {
-                        assert(m1 + m2 == n1 + n2);
-                        assert(s4.data == s.data);
+            }
+            if let Ok((sout, n, _)) = spec_parse_pair(parser1, parser2)(s) {
+                assert(n == n1 + n2);
+            }
+        }
+    }
+}
+
+pub proof fn lemma_serialize_pair_well_behaved_on<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s: SpecStream,
+    v: (T1, T2),
+)
+    requires
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v),
+{
+    lemma_serialize_well_behaved_on(serializer1, s, v.0);
+    if let Ok((s1, n1)) = serializer1(s, v.0) {
+        assert(s1.data.len() == s.data.len() && 0 <= s.start <= s1.start <= s.data.len() && s1.start
+            == s.start + n1 && s1.data.subrange(0, s.start) == s.data.subrange(0, s.start)
+            && s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(
+            s.start + n1,
+            s.data.len() as int,
+        ));
+        lemma_serialize_well_behaved_on(serializer2, s1, v.1);
+        if let Ok((s2, n2)) = serializer2(s1, v.1) {
+            assert(s2.data.len() == s1.data.len() && 0 <= s1.start <= s2.start <= s1.data.len()
+                && s2.start == s1.start + n2 && s2.data.subrange(0, s1.start) == s1.data.subrange(
+                0,
+                s1.start,
+            ) && s2.data.subrange(s1.start + n2, s1.data.len() as int) == s1.data.subrange(
+                s1.start + n2,
+                s1.data.len() as int,
+            ));
+            if let Ok((sout, n)) = spec_serialize_pair(serializer1, serializer2)(s, v) {
+                // assert(n == n1 + n2);
+                // assert(s2 == sout);
+                assert(sout.data.len() == s.data.len());
+                assert(0 <= s.start <= sout.start <= s.data.len());
+                assert(sout.start == s.start + n);
+                assert(sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
+                    assert(s2.data.subrange(0, s1.start).subrange(0, s.start) =~= s2.data.subrange(
+                        0,
+                        s.start,
+                    ));
+                    assert(s1.data.subrange(0, s1.start).subrange(0, s.start) =~= s1.data.subrange(
+                        0,
+                        s.start,
+                    ));
+                }
+                assert(sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(
+                    s.start + n,
+                    s.data.len() as int,
+                )) by {
+                    assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                        n2 as int,
+                        s.data.len() - s.start - n1,
+                    ) =~= s1.data.subrange(s.start + n, s.data.len() as int));
+                    assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                        n2 as int,
+                        s.data.len() - s.start - n1,
+                    ) =~= s.data.subrange(s.start + n, s.data.len() as int));
+                }
+            }
+        }
+    }
+}
+
+pub proof fn lemma_serialize_pair_deterministic_on<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (T1, T2),
+)
+    requires
+        prop_serialize_deterministic(serializer1),
+        prop_serialize_deterministic(serializer2),
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_deterministic_on(spec_serialize_pair(serializer1, serializer2), s1, s2, v),
+{
+    lemma_serialize_deterministic_on(serializer1, s1, s2, v.0);
+    lemma_serialize_well_behaved_on(serializer1, s1, v.0);
+    lemma_serialize_well_behaved_on(serializer1, s2, v.0);
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer1(s1, v.0), serializer1(s2, v.0)) {
+        lemma_serialize_deterministic_on(serializer2, sout1, sout2, v.1);
+        lemma_serialize_well_behaved_on(serializer2, sout1, v.1);
+        lemma_serialize_well_behaved_on(serializer2, sout2, v.1);
+        if let (Ok((sout3, n3)), Ok((sout4, n4))) = (
+            serializer2(sout1, v.1),
+            serializer2(sout2, v.1),
+        ) {
+            assert(n1 + n3 == n2 + n4);
+            assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout4.data.subrange(
+                s2.start,
+                s2.start + n2 + n4,
+            )) by {
+                assert(sout1.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1)
+                    =~= sout1.data.subrange(s1.start, s1.start + n1));
+                assert(sout2.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2)
+                    =~= sout2.data.subrange(s2.start, s2.start + n2));
+                assert(sout3.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1)
+                    =~= sout3.data.subrange(s1.start, s1.start + n1));
+                assert(sout4.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2)
+                    =~= sout4.data.subrange(s2.start, s2.start + n2));
+
+                assert(sout3.data.subrange(s1.start, s1.start + n1) =~= sout4.data.subrange(
+                    s2.start,
+                    s2.start + n2,
+                ));
+                assert(sout3.data.subrange(s1.start + n1, s1.start + n1 + n3)
+                    == sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
+
+                assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout3.data.subrange(
+                    s1.start,
+                    s1.start + n1,
+                ) + sout3.data.subrange(s1.start + n1, s1.start + n1 + n3));
+                assert(sout4.data.subrange(s2.start, s2.start + n2 + n4) =~= sout4.data.subrange(
+                    s2.start,
+                    s2.start + n2,
+                ) + sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
+            }
+        }
+    }
+}
+
+pub proof fn lemma_parse_pair_strong_prefix_on<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+    s1: SpecStream,
+    s2: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_strong_prefix(parser2),
+    ensures
+        prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_pair(parser1, parser2)(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX && 0 <= s2.start <= s2.start
+            + n <= s2.data.len() <= usize::MAX && s1.data.subrange(s1.start, s1.start + n)
+            == s2.data.subrange(s2.start, s2.start + n) {
+            // assert(parser1(s1).is_ok());
+            if let Ok((p1s1, n1, p1x1)) = parser1(s1) {
+                // assert(parser2(p1s1).is_ok());
+                if let Ok((p2s1, n2, p2x1)) = parser2(p1s1) {
+                    assert(s1.data.subrange(s1.start, s1.start + n1) == s2.data.subrange(
+                        s2.start,
+                        s2.start + n1,
+                    )) by {
+                        assert(s1.data.subrange(s1.start, s1.start + n).subrange(0, n1 as int)
+                            =~= s1.data.subrange(s1.start, s1.start + n1));
+                        assert(s2.data.subrange(s2.start, s2.start + n).subrange(0, n1 as int)
+                            =~= s2.data.subrange(s2.start, s2.start + n1));
+                    }
+                    lemma_parse_strong_prefix_on(parser1, s1, s2);
+                    // assert(parser1(s2).is_ok());
+                    if let Ok((p1s2, m1, p1x2)) = parser1(s2) {
+                        lemma_parse_well_behaved_on(parser1, s1);
+                        lemma_parse_well_behaved_on(parser1, s2);
+                        // assert(p1s1.data == s1.data);
+                        // assert(p1s2.data == s2.data);
+                        // assert(p1s1.start == s1.start + n1);
+                        // assert(p1s2.start == s2.start + n1);
+                        // assert(n == n1 + n2);
+                        assert(s1.data.subrange(s1.start + n1, s1.start + n1 + n2)
+                            == s2.data.subrange(s2.start + n1, s2.start + n1 + n2)) by {
+                            assert(s1.data.subrange(s1.start, s1.start + n).subrange(
+                                n1 as int,
+                                n as int,
+                            ) =~= s1.data.subrange(s1.start + n1, s1.start + n1 + n2));
+                            assert(s2.data.subrange(s2.start, s2.start + n).subrange(
+                                n1 as int,
+                                n as int,
+                            ) =~= s2.data.subrange(s2.start + n1, s2.start + n1 + n2));
+                        }
+                        assert(p1s1.data.subrange(p1s1.start, p1s1.start + n2)
+                            == p1s2.data.subrange(p1s2.start, p1s2.start + n2));
+                        lemma_parse_strong_prefix_on(parser2, p1s1, p1s2);
+                        // assert(parser2(p1s2).is_ok());
+                        if let Ok((p2s2, m2, p2x2)) = parser2(p1s2) {
+                            if let Ok((sout2, m, x2)) = spec_parse_pair(parser1, parser2)(s2) {
+                                assert(m == n && x2 == x1);
+                            }
+                        }
                     }
                 }
             }
@@ -2597,153 +2705,303 @@ verus! {
     }
 }
 
+pub proof fn lemma_parse_pair_correct_on<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s: SpecStream,
+    v: (T1, T2),
+)
+    requires
+        s.data.len() <= usize::MAX,
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+        prop_parse_well_behaved(parser1),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_correct(parser1, serializer1),
+        prop_parse_correct(parser2, serializer2),
+    ensures
+        prop_parse_correct_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+            v,
+        ),
+{
+    if let Ok((s1, n1)) = serializer1(s, v.0) {
+        if let Ok((s2, n2)) = serializer2(s1, v.1) {
+            lemma_serialize_well_behaved_on(serializer1, s, v.0);
+            lemma_serialize_well_behaved_on(serializer2, s1, v.1);
+            lemma_parse_correct_on(parser1, serializer1, s, v.0);
+            if let Ok((s_c1, n_c1, r_c1)) = parser1(SpecStream { start: s.start, ..s1 }) {
+                assert(n1 == n_c1 && r_c1 == v.0);
+                assert(s1.data.subrange(s.start, s.start + n_c1) == s2.data.subrange(
+                    s.start,
+                    s.start + n_c1,
+                )) by {
+                    assert(s1.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1)
+                        =~= s1.data.subrange(s.start, s.start + n1));
+                    assert(s2.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1)
+                        =~= s2.data.subrange(s.start, s.start + n1));
+                }
+                lemma_parse_strong_prefix_on(
+                    parser1,
+                    SpecStream { start: s.start, ..s1 },
+                    SpecStream { start: s.start, ..s2 },
+                );
+                if let Ok((s3, m1, res1)) = parser1(SpecStream { start: s.start, ..s2 }) {
+                    assert(m1 == n_c1 && res1 == r_c1);
+                    assert(m1 == n1 && res1 == v.0);  // crucial fact 1
+                    lemma_parse_well_behaved_on(parser1, SpecStream { start: s.start, ..s2 });
+                    assert(s3.data == s2.data && s3.start == s.start + m1);  // crucial fact 2 (s3 == SpecStream {start: s1.start, ..s2})
+                    lemma_parse_correct_on(parser2, serializer2, s1, v.1);
+                    // if let Ok((s_c2, n_c2, r_c2)) = parser2(SpecStream {start: s1.start, ..s2}) {
+                    // assert(n2 == n_c2 && r_c2 == v.1);
+                    if let Ok((s4, m2, res2)) = parser2(s3) {
+                        // assert(m2 == n_c2 && res2 == r_c2);
+                        assert(m1 + m2 == n1 + n2);
+                        assert(res1 == v.0 && res2 == v.1);
+                    }
+                    // }
+
+                }
+            }
+        }
+    }
+}
+
+pub proof fn lemma_parse_pair_serialize_inverse_on<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_serialize_well_behaved(serializer1),
+        prop_parse_serialize_inverse(parser1, serializer1),
+        prop_parse_serialize_inverse(parser2, serializer2),
+    ensures
+        prop_parse_serialize_inverse_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+        ),
+{
+    if let Ok((s1, n1, x1)) = parser1(s) {
+        if let Ok((s2, n2, x2)) = parser2(s1) {
+            lemma_parse_well_behaved_on(parser1, s);
+            lemma_parse_well_behaved_on(parser2, s1);
+            lemma_parse_serialize_inverse_on(parser1, serializer1, s);
+            lemma_serialize_well_behaved_on(serializer1, s, x1);
+            if let Ok((s3, m1)) = serializer1(s, x1) {
+                assert(m1 == n1 && s3.data == s.data);
+                lemma_parse_serialize_inverse_on(parser2, serializer2, s1);
+                if let Ok((s4, m2)) = serializer2(s3, x2) {
+                    assert(m1 + m2 == n1 + n2);
+                    assert(s4.data == s.data);
+                }
+            }
+        }
+    }
+}
+
+} // verus!
 verus! {
 
-    pub open spec fn spec_parse_repeat_n_rec<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat,
-        s: SpecStream) -> SpecParseResult<Seq<R>>
-        decreases n
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.len() {
-            Err(ParseError::Eof)
-        } else if n == 0 {
-            Ok((s, 0, seq![]))
-        } else {
-            match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
-                Ok((s, k, rs)) => match parser(s) {
-                    Ok((s, m, r)) => {
-                        if m + k > usize::MAX {
-                            Err(ParseError::IntegerOverflow)
-                        } else {
-                            Ok((s, m + k, rs.push(r))) // repeat_n(n) = repeat_n(n - 1).push(parse()) = repeat_n(n - 2).push(parse()).push(parse()) = ... = repeat_n(0).push(parse()).push(parse()).push(parse()) = seq![parse(), parse(), ..., parse()]
-                        }
-                    }
-                    Err(e) => Err(e),
-                },
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    pub open spec fn spec_parse_repeat_n<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat) ->
-        spec_fn(SpecStream) -> SpecParseResult<Seq<R>>
-    {
-        move |s| spec_parse_repeat_n_rec(parser, n, s)
-    }
-
-    pub open spec fn spec_serialize_repeat_n_rec<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream,
-        vs: Seq<T>) -> SpecSerializeResult
-        recommends
-            vs.len() == n // otherwise cannot prove correctness
-        decreases n
-    {
-        if vs.len() != n {
-            Err(SerializeError::RepeatNMismatch)
-        } else if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start > s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if n == 0 {
-            Ok((s, 0))
-        } else {
-            match spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1)) {
-                Ok((s, k)) => match serializer(s, vs[vs.len() as int - 1]) {
-                    Ok((s, m)) => {
-                        if m + k > usize::MAX {
-                            Err(SerializeError::IntegerOverflow)
-                        } else {
-                            Ok((s, m + k))
-                        }
-                    }
-                    Err(e) => Err(e),
-                },
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    pub open spec fn spec_serialize_repeat_n<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat) ->
-        spec_fn(SpecStream, Seq<T>) -> SpecSerializeResult
-    {
-        move |s, vs| spec_serialize_repeat_n_rec(serializer, n, s, vs)
-    }
-
-    pub exec fn parse_repeat_n<'a, P, R>(
-        exec_parser: P,
-        Ghost(spec_parser): Ghost<spec_fn(SpecStream) -> SpecParseResult<R::V>>,
-        n: usize, s: Stream<'a>) -> (res: ParseResult<'a, Vec<R>>)
-        where
-            P: Fn(Stream<'a>) -> ParseResult<'a, R>,
-            R: DView,
-        requires
-            prop_parse_exec_spec_equiv(exec_parser, spec_parser),
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat))
-    {
-        proof { reveal(prop_parse_exec_spec_equiv); }
-
-        if s.start < 0 {
-            return Err(ParseError::NegativeIndex);
-        } else if s.start > s.data.length() {
-            return Err(ParseError::Eof);
-        }
-
-        let (mut xs, mut mut_s, mut i, mut m): (Vec<R>, Stream, usize, usize) = (vec_new(), s, 0, 0);
-        let ghost res = Ok((mut_s, 0, xs));
-
-        while i < n
-            invariant
-                0 <= i <= n,
-                0 <= m <= usize::MAX,
-                forall |s| #![auto] exec_parser.requires((s,)),
-                res == Ok::<(Stream, usize, Vec<R>), ParseError>((mut_s, m, xs)),
-                prop_parse_exec_spec_equiv(exec_parser, spec_parser),
-                prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, i as nat)),
-        {
-            i = i + 1;
-            let res1 = exec_parser(mut_s);
-            proof { lemma_parse_exec_spec_equiv_on(exec_parser, spec_parser, mut_s, res1); }
-            match res1 {
-                Ok((s1, m1, r1)) => {
-                    if m > usize::MAX - m1 {
-                        proof { res = Err(ParseError::IntegerOverflow); }
-                        proof { lemma_parse_repeat_n_rec_error_unrecoverable_on(spec_parser, i as nat, n as nat, s.dview()); }
-                        assert(prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat)));
-                        return Err(ParseError::IntegerOverflow);
+pub open spec fn spec_parse_repeat_n_rec<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+    s: SpecStream,
+) -> SpecParseResult<Seq<R>>
+    decreases n,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.len() {
+        Err(ParseError::Eof)
+    } else if n == 0 {
+        Ok((s, 0, seq![]))
+    } else {
+        match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
+            Ok((s, k, rs)) => match parser(s) {
+                Ok((s, m, r)) => {
+                    if m + k > usize::MAX {
+                        Err(ParseError::IntegerOverflow)
                     } else {
-                        vec_push(&mut xs, r1);
-                        mut_s = s1;
-                        m = m + m1;
-                        proof { res = Ok((mut_s, m, xs)); }
-                        assert(prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, i as nat)));
-                    }
-                }
-                Err(e) => {
-                    proof { res = Err(e); }
-                    proof { lemma_parse_repeat_n_rec_error_unrecoverable_on(spec_parser, i as nat, n as nat, s.dview()); }
-                    assert(prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat)));
-                    return Err(e);
-                }
-            }
-        }
+                        Ok(
+                            (s, m + k, rs.push(r)),
+                        )  // repeat_n(n) = repeat_n(n - 1).push(parse()) = repeat_n(n - 2).push(parse()).push(parse()) = ... = repeat_n(0).push(parse()).push(parse()).push(parse()) = seq![parse(), parse(), ..., parse()]
 
-        Ok((mut_s, m, xs))
+                    }
+                },
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub open spec fn spec_parse_repeat_n<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+) -> spec_fn(SpecStream) -> SpecParseResult<Seq<R>> {
+    move |s| spec_parse_repeat_n_rec(parser, n, s)
+}
+
+pub open spec fn spec_serialize_repeat_n_rec<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+    vs: Seq<T>,
+) -> SpecSerializeResult
+    recommends
+        vs.len() == n  // otherwise cannot prove correctness
+        ,
+    decreases n,
+{
+    if vs.len() != n {
+        Err(SerializeError::RepeatNMismatch)
+    } else if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start > s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if n == 0 {
+        Ok((s, 0))
+    } else {
+        match spec_serialize_repeat_n_rec(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        ) {
+            Ok((s, k)) => match serializer(s, vs[vs.len() as int - 1]) {
+                Ok((s, m)) => {
+                    if m + k > usize::MAX {
+                        Err(SerializeError::IntegerOverflow)
+                    } else {
+                        Ok((s, m + k))
+                    }
+                },
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub open spec fn spec_serialize_repeat_n<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+) -> spec_fn(SpecStream, Seq<T>) -> SpecSerializeResult {
+    move |s, vs| spec_serialize_repeat_n_rec(serializer, n, s, vs)
+}
+
+pub exec fn parse_repeat_n<'a, P, R>(
+    exec_parser: P,
+    Ghost(spec_parser): Ghost<spec_fn(SpecStream) -> SpecParseResult<R::V>>,
+    n: usize,
+    s: Stream<'a>,
+) -> (res: ParseResult<'a, Vec<R>>) where P: Fn(Stream<'a>) -> ParseResult<'a, R>, R: DView
+    requires
+        prop_parse_exec_spec_equiv(exec_parser, spec_parser),
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat)),
+{
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
     }
 
-    proof fn lemma_parse_repeat_n_rec_error_unrecoverable_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n1: nat, n2: nat, s: SpecStream)
-        ensures
+    if s.start < 0 {
+        return Err(ParseError::NegativeIndex);
+    } else if s.start > s.data.length() {
+        return Err(ParseError::Eof);
+    }
+    let (mut xs, mut mut_s, mut i, mut m): (Vec<R>, Stream, usize, usize) = (vec_new(), s, 0, 0);
+    let ghost res = Ok((mut_s, 0, xs));
+
+    while i < n
+        invariant
+            0 <= i <= n,
+            0 <= m <= usize::MAX,
+            forall|s| #![auto] exec_parser.requires((s,)),
+            res == Ok::<(Stream, usize, Vec<R>), ParseError>((mut_s, m, xs)),
+            prop_parse_exec_spec_equiv(exec_parser, spec_parser),
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, i as nat)),
+    {
+        i = i + 1;
+        let res1 = exec_parser(mut_s);
+        proof {
+            lemma_parse_exec_spec_equiv_on(exec_parser, spec_parser, mut_s, res1);
+        }
+        match res1 {
+            Ok((s1, m1, r1)) => {
+                if m > usize::MAX - m1 {
+                    proof {
+                        res = Err(ParseError::IntegerOverflow);
+                    }
+                    proof {
+                        lemma_parse_repeat_n_rec_error_unrecoverable_on(
+                            spec_parser,
+                            i as nat,
+                            n as nat,
+                            s.dview(),
+                        );
+                    }
+                    assert(prop_parse_exec_spec_equiv_on(
+                        s,
+                        res,
+                        spec_parse_repeat_n(spec_parser, n as nat),
+                    ));
+                    return Err(ParseError::IntegerOverflow);
+                } else {
+                    vec_push(&mut xs, r1);
+                    mut_s = s1;
+                    m = m + m1;
+                    proof {
+                        res = Ok((mut_s, m, xs));
+                    }
+                    assert(prop_parse_exec_spec_equiv_on(
+                        s,
+                        res,
+                        spec_parse_repeat_n(spec_parser, i as nat),
+                    ));
+                }
+            },
+            Err(e) => {
+                proof {
+                    res = Err(e);
+                }
+                proof {
+                    lemma_parse_repeat_n_rec_error_unrecoverable_on(
+                        spec_parser,
+                        i as nat,
+                        n as nat,
+                        s.dview(),
+                    );
+                }
+                assert(prop_parse_exec_spec_equiv_on(
+                    s,
+                    res,
+                    spec_parse_repeat_n(spec_parser, n as nat),
+                ));
+                return Err(e);
+            },
+        }
+    }
+    Ok((mut_s, m, xs))
+}
+
+proof fn lemma_parse_repeat_n_rec_error_unrecoverable_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n1: nat,
+    n2: nat,
+    s: SpecStream,
+)
+    ensures
         n2 >= n1 ==> {
             if let Err(e1) = spec_parse_repeat_n_rec(parser, n1, s) {
                 if let Err(e2) = spec_parse_repeat_n_rec(parser, n2, s) {
@@ -2754,484 +3012,687 @@ verus! {
             } else {
                 true
             }
-        }
-        decreases n2
-    {
-        if n2 == n1 {}
-        else if n2 > n1 {
-            lemma_parse_repeat_n_rec_error_unrecoverable_on(parser, n1, (n2 - 1) as nat, s);
-        }
+        },
+    decreases n2,
+{
+    if n2 == n1 {
+    } else if n2 > n1 {
+        lemma_parse_repeat_n_rec_error_unrecoverable_on(parser, n1, (n2 - 1) as nat, s);
     }
+}
 
-    proof fn lemma_serialize_repeat_n_rec_error_unrecoverable_on<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n1: nat, n2: nat, s: SpecStream, vs1: Seq<T>, vs2: Seq<T>)
-        requires
-            n2 >= n1,
-            vs1.len() == n1,
-            vs2.len() == n2,
-            vs1 == vs2.subrange(0, n1 as int),
-        ensures
-            if let Err(e1) = spec_serialize_repeat_n_rec(serializer, n1, s, vs1) {
-                if let Err(e2) = spec_serialize_repeat_n_rec(serializer, n2, s, vs2) {
-                    e1 == e2
-                } else {
-                    false
-                }
+proof fn lemma_serialize_repeat_n_rec_error_unrecoverable_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n1: nat,
+    n2: nat,
+    s: SpecStream,
+    vs1: Seq<T>,
+    vs2: Seq<T>,
+)
+    requires
+        n2 >= n1,
+        vs1.len() == n1,
+        vs2.len() == n2,
+        vs1 == vs2.subrange(0, n1 as int),
+    ensures
+        if let Err(e1) = spec_serialize_repeat_n_rec(serializer, n1, s, vs1) {
+            if let Err(e2) = spec_serialize_repeat_n_rec(serializer, n2, s, vs2) {
+                e1 == e2
             } else {
-                true
+                false
             }
-        decreases n2, vs2.len()
-    {
-        if n2 == n1 {
-            assert(vs1 =~= vs2);
-        }
-        else if n2 > n1 {
-            assert(vs1 =~= vs2.subrange(0, vs2.len() as int - 1).subrange(0, n1 as int));
-            lemma_serialize_repeat_n_rec_error_unrecoverable_on(serializer, n1, (n2 - 1) as nat, s, vs1, vs2.subrange(0, vs2.len() as int - 1));
-        }
+        } else {
+            true
+        },
+    decreases n2, vs2.len(),
+{
+    if n2 == n1 {
+        assert(vs1 =~= vs2);
+    } else if n2 > n1 {
+        assert(vs1 =~= vs2.subrange(0, vs2.len() as int - 1).subrange(0, n1 as int));
+        lemma_serialize_repeat_n_rec_error_unrecoverable_on(
+            serializer,
+            n1,
+            (n2 - 1) as nat,
+            s,
+            vs1,
+            vs2.subrange(0, vs2.len() as int - 1),
+        );
     }
+}
 
-    pub proof fn spec_parse_repeat_n_rec_step<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat, s: SpecStream)
-        ensures
-            s.start < 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(ParseError::NegativeIndex),
-            s.start > s.data.len() ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(ParseError::Eof),
-            0 <= s.start <= s.data.len() ==> {
-                &&& n == 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Ok::<(SpecStream, nat, Seq<R>), ParseError>((s, 0, seq![]))
-                &&& n > 0 ==> match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
-                    Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(e),
-                    Ok((s0, m, rs)) => match parser(s0) {
-                        Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(e),
-                        Ok((s1, k, r)) => {
-                            if m + k > usize::MAX {
-                                spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(ParseError::IntegerOverflow)
-                            } else {
-                                spec_parse_repeat_n_rec(parser, n, s) == Ok::<(SpecStream, nat, Seq<R>), ParseError>((s1, m + k, rs.push(r)))
-                            }
+pub proof fn spec_parse_repeat_n_rec_step<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+    s: SpecStream,
+)
+    ensures
+        s.start < 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<
+            (SpecStream, nat, Seq<R>),
+            ParseError,
+        >(ParseError::NegativeIndex),
+        s.start > s.data.len() ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<
+            (SpecStream, nat, Seq<R>),
+            ParseError,
+        >(ParseError::Eof),
+        0 <= s.start <= s.data.len() ==> {
+            &&& n == 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Ok::<
+                (SpecStream, nat, Seq<R>),
+                ParseError,
+            >((s, 0, seq![]))
+            &&& n > 0 ==> match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
+                Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<
+                    (SpecStream, nat, Seq<R>),
+                    ParseError,
+                >(e),
+                Ok((s0, m, rs)) => match parser(s0) {
+                    Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<
+                        (SpecStream, nat, Seq<R>),
+                        ParseError,
+                    >(e),
+                    Ok((s1, k, r)) => {
+                        if m + k > usize::MAX {
+                            spec_parse_repeat_n_rec(parser, n, s) == Err::<
+                                (SpecStream, nat, Seq<R>),
+                                ParseError,
+                            >(ParseError::IntegerOverflow)
+                        } else {
+                            spec_parse_repeat_n_rec(parser, n, s) == Ok::<
+                                (SpecStream, nat, Seq<R>),
+                                ParseError,
+                            >((s1, m + k, rs.push(r)))
                         }
-                    }
-                }
+                    },
+                },
             }
-    {}
+        },
+{
+}
 
-    pub proof fn lemma_parse_repeat_n_correct<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_strong_prefix(parser),
-            prop_parse_correct(parser, serializer)
-        ensures
-            prop_parse_correct(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_parse_correct);
-        assert forall |s: SpecStream, vs: Seq<T>| s.data.len() <= usize::MAX ==> prop_parse_correct_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s, vs) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_repeat_n_correct_on(parser, serializer, n, s, vs);
-            }
+pub proof fn lemma_parse_repeat_n_correct<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_strong_prefix(parser),
+        prop_parse_correct(parser, serializer),
+    ensures
+        prop_parse_correct(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n)),
+{
+    reveal(prop_parse_correct);
+    assert forall|s: SpecStream, vs: Seq<T>|
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+            vs,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_repeat_n_correct_on(parser, serializer, n, s, vs);
         }
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_serialize_inverse<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_serialize_inverse(parser, serializer)
-        ensures
-            prop_parse_serialize_inverse(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_parse_serialize_inverse);
-        assert forall |s: SpecStream| prop_parse_serialize_inverse_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s) by {
-            lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, n, s);
-        }
+pub proof fn lemma_parse_repeat_n_serialize_inverse<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_serialize_inverse(parser, serializer),
+    ensures
+        prop_parse_serialize_inverse(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+        ),
+{
+    reveal(prop_parse_serialize_inverse);
+    assert forall|s: SpecStream|
+        prop_parse_serialize_inverse_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+        ) by {
+        lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, n, s);
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_well_behaved<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser)
-        ensures
-            prop_parse_well_behaved(spec_parse_repeat_n(parser, n)),
-            forall |s| {
+pub proof fn lemma_parse_repeat_n_well_behaved<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+    ensures
+        prop_parse_well_behaved(spec_parse_repeat_n(parser, n)),
+        forall|s|
+            {
                 if let Ok((_, _, res)) = #[trigger] spec_parse_repeat_n(parser, n)(s) {
                     res.len() == n
                 } else {
                     true
                 }
-            }
-        decreases n
-    {
-        reveal(prop_parse_well_behaved);
-        assert forall |s:SpecStream| prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s) by {
-            lemma_parse_repeat_n_well_behaved_on(parser, n, s);
-        }
-        assert forall |s:SpecStream| {
+            },
+    decreases n,
+{
+    reveal(prop_parse_well_behaved);
+    assert forall|s: SpecStream| prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s) by {
+        lemma_parse_repeat_n_well_behaved_on(parser, n, s);
+    }
+    assert forall|s: SpecStream|
+        {
             if let Ok((_, _, res)) = #[trigger] spec_parse_repeat_n(parser, n)(s) {
                 res.len() == n
             } else {
                 true
             }
         } by {
-            lemma_parse_repeat_n_well_behaved_on(parser, n, s);
+        lemma_parse_repeat_n_well_behaved_on(parser, n, s);
+    }
+}
+
+pub proof fn lemma_serialize_repeat_n_well_behaved<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+    ensures
+        prop_serialize_well_behaved(spec_serialize_repeat_n(serializer, n)),
+{
+    reveal(prop_serialize_well_behaved);
+    assert forall|s: SpecStream, vs: Seq<T>|
+        prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs) by {
+        lemma_serialize_repeat_n_well_behaved_on(serializer, n, s, vs);
+    }
+}
+
+pub proof fn lemma_serialize_repeat_n_deterministic<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n)),
+{
+    reveal(prop_serialize_deterministic);
+    assert forall|s1, s2, v|
+        prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, v) by {
+        lemma_serialize_repeat_n_deterministic_on(serializer, n, s1, s2, v);
+    }
+}
+
+pub proof fn lemma_parse_repeat_n_nonmalleable<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_parse_serialize_inverse(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+        ),
+        prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n)),
+    ensures
+        prop_parse_nonmalleable(spec_parse_repeat_n(parser, n)),
+{
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        spec_parse_repeat_n(parser, n),
+        spec_serialize_repeat_n(serializer, n),
+    );
+}
+
+pub proof fn lemma_parse_repeat_n_strong_prefix<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_parse_strong_prefix(parser),
+    ensures
+        prop_parse_strong_prefix(spec_parse_repeat_n(parser, n)),
+{
+    reveal(prop_parse_strong_prefix);
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2) by {
+        lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, n);
+    }
+}
+
+pub proof fn lemma_parse_repeat_n_correct_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+    vs: Seq<T>,
+)
+    requires
+        s.data.len() <= usize::MAX,
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_strong_prefix(parser),
+        prop_parse_correct(parser, serializer),
+    ensures
+        prop_parse_correct_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+            vs,
+        ),
+    decreases n, vs.len(),
+{
+    if vs.len() != n {
+    } else if s.start < 0 {
+    } else if s.start > s.data.len() {
+    } else if n == 0 {
+        assert(vs =~= seq![]);
+    } else {
+        // induction
+        lemma_parse_repeat_n_correct_on(
+            parser,
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        );
+        lemma_serialize_repeat_n_well_behaved_on(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        );
+        if let Ok((s0, n0)) = spec_serialize_repeat_n_rec(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        ) {
+            lemma_serialize_well_behaved_on(serializer, s0, vs[vs.len() as int - 1]);
+            if let Ok((s1, n1)) = serializer(s0, vs[vs.len() as int - 1]) {
+                assert(s0.data.subrange(s.start, s.start + n0) == s1.data.subrange(
+                    s.start,
+                    s.start + n0,
+                )) by {
+                    assert(s0.data.subrange(0, s0.start).subrange(s.start, s.start + n0)
+                        =~= s0.data.subrange(s.start, s.start + n0));
+                    assert(s1.data.subrange(0, s0.start).subrange(s.start, s.start + n0)
+                        =~= s1.data.subrange(s.start, s.start + n0));
+                }
+                lemma_parse_repeat_n_strong_prefix(parser, (n - 1) as nat);
+                lemma_parse_strong_prefix_on(
+                    spec_parse_repeat_n(parser, (n - 1) as nat),
+                    SpecStream { start: s.start, ..s0 },
+                    SpecStream { start: s.start, ..s1 },
+                );
+                lemma_parse_correct_on(parser, serializer, s0, vs[vs.len() as int - 1]);
+                lemma_parse_repeat_n_well_behaved_on(
+                    parser,
+                    (n - 1) as nat,
+                    SpecStream { start: s.start, ..s1 },
+                );
+                if let Ok((s2, n2, x0)) = spec_parse_repeat_n_rec(
+                    parser,
+                    (n - 1) as nat,
+                    SpecStream { start: s.start, ..s1 },
+                ) {
+                    if let Ok((s3, n3, x1)) = parser(s2) {
+                        assert(n3 == n1 && x1 == vs[vs.len() as int - 1]);
+                        assert(n2 + n3 == n0 + n1);
+                        assert(x0 == vs.subrange(0, vs.len() as int - 1));
+                        assert(x0.push(x1) =~= vs);
+                    }
+                }
+            }
         }
     }
+}
 
-    pub proof fn lemma_serialize_repeat_n_well_behaved<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_serialize_well_behaved(serializer),
-        ensures
-            prop_serialize_well_behaved(spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_serialize_well_behaved);
-        assert forall |s:SpecStream, vs: Seq<T>| prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs) by {
-            lemma_serialize_repeat_n_well_behaved_on(serializer, n, s, vs);
+pub proof fn lemma_parse_repeat_n_serialize_inverse_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_serialize_inverse(parser, serializer),
+    ensures
+        prop_parse_serialize_inverse_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+        ),
+    decreases n,
+{
+    if s.start < 0 {
+    } else if s.start > s.data.len() {
+    } else if n == 0 {
+    } else {
+        // induction
+        lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, (n - 1) as nat, s);
+        lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
+        if let Ok((s0, n0, x0)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
+            lemma_parse_well_behaved_on(parser, s0);
+            if let Ok((s1, n1, x1)) = parser(s0) {
+                assert(x0.push(x1).subrange(0, x0.push(x1).len() as int - 1) =~= x0);
+                lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, x0);
+                if let Ok((s2, n2)) = spec_serialize_repeat_n_rec(
+                    serializer,
+                    (n - 1) as nat,
+                    s,
+                    x0,
+                ) {
+                    lemma_serialize_well_behaved_on(serializer, s2, x1);
+                    lemma_parse_serialize_inverse_on(parser, serializer, s0);
+                    assert(s2 == s0);
+                    if let Ok((s3, n3)) = serializer(s2, x1) {
+                        assert(n0 + n1 == n2 + n3);
+                        assert(s3.data == s.data);
+                    }
+                }
+            }
         }
     }
+}
 
-    pub proof fn lemma_serialize_repeat_n_deterministic<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_serialize_well_behaved(serializer),
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_serialize_deterministic);
-        assert forall |s1, s2, v| prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, v) by {
-            lemma_serialize_repeat_n_deterministic_on(serializer, n, s1, s2, v);
+pub proof fn lemma_parse_repeat_n_well_behaved_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser),
+    ensures
+        prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s) && if let Ok((_, _, res)) =
+            spec_parse_repeat_n(parser, n)(s) {
+            res.len() == n
+        } else {
+            true
+        },
+    decreases n,
+{
+    if n == 0 {
+    } else {
+        match spec_parse_repeat_n(parser, n)(s) {
+            Ok((sout, n_total, res)) => {
+                assert(sout.data == s.data && sout.start == s.start + n_total && 0 <= s.start
+                    <= sout.start <= s.data.len() && res.len() == n) by {
+                    if let Ok((s1, n1, res1)) = spec_parse_repeat_n(parser, (n - 1) as nat)(s) {
+                        assert(s1.data == s.data && s1.start == s.start + n1 && 0 <= s.start
+                            <= s1.start <= s.data.len() && res1.len() == n - 1) by {  // induction on n
+                            lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
+                        }
+                        if let Ok((s2, n2, res2)) = parser(s1) {
+                            assert(s2.data == s1.data && s2.start == s1.start + n2 && 0 <= s1.start
+                                <= s2.start <= s1.data.len()) by {
+                                lemma_parse_well_behaved_on(parser, s1);
+                            }
+                            assert(sout == s2 && n_total == n1 + n2 && res == res1.push(res2)
+                                && res.len() == n);
+                        }
+                    }
+                }
+            },
+            Err(_) => {},
         }
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_nonmalleable<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_parse_serialize_inverse(spec_parse_repeat_n(parser, n),
-                                        spec_serialize_repeat_n(serializer, n)),
-            prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n)),
-        ensures
-            prop_parse_nonmalleable(spec_parse_repeat_n(parser, n))
-    {
-        lemma_parse_serialize_inverse_implies_nonmalleable(spec_parse_repeat_n(parser, n),
-                                        spec_serialize_repeat_n(serializer, n));
-    }
+pub proof fn lemma_serialize_repeat_n_well_behaved_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+    vs: Seq<T>,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+    ensures
+        prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs),
+    decreases n,
+{
+    if vs.len() != n {
+    } else if s.start < 0 {
+    } else if s.start > s.data.len() {
+    } else if n == 0 {
+    } else {
+        lemma_serialize_repeat_n_well_behaved_on(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        );
+        match spec_serialize_repeat_n_rec(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        ) {
+            Ok((s1, n1)) => {
+                assert(s.start + n1 == s1.start);
+                assert(s1.data.subrange(0, s.start) == s.data.subrange(0, s.start));
+                assert(s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(
+                    s.start + n1,
+                    s.data.len() as int,
+                ));
+                lemma_serialize_well_behaved_on(serializer, s1, vs[vs.len() as int - 1]);
+                match serializer(s1, vs[vs.len() as int - 1]) {
+                    Ok((s2, n2)) => {
+                        assert(s1.start + n2 == s2.start);
+                        assert(s2.data.subrange(0, s1.start) == s1.data.subrange(0, s1.start));
+                        assert(s2.data.subrange(s1.start + n2, s.data.len() as int)
+                            == s1.data.subrange(s1.start + n2, s.data.len() as int));
 
-    pub proof fn lemma_parse_repeat_n_strong_prefix<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_parse_strong_prefix(parser),
-        ensures
-            prop_parse_strong_prefix(spec_parse_repeat_n(parser, n))
-    {
-        reveal(prop_parse_strong_prefix);
-        assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2) by {
-            lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, n);
+                        assert(s.start + n1 + n2 == s2.start);
+                        assert(s2.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
+                            assert(s2.data.subrange(0, s1.start).subrange(0, s.start)
+                                =~= s2.data.subrange(0, s.start));
+                            assert(s1.data.subrange(0, s1.start).subrange(0, s.start)
+                                =~= s.data.subrange(0, s.start));
+                        }
+                        assert(s2.data.subrange(s.start + n1 + n2, s.data.len() as int)
+                            == s.data.subrange(s.start + n1 + n2, s.data.len() as int)) by {
+                            assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                                n2 as int,
+                                s.data.len() - s.start - n1,
+                            ) =~= s1.data.subrange(s.start + n1 + n2, s.data.len() as int));
+                            assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                                n2 as int,
+                                s.data.len() - s.start - n1,
+                            ) =~= s.data.subrange(s.start + n1 + n2, s.data.len() as int));
+                        }
+                    },
+                    Err(e) => {},
+                }
+            },
+            Err(e) => {},
         }
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_correct_on<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream,
-        vs: Seq<T>)
-        requires
-            s.data.len() <= usize::MAX,
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_strong_prefix(parser),
-            prop_parse_correct(parser, serializer)
-        ensures
-            prop_parse_correct_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s, vs)
-        decreases n, vs.len()
-    {
+pub proof fn lemma_serialize_repeat_n_deterministic_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s1: SpecStream,
+    s2: SpecStream,
+    vs: Seq<T>,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, vs),
+    decreases n, vs.len(),
+{
+    if let (Ok((sn1, m1)), Ok((sn2, m2))) = (
+        spec_serialize_repeat_n(serializer, n)(s1, vs),
+        spec_serialize_repeat_n(serializer, n)(s2, vs),
+    ) {
         if vs.len() != n {
-        } else if s.start < 0 {
-        } else if s.start > s.data.len() {
-        } else if n == 0 {
-            assert(vs =~= seq![]);
-        } else {
-            // induction
-            lemma_parse_repeat_n_correct_on(parser, serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1));
-            lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1));
-            if let Ok((s0, n0)) = spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1)) {
-                lemma_serialize_well_behaved_on(serializer, s0, vs[vs.len() as int - 1]);
-                if let Ok((s1, n1)) = serializer(s0, vs[vs.len() as int - 1]) {
-                    assert(s0.data.subrange(s.start, s.start + n0) == s1.data.subrange(s.start, s.start + n0)) by {
-                        assert(s0.data.subrange(0, s0.start).subrange(s.start, s.start + n0) =~= s0.data.subrange(s.start, s.start + n0));
-                        assert(s1.data.subrange(0, s0.start).subrange(s.start, s.start + n0) =~= s1.data.subrange(s.start, s.start + n0));
-                    }
-                    lemma_parse_repeat_n_strong_prefix(parser, (n - 1) as nat);
-                    lemma_parse_strong_prefix_on(spec_parse_repeat_n(parser, (n - 1) as nat), SpecStream { start: s.start, ..s0 }, SpecStream { start: s.start, ..s1 });
-                    lemma_parse_correct_on(parser, serializer, s0, vs[vs.len() as int - 1]);
-                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, SpecStream { start: s.start, ..s1 });
-                    if let Ok((s2, n2, x0)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, SpecStream { start: s.start, ..s1 }) {
-                        if let Ok((s3, n3, x1)) = parser(s2) {
-                            assert(n3 == n1 && x1 == vs[vs.len() as int - 1]);
-                            assert(n2 + n3 == n0 + n1);
-                            assert(x0 == vs.subrange(0, vs.len() as int - 1));
-                            assert(x0.push(x1) =~= vs);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_repeat_n_serialize_inverse_on<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_serialize_inverse(parser, serializer)
-        ensures
-            prop_parse_serialize_inverse_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s)
-        decreases n
-    {
-        if s.start < 0 {
-        } else if s.start > s.data.len() {
+        } else if s1.start < 0 || s2.start < 0 {
+        } else if s1.start > s1.data.len() || s2.start > s2.data.len() {
         } else if n == 0 {
         } else {
-            // induction
-            lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, (n - 1) as nat, s);
-            lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
-            if let Ok((s0, n0, x0)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
-                lemma_parse_well_behaved_on(parser, s0);
-                if let Ok((s1, n1, x1)) = parser(s0) {
-                    assert(x0.push(x1).subrange(0, x0.push(x1).len() as int - 1) =~= x0);
-                    lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, x0);
-                    if let Ok((s2, n2)) = spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, x0) {
-                        lemma_serialize_well_behaved_on(serializer, s2, x1);
-                        lemma_parse_serialize_inverse_on(parser, serializer, s0);
-                        assert(s2 == s0);
-                        if let Ok((s3, n3)) = serializer(s2, x1) {
-                            assert(n0 + n1 == n2 + n3);
-                            assert(s3.data == s.data);
+            // induction on n
+            lemma_serialize_repeat_n_well_behaved_on(
+                serializer,
+                (n - 1) as nat,
+                s1,
+                vs.subrange(0, vs.len() as int - 1),
+            );
+            lemma_serialize_repeat_n_well_behaved_on(
+                serializer,
+                (n - 1) as nat,
+                s2,
+                vs.subrange(0, vs.len() as int - 1),
+            );
+            lemma_serialize_repeat_n_deterministic_on(
+                serializer,
+                (n - 1) as nat,
+                s1,
+                s2,
+                vs.subrange(0, vs.len() as int - 1),
+            );
+            if let (Ok((snn1, nn1)), Ok((snn2, nn2))) = (
+                spec_serialize_repeat_n_rec(
+                    serializer,
+                    (n - 1) as nat,
+                    s1,
+                    vs.subrange(0, vs.len() as int - 1),
+                ),
+                spec_serialize_repeat_n_rec(
+                    serializer,
+                    (n - 1) as nat,
+                    s2,
+                    vs.subrange(0, vs.len() as int - 1),
+                ),
+            ) {
+                assert(nn1 == nn2);
+                assert(snn1.data.subrange(s1.start, s1.start + nn1) == snn2.data.subrange(
+                    s2.start,
+                    s2.start + nn2,
+                ));
+
+                lemma_serialize_well_behaved_on(serializer, snn1, vs[vs.len() as int - 1]);
+                lemma_serialize_well_behaved_on(serializer, snn2, vs[vs.len() as int - 1]);
+                lemma_serialize_deterministic_on(serializer, snn1, snn2, vs[vs.len() as int - 1]);
+                if let Ok((sout1, n1)) = serializer(snn1, vs[vs.len() as int - 1]) {
+                    if let Ok((sout2, n2)) = serializer(snn2, vs[vs.len() as int - 1]) {
+                        assert(n1 + nn1 == n2 + nn2);
+                        assert(sout1.data.subrange(snn1.start, snn1.start + n1)
+                            == sout2.data.subrange(snn2.start, snn2.start + n2));
+
+                        assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1)
+                            == sout2.data.subrange(s2.start, s2.start + n2 + nn2)) by {
+                            assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1)
+                                =~= sout1.data.subrange(s1.start, s1.start + nn1)
+                                + sout1.data.subrange(s1.start + nn1, s1.start + n1 + nn1));
+                            assert(sout2.data.subrange(s2.start, s2.start + n2 + nn2)
+                                =~= sout2.data.subrange(s2.start, s2.start + nn2)
+                                + sout2.data.subrange(s2.start + nn2, s2.start + n2 + nn2));
+
+                            assert(sout1.data.subrange(s1.start, s1.start + nn1)
+                                =~= sout1.data.subrange(0, s1.start + nn1).subrange(
+                                s1.start,
+                                s1.start + nn1,
+                            ));
+                            assert(sout2.data.subrange(s2.start, s2.start + nn2)
+                                =~= sout2.data.subrange(0, s2.start + nn2).subrange(
+                                s2.start,
+                                s2.start + nn2,
+                            ));
+
+                            assert(snn1.data.subrange(s1.start, s1.start + nn1)
+                                =~= snn1.data.subrange(0, s1.start + nn1).subrange(
+                                s1.start,
+                                s1.start + nn1,
+                            ));
+                            assert(snn2.data.subrange(s2.start, s2.start + nn2)
+                                =~= snn2.data.subrange(0, s2.start + nn2).subrange(
+                                s2.start,
+                                s2.start + nn2,
+                            ));
                         }
                     }
                 }
             }
         }
-    }
-
-    pub proof fn lemma_parse_repeat_n_well_behaved_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser)
-        ensures
-            prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s)
-            &&
-            if let Ok((_, _, res)) = spec_parse_repeat_n(parser, n)(s) {
-                res.len() == n
-            } else {
-                true
-            }
-        decreases n
-    {
-        if n == 0 {
-        } else {
-            match spec_parse_repeat_n(parser, n)(s) {
-                Ok((sout, n_total, res)) => {
-                    assert(
-                        sout.data == s.data &&
-                        sout.start == s.start + n_total &&
-                        0 <= s.start <= sout.start <= s.data.len() &&
-                        res.len() == n) by {
-                            if let Ok((s1, n1, res1)) = spec_parse_repeat_n(parser, (n - 1) as nat)(s) {
-                                assert(
-                                    s1.data == s.data &&
-                                    s1.start == s.start + n1 &&
-                                    0 <= s.start <= s1.start <= s.data.len() &&
-                                    res1.len() == n - 1) by { // induction on n
-                                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
-                                }
-                                if let Ok((s2, n2, res2)) = parser(s1) {
-                                    assert(
-                                        s2.data == s1.data &&
-                                        s2.start == s1.start + n2 &&
-                                        0 <= s1.start <= s2.start <= s1.data.len()) by {
-                                            lemma_parse_well_behaved_on(parser, s1);
-                                        }
-                                    assert(
-                                        sout == s2 &&
-                                        n_total == n1 + n2 &&
-                                        res == res1.push(res2) &&
-                                        res.len() == n
-                                    );
-                                }
-                            }
-                        }
-                }
-                Err(_) => {}
-            }
-        }
-    }
-
-    pub proof fn lemma_serialize_repeat_n_well_behaved_on<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream,
-        vs: Seq<T>)
-        requires
-            prop_serialize_well_behaved(serializer),
-        ensures
-            prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs)
-        decreases n
-    {
-        if vs.len() != n {}
-        else if s.start < 0 {}
-        else if s.start > s.data.len() {}
-        else if n == 0 {}
-        else {
-            lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1));
-            match spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1)) {
-                Ok((s1, n1)) =>
-                {
-                    assert(s.start + n1 == s1.start);
-                    assert(s1.data.subrange(0, s.start) == s.data.subrange(0, s.start));
-                    assert(s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(s.start + n1, s.data.len() as int));
-                    lemma_serialize_well_behaved_on(serializer, s1, vs[vs.len() as int - 1]);
-                    match serializer(s1, vs[vs.len() as int - 1]) {
-                        Ok((s2, n2)) => {
-                            assert(s1.start + n2 == s2.start);
-                            assert(s2.data.subrange(0, s1.start) == s1.data.subrange(0, s1.start));
-                            assert(s2.data.subrange(s1.start + n2, s.data.len() as int) == s1.data.subrange(s1.start + n2, s.data.len() as int));
-
-                            assert(s.start + n1 + n2 == s2.start);
-                            assert(s2.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
-                                assert(s2.data.subrange(0, s1.start).subrange(0, s.start) =~= s2.data.subrange(0, s.start));
-                                assert(s1.data.subrange(0, s1.start).subrange(0, s.start) =~= s.data.subrange(0, s.start));
-                            }
-                            assert(s2.data.subrange(s.start + n1 + n2, s.data.len() as int) == s.data.subrange(s.start + n1 + n2, s.data.len() as int)) by {
-                                assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s1.data.subrange(s.start + n1 + n2, s.data.len() as int));
-                                assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s.data.subrange(s.start + n1 + n2, s.data.len() as int));
-                            }
-                        }
-                        Err(e) => {}
-                    }
-                },
-                Err(e) => {}
-            }
-        }
-    }
-
-    pub proof fn lemma_serialize_repeat_n_deterministic_on<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s1: SpecStream,
-        s2: SpecStream,
-        vs: Seq<T>)
-        requires
-            prop_serialize_well_behaved(serializer),
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, vs)
-        decreases n, vs.len()
-    {
-        if let (Ok((sn1, m1)), Ok((sn2, m2))) = (spec_serialize_repeat_n(serializer, n)(s1, vs), spec_serialize_repeat_n(serializer, n)(s2, vs))
-        {
-            if vs.len() != n {}
-            else if s1.start < 0 || s2.start < 0 {}
-            else if s1.start > s1.data.len() || s2.start > s2.data.len() {}
-            else if n == 0 {}
-            else {
-                // induction on n
-                lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s1, vs.subrange(0, vs.len() as int - 1));
-                lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s2, vs.subrange(0, vs.len() as int - 1));
-                lemma_serialize_repeat_n_deterministic_on(serializer, (n - 1) as nat, s1, s2, vs.subrange(0, vs.len() as int - 1));
-                if let (Ok((snn1, nn1)), Ok((snn2, nn2))) = (spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s1, vs.subrange(0, vs.len() as int - 1)), spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s2, vs.subrange(0, vs.len() as int - 1))) {
-                    assert(nn1 == nn2);
-                    assert(snn1.data.subrange(s1.start, s1.start + nn1) == snn2.data.subrange(s2.start, s2.start + nn2));
-
-                    lemma_serialize_well_behaved_on(serializer, snn1, vs[vs.len() as int - 1]);
-                    lemma_serialize_well_behaved_on(serializer, snn2, vs[vs.len() as int - 1]);
-                    lemma_serialize_deterministic_on(serializer, snn1, snn2, vs[vs.len() as int - 1]);
-                    if let Ok((sout1, n1)) = serializer(snn1, vs[vs.len() as int - 1]) {
-                        if let Ok((sout2, n2)) = serializer(snn2, vs[vs.len() as int - 1]) {
-                            assert(n1 + nn1 == n2 + nn2);
-                            assert(sout1.data.subrange(snn1.start, snn1.start + n1) == sout2.data.subrange(snn2.start, snn2.start + n2));
-
-                            assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1) == sout2.data.subrange(s2.start, s2.start + n2 + nn2)) by {
-                                assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1) =~= sout1.data.subrange(s1.start, s1.start + nn1) + sout1.data.subrange(s1.start + nn1, s1.start + n1 + nn1));
-                                assert(sout2.data.subrange(s2.start, s2.start + n2 + nn2) =~= sout2.data.subrange(s2.start, s2.start + nn2) + sout2.data.subrange(s2.start + nn2, s2.start + n2 + nn2));
-
-                                assert(sout1.data.subrange(s1.start, s1.start + nn1) =~= sout1.data.subrange(0, s1.start + nn1).subrange(s1.start, s1.start + nn1));
-                                assert(sout2.data.subrange(s2.start, s2.start + nn2) =~= sout2.data.subrange(0, s2.start + nn2).subrange(s2.start, s2.start + nn2));
-
-                                assert(snn1.data.subrange(s1.start, s1.start + nn1) =~= snn1.data.subrange(0, s1.start + nn1).subrange(s1.start, s1.start + nn1));
-                                assert(snn2.data.subrange(s2.start, s2.start + nn2) =~= snn2.data.subrange(0, s2.start + nn2).subrange(s2.start, s2.start + nn2));
-                            }
-                        }
-                    }
-                }
-            }
         assert(m1 == m2);
-        assert(sn1.data.subrange(s1.start, s1.start + m1) =~= sn2.data.subrange(s2.start, s2.start + m2));
-        }
+        assert(sn1.data.subrange(s1.start, s1.start + m1) =~= sn2.data.subrange(
+            s2.start,
+            s2.start + m2,
+        ));
     }
+}
 
-
-    pub proof fn lemma_parse_repeat_n_strong_prefix_on<R>(
-        s1: SpecStream,
-        s2: SpecStream,
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_parse_strong_prefix(parser),
-        ensures
-            prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2)
-        decreases n
-    {
-        if let Ok((sout1, n1, x1)) = spec_parse_repeat_n(parser, n)(s1) {
-            if 0 <= s1.start <= s1.start + n1 <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + n1 <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + n1) == s2.data.subrange(s2.start, s2.start + n1) {
-                if n == 0 {
-                } else {
-                    // induction on n
-                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s1);
-                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s2);
-                    lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, (n - 1) as nat);
-                    if let Ok((sn1, nn1, xn1)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s1) {
-                        assert(s1.data.subrange(s1.start, s1.start + nn1) == s2.data.subrange(s2.start, s2.start + nn1)) by {
-                            assert(s1.data.subrange(s1.start, s1.start + n1).subrange(0, nn1 as int) =~= s1.data.subrange(s1.start, s1.start + nn1));
-                            assert(s2.data.subrange(s2.start, s2.start + n1).subrange(0, nn1 as int) =~= s2.data.subrange(s2.start, s2.start + nn1));
-                        }
-                        if let Ok((sn2, nn2, xn2)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s2) {
-                            assert(nn1 == nn2 && xn1 == xn2);
-                            lemma_parse_well_behaved_on(parser, sn1);
-                            lemma_parse_well_behaved_on(parser, sn2);
-                            lemma_parse_strong_prefix_on(parser, sn1, sn2);
-                            if let Ok((sn1_, nn1_, xn1_)) = parser(sn1) {
-                                // assert(n1 == nn1 + nn1_);
-                                assert(s1.data.subrange(s1.start + nn1, s1.start + n1) == s2.data.subrange(s2.start + nn1, s2.start + n1)) by {
-                                    assert(s1.data.subrange(s1.start, s1.start + n1).subrange(nn1 as int, n1 as int) =~= s1.data.subrange(s1.start + nn1, s1.start + n1));
-                                    assert(s2.data.subrange(s2.start, s2.start + n1).subrange(nn1 as int, n1 as int) =~= s2.data.subrange(s2.start + nn1, s2.start + n1));
-                                }
-                                assert(sn1.data.subrange(sn1.start, sn1.start + nn1_) == sn2.data.subrange(sn2.start, sn2.start + nn1_));
-                                if let Ok((sn2_, nn2_, xn2_)) = parser(sn2) {
-                                    assert(nn1_ == nn2_ && xn1_ == xn2_);
-                                }
+pub proof fn lemma_parse_repeat_n_strong_prefix_on<R>(
+    s1: SpecStream,
+    s2: SpecStream,
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_parse_strong_prefix(parser),
+    ensures
+        prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2),
+    decreases n,
+{
+    if let Ok((sout1, n1, x1)) = spec_parse_repeat_n(parser, n)(s1) {
+        if 0 <= s1.start <= s1.start + n1 <= s1.data.len() <= usize::MAX && 0 <= s2.start
+            <= s2.start + n1 <= s2.data.len() <= usize::MAX && s1.data.subrange(
+            s1.start,
+            s1.start + n1,
+        ) == s2.data.subrange(s2.start, s2.start + n1) {
+            if n == 0 {
+            } else {
+                // induction on n
+                lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s1);
+                lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s2);
+                lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, (n - 1) as nat);
+                if let Ok((sn1, nn1, xn1)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s1) {
+                    assert(s1.data.subrange(s1.start, s1.start + nn1) == s2.data.subrange(
+                        s2.start,
+                        s2.start + nn1,
+                    )) by {
+                        assert(s1.data.subrange(s1.start, s1.start + n1).subrange(0, nn1 as int)
+                            =~= s1.data.subrange(s1.start, s1.start + nn1));
+                        assert(s2.data.subrange(s2.start, s2.start + n1).subrange(0, nn1 as int)
+                            =~= s2.data.subrange(s2.start, s2.start + nn1));
+                    }
+                    if let Ok((sn2, nn2, xn2)) = spec_parse_repeat_n_rec(
+                        parser,
+                        (n - 1) as nat,
+                        s2,
+                    ) {
+                        assert(nn1 == nn2 && xn1 == xn2);
+                        lemma_parse_well_behaved_on(parser, sn1);
+                        lemma_parse_well_behaved_on(parser, sn2);
+                        lemma_parse_strong_prefix_on(parser, sn1, sn2);
+                        if let Ok((sn1_, nn1_, xn1_)) = parser(sn1) {
+                            // assert(n1 == nn1 + nn1_);
+                            assert(s1.data.subrange(s1.start + nn1, s1.start + n1)
+                                == s2.data.subrange(s2.start + nn1, s2.start + n1)) by {
+                                assert(s1.data.subrange(s1.start, s1.start + n1).subrange(
+                                    nn1 as int,
+                                    n1 as int,
+                                ) =~= s1.data.subrange(s1.start + nn1, s1.start + n1));
+                                assert(s2.data.subrange(s2.start, s2.start + n1).subrange(
+                                    nn1 as int,
+                                    n1 as int,
+                                ) =~= s2.data.subrange(s2.start + nn1, s2.start + n1));
+                            }
+                            assert(sn1.data.subrange(sn1.start, sn1.start + nn1_)
+                                == sn2.data.subrange(sn2.start, sn2.start + nn1_));
+                            if let Ok((sn2_, nn2_, xn2_)) = parser(sn2) {
+                                assert(nn1_ == nn2_ && xn1_ == xn2_);
                             }
                         }
                     }
@@ -3241,807 +3702,868 @@ verus! {
     }
 }
 
+} // verus!
 verus! {
-    pub open spec fn spec_parse_bytes(s: SpecStream, n: nat) -> SpecParseResult<Seq<u8>>
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.len() {
-            Err(ParseError::Eof) // don't fail when start == data.len(), which is different from the uint parsers
-        } else if s.start + n > usize::MAX {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start + n > s.data.len() {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
-                SpecStream {
-                    start: s.start + n as int,
-                    ..s
-                },
+
+pub open spec fn spec_parse_bytes(s: SpecStream, n: nat) -> SpecParseResult<Seq<u8>> {
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.len() {
+        Err(
+            ParseError::Eof,
+        )  // don't fail when start == data.len(), which is different from the uint parsers
+
+    } else if s.start + n > usize::MAX {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start + n > s.data.len() {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + n as int, ..s },
                 n,
                 s.data.subrange(s.start, s.start + n as int),
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_serialize_bytes(s: SpecStream, v: Seq<u8>, n: nat) -> SpecSerializeResult
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start + v.len() > usize::MAX {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.len() > s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.len() != n {
-            Err(SerializeError::BytesLengthMismatch)
-        } else {
-            Ok((
+pub open spec fn spec_serialize_bytes(s: SpecStream, v: Seq<u8>, n: nat) -> SpecSerializeResult {
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start + v.len() > usize::MAX {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.len() > s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.len() != n {
+        Err(SerializeError::BytesLengthMismatch)
+    } else {
+        Ok(
+            (
                 SpecStream {
                     start: s.start + n as int,
-                    data: s.data.subrange(0, s.start) + v + s.data.subrange(s.start + n as int, s.data.len() as int),
+                    data: s.data.subrange(0, s.start) + v + s.data.subrange(
+                        s.start + n as int,
+                        s.data.len() as int,
+                    ),
                 },
                 n,
-            ))
-        }
+            ),
+        )
     }
-
-    pub exec fn parse_bytes(s: Stream, n: usize) -> (res: ParseResult<&[u8]>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.start > usize::MAX - n {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start + n > s.data.length() {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(s.data, s.start, s.start + n);
-            Ok((
-                Stream {
-                    start: s.start + n,
-                    ..s
-                },
-                n,
-                data,
-            ))
-        }
-    }
-
-    pub exec fn serialize_bytes(data: &mut [u8], start: usize, v: &[u8], n: usize) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, n as nat))
-    {
-        let ghost old_data = data.dview();
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if start + v.length() > data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != n {
-            Err(SerializeError::BytesLengthMismatch)
-        } else {
-            let mut i = start;
-            let mut j = 0;
-
-            while j < n
-                invariant
-                    v.dview().len() == n,
-                    i - start == j,
-                    data.dview().len() == old(data).dview().len(), // critical!
-                    0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
-                    forall |k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k], // data[0..start] == old(data)[0..start]
-                    forall |k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start], // data[start..start + j] == v[0..j]
-                    forall |k| start + n <= k < data.dview().len() ==> data.dview()[k] == old(data).dview()[k], // data[start + n..] == old(data)[start + n..]
-            {
-                data.set(i, *slice_index_get(v, j)); // data[i] = v[j];
-                i = i + 1;
-                j = j + 1;
-            }
-            let ghost spec_res = spec_serialize_bytes(SpecStream {
-                data: old_data,
-                start: start as int,
-            }, v.dview(), n as nat);
-            // assert(spec_res.is_ok() && spec_res.unwrap().1 == n && spec_res.unwrap().0.start == (start + n) as int);
-            let ghost spec_data = spec_res.unwrap().0.data;
-            assert(spec_data == data.dview());
-            Ok((
-                start + n,
-                n,
-            ))
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_well_behaved(n: nat)
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_bytes(s, n))
-    {
-        reveal(prop_parse_well_behaved);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_bytes, s) by {
-            lemma_parse_bytes_well_behaved_on(s, n)
-        }
-    }
-
-    pub proof fn lemma_serialize_bytes_well_behaved(n: nat)
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_serialize_well_behaved);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_bytes, s, v) by {
-            lemma_serialize_bytes_well_behaved_on(s, v, n)
-        }
-    }
-
-    pub proof fn lemma_serialize_bytes_deterministic(n: nat)
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_serialize_deterministic);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_bytes, s1, s2, v) by {
-            lemma_serialize_bytes_deterministic_on(s1, s2, v, n)
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_strong_prefix(n: nat)
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_bytes(s, n))
-    {
-        reveal(prop_parse_strong_prefix);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_bytes, s1, s2) by {
-            lemma_parse_bytes_strong_prefix_on(s1, s2, n)
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_correct(n: nat)
-        ensures
-            prop_parse_correct(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_parse_correct::<Seq<u8>>);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_bytes, spec_serialize_bytes, s, v) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_bytes_correct_on(s, v, n)
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_serialize_inverse(n: nat)
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_parse_serialize_inverse::<Seq<u8>>);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_bytes, spec_serialize_bytes, s) by {
-            lemma_parse_bytes_serialize_inverse_on(s, n)
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_nonmalleable(n: nat)
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_bytes(s, n))
-    {
-        lemma_parse_bytes_serialize_inverse(n);
-        lemma_serialize_bytes_deterministic(n);
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n));
-    }
-
-
-    pub proof fn lemma_parse_bytes_well_behaved_on(s: SpecStream, n: nat)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_bytes(s, n), s)
-    {}
-
-    pub proof fn lemma_serialize_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>, n: nat)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_bytes(s, v, n), s, v)
-    {
-        if let Ok((sout, m)) = spec_serialize_bytes(s, v, n) {
-            assert(m == n);
-            assert(sout.data.len() =~= s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + m, s.data.len() as int) =~= s.data.subrange(s.start + m, s.data.len() as int));
-        }
-    }
-
-    pub proof fn lemma_serialize_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>, n: nat)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_bytes(s, v, n), s1, s2, v)
-    {
-        let n = v.len();
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_bytes(s1, v, n), spec_serialize_bytes(s2, v, n)) {
-            assert(n1 == n && n2 == n);
-            assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(s2.start, s2.start + n));
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream, n: nat)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_bytes(s, n), s1, s2)
-    {
-        if let Ok((sout1, m1, x1)) = spec_parse_bytes(s1, n) {
-            if 0 <= s1.start <= s1.start + m1 <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + m1 <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + m1) == s2.data.subrange(s2.start, s2.start + m1) {
-                if let Ok((sout2, m2, x2)) = spec_parse_bytes(s2, m1) {
-                    assert(m1 == m2);
-                    assert(x1 == x2);
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_correct_on(s: SpecStream, v: Seq<u8>, n: nat)
-        requires s.data.len() <= usize::MAX,
-        ensures
-            prop_parse_correct_on(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n), s, v)
-    {
-        if let Ok((sout, m1)) = spec_serialize_bytes(s, v, n) {
-            if let Ok((_, m2, res)) = spec_parse_bytes(SpecStream {start: s.start, ..sout}, n) {
-                assert(m1 == m2);
-                assert(res =~= v);
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_serialize_inverse_on(s: SpecStream, n: nat)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n), s)
-    {
-        if let Ok((sout, m1, x)) = spec_parse_bytes(s, n) {
-            if let Ok((sout2, m2)) = spec_serialize_bytes(s, x, m1) {
-                assert(m1 == m2);
-                assert(sout.data =~= sout2.data);
-            }
-        }
-    }
-
 }
 
+pub exec fn parse_bytes(s: Stream, n: usize) -> (res: ParseResult<&[u8]>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.start > usize::MAX - n {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start + n > s.data.length() {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(s.data, s.start, s.start + n);
+        Ok((Stream { start: s.start + n, ..s }, n, data))
+    }
+}
+
+pub exec fn serialize_bytes(data: &mut [u8], start: usize, v: &[u8], n: usize) -> (res:
+    SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, n as nat),
+        ),
+{
+    let ghost old_data = data.dview();
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if start + v.length() > data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != n {
+        Err(SerializeError::BytesLengthMismatch)
+    } else {
+        let mut i = start;
+        let mut j = 0;
+
+        while j < n
+            invariant
+                v.dview().len() == n,
+                i - start == j,
+                data.dview().len() == old(data).dview().len(),  // critical!
+                0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
+                forall|k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k],  // data[0..start] == old(data)[0..start]
+                forall|k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start],  // data[start..start + j] == v[0..j]
+                forall|k|
+                    start + n <= k < data.dview().len() ==> data.dview()[k] == old(data).dview()[k],  // data[start + n..] == old(data)[start + n..]
+        {
+            data.set(i, *slice_index_get(v, j));  // data[i] = v[j];
+            i = i + 1;
+            j = j + 1;
+        }
+        let ghost spec_res = spec_serialize_bytes(
+            SpecStream { data: old_data, start: start as int },
+            v.dview(),
+            n as nat,
+        );
+        // assert(spec_res.is_ok() && spec_res.unwrap().1 == n && spec_res.unwrap().0.start == (start + n) as int);
+        let ghost spec_data = spec_res.unwrap().0.data;
+        assert(spec_data == data.dview());
+        Ok((start + n, n))
+    }
+}
+
+pub proof fn lemma_parse_bytes_well_behaved(n: nat)
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_bytes(s, n)),
+{
+    reveal(prop_parse_well_behaved);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_bytes, s) by {
+        lemma_parse_bytes_well_behaved_on(s, n)
+    }
+}
+
+pub proof fn lemma_serialize_bytes_well_behaved(n: nat)
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_bytes(s, v, n)),
+{
+    reveal(prop_serialize_well_behaved);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_bytes, s, v) by {
+        lemma_serialize_bytes_well_behaved_on(s, v, n)
+    }
+}
+
+pub proof fn lemma_serialize_bytes_deterministic(n: nat)
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_bytes(s, v, n)),
+{
+    reveal(prop_serialize_deterministic);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_bytes, s1, s2, v) by {
+        lemma_serialize_bytes_deterministic_on(s1, s2, v, n)
+    }
+}
+
+pub proof fn lemma_parse_bytes_strong_prefix(n: nat)
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_bytes(s, n)),
+{
+    reveal(prop_parse_strong_prefix);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_bytes, s1, s2) by {
+        lemma_parse_bytes_strong_prefix_on(s1, s2, n)
+    }
+}
+
+pub proof fn lemma_parse_bytes_correct(n: nat)
+    ensures
+        prop_parse_correct(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n)),
+{
+    reveal(prop_parse_correct::<Seq<u8>>);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_bytes,
+            spec_serialize_bytes,
+            s,
+            v,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_bytes_correct_on(s, v, n)
+        }
+    }
+}
+
+pub proof fn lemma_parse_bytes_serialize_inverse(n: nat)
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_bytes(s, n),
+            |s, v| spec_serialize_bytes(s, v, n),
+        ),
+{
+    reveal(prop_parse_serialize_inverse::<Seq<u8>>);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_bytes, spec_serialize_bytes, s) by {
+        lemma_parse_bytes_serialize_inverse_on(s, n)
+    }
+}
+
+pub proof fn lemma_parse_bytes_nonmalleable(n: nat)
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_bytes(s, n)),
+{
+    lemma_parse_bytes_serialize_inverse(n);
+    lemma_serialize_bytes_deterministic(n);
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_bytes(s, n),
+        |s, v| spec_serialize_bytes(s, v, n),
+    );
+}
+
+pub proof fn lemma_parse_bytes_well_behaved_on(s: SpecStream, n: nat)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_bytes(s, n), s),
+{
+}
+
+pub proof fn lemma_serialize_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>, n: nat)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_bytes(s, v, n), s, v),
+{
+    if let Ok((sout, m)) = spec_serialize_bytes(s, v, n) {
+        assert(m == n);
+        assert(sout.data.len() =~= s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + m, s.data.len() as int) =~= s.data.subrange(
+            s.start + m,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_bytes_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: Seq<u8>,
+    n: nat,
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_bytes(s, v, n), s1, s2, v),
+{
+    let n = v.len();
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_bytes(s1, v, n),
+        spec_serialize_bytes(s2, v, n),
+    ) {
+        assert(n1 == n && n2 == n);
+        assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ));
+    }
+}
+
+pub proof fn lemma_parse_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream, n: nat)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_bytes(s, n), s1, s2),
+{
+    if let Ok((sout1, m1, x1)) = spec_parse_bytes(s1, n) {
+        if 0 <= s1.start <= s1.start + m1 <= s1.data.len() <= usize::MAX && 0 <= s2.start
+            <= s2.start + m1 <= s2.data.len() <= usize::MAX && s1.data.subrange(
+            s1.start,
+            s1.start + m1,
+        ) == s2.data.subrange(s2.start, s2.start + m1) {
+            if let Ok((sout2, m2, x2)) = spec_parse_bytes(s2, m1) {
+                assert(m1 == m2);
+                assert(x1 == x2);
+            }
+        }
+    }
+}
+
+pub proof fn lemma_parse_bytes_correct_on(s: SpecStream, v: Seq<u8>, n: nat)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_bytes(s, n),
+            |s, v| spec_serialize_bytes(s, v, n),
+            s,
+            v,
+        ),
+{
+    if let Ok((sout, m1)) = spec_serialize_bytes(s, v, n) {
+        if let Ok((_, m2, res)) = spec_parse_bytes(SpecStream { start: s.start, ..sout }, n) {
+            assert(m1 == m2);
+            assert(res =~= v);
+        }
+    }
+}
+
+pub proof fn lemma_parse_bytes_serialize_inverse_on(s: SpecStream, n: nat)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_bytes(s, n),
+            |s, v| spec_serialize_bytes(s, v, n),
+            s,
+        ),
+{
+    if let Ok((sout, m1, x)) = spec_parse_bytes(s, n) {
+        if let Ok((sout2, m2)) = spec_serialize_bytes(s, x, m1) {
+            assert(m1 == m2);
+            assert(sout.data =~= sout2.data);
+        }
+    }
+}
+
+} // verus!
 verus! {
 
-    /// A parser that consumes the rest of the input.
-    pub open spec fn spec_parse_tail(s: SpecStream) -> SpecParseResult<Seq<u8>>
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.data.len() > usize::MAX {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start > s.data.len() {
-            Err(ParseError::Eof) // don't fail when start == data.len(), which is different from the uint parsers
-        } else {
-            let n = s.data.len() as int;
-            Ok((
-                SpecStream {
-                    start: n,
-                    ..s
-                },
-                (n - s.start) as nat,
-                s.data.subrange(s.start, n),
-            ))
+/// A parser that consumes the rest of the input.
+pub open spec fn spec_parse_tail(s: SpecStream) -> SpecParseResult<Seq<u8>> {
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.data.len() > usize::MAX {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start > s.data.len() {
+        Err(
+            ParseError::Eof,
+        )  // don't fail when start == data.len(), which is different from the uint parsers
+
+    } else {
+        let n = s.data.len() as int;
+        Ok((SpecStream { start: n, ..s }, (n - s.start) as nat, s.data.subrange(s.start, n)))
+    }
+}
+
+pub open spec fn spec_serialize_tail(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start + v.len() > usize::MAX {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.len() > s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.len() != s.data.len() - s.start {
+        Err(SerializeError::TailLengthMismatch)
+    } else {
+        let n = v.len() as int;
+        Ok((SpecStream { start: s.start + n, data: s.data.subrange(0, s.start) + v }, n as nat))
+    }
+}
+
+pub exec fn parse_tail(s: Stream) -> (res: ParseResult<&[u8]>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else {
+        let n = s.data.length();
+        let data = slice_subrange(s.data, s.start, n);
+        Ok((Stream { start: n, ..s }, n - s.start, data))
+    }
+}
+
+pub exec fn serialize_tail(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_tail(s, v),
+        ),
+{
+    let ghost old_data = data.dview();
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if start + v.length() > data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != data.length() - start {
+        Err(SerializeError::TailLengthMismatch)
+    } else {
+        let n = v.length();
+        let mut i = start;
+        let mut j = 0;
+
+        while j < n
+            invariant
+                v.dview().len() == n,
+                i - start == j,
+                data.dview().len() == old(data).dview().len(),
+                0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
+                forall|k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k],  // data[0..start] == old(data)[0..start]
+                forall|k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start],  // data[start..start + j] == v[0..j]
+        {
+            data.set(i, *slice_index_get(v, j));  // data[i] = v[j];
+            i = i + 1;
+            j = j + 1;
         }
+        let ghost spec_res = spec_serialize_tail(
+            SpecStream { data: old_data, start: start as int },
+            v.dview(),
+        );
+        let ghost spec_data = spec_res.unwrap().0.data;
+        assert(spec_data == data.dview());
+        Ok((start + n, n))
     }
+}
 
-    pub open spec fn spec_serialize_tail(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start + v.len() > usize::MAX {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.len() > s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.len() != s.data.len() - s.start {
-            Err(SerializeError::TailLengthMismatch)
-        } else {
-            let n = v.len() as int;
-            Ok((
-                SpecStream {
-                    start: s.start + n,
-                    data: s.data.subrange(0, s.start) + v,
-                },
-                n as nat,
-            ))
-        }
+pub proof fn lemma_parse_tail_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_tail(s)),
+{
+    reveal(prop_parse_well_behaved::<Seq<u8>>);
+    let spec_parse_tail = |s| spec_parse_tail(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_tail, s) by {
+        lemma_parse_tail_well_behaved_on(s)
     }
+}
 
-    pub exec fn parse_tail(s: Stream) -> (res: ParseResult<&[u8]>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else {
-            let n = s.data.length();
-            let data = slice_subrange(s.data, s.start, n);
-            Ok((
-                Stream {
-                    start: n,
-                    ..s
-                },
-                n - s.start,
-                data,
-            ))
-        }
+pub proof fn lemma_serialize_tail_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<Seq<u8>>);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_tail, s, v) by {
+        lemma_serialize_tail_well_behaved_on(s, v)
     }
+}
 
-    pub exec fn serialize_tail(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_tail(s, v))
-    {
-        let ghost old_data = data.dview();
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if start + v.length() > data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != data.length() - start {
-            Err(SerializeError::TailLengthMismatch)
-        } else {
-            let n = v.length();
-            let mut i = start;
-            let mut j = 0;
-
-            while j < n
-                invariant
-                    v.dview().len() == n,
-                    i - start == j,
-                    data.dview().len() == old(data).dview().len(),
-                    0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
-                    forall |k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k], // data[0..start] == old(data)[0..start]
-                    forall |k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start], // data[start..start + j] == v[0..j]
-            {
-                data.set(i, *slice_index_get(v, j)); // data[i] = v[j];
-                i = i + 1;
-                j = j + 1;
-            }
-            let ghost spec_res = spec_serialize_tail(SpecStream {
-                data: old_data,
-                start: start as int,
-            }, v.dview());
-            let ghost spec_data = spec_res.unwrap().0.data;
-            assert(spec_data == data.dview());
-            Ok((
-                start + n,
-                n,
-            ))
-        }
+pub proof fn lemma_serialize_tail_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_serialize_deterministic::<Seq<u8>>);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_tail, s1, s2, v) by {
+        lemma_serialize_tail_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_parse_tail_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_tail(s))
-    {
-        reveal(prop_parse_well_behaved::<Seq<u8>>);
-        let spec_parse_tail = |s| spec_parse_tail(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_tail, s) by {
-            lemma_parse_tail_well_behaved_on(s)
-        }
-    }
-
-    pub proof fn lemma_serialize_tail_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<Seq<u8>>);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_tail, s, v) by {
-            lemma_serialize_tail_well_behaved_on(s, v)
-        }
-    }
-
-    pub proof fn lemma_serialize_tail_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_serialize_deterministic::<Seq<u8>>);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_tail, s1, s2, v) by {
-            lemma_serialize_tail_deterministic_on(s1, s2, v)
-        }
-    }
-
-    pub proof fn lemma_parse_tail_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_parse_correct::<Seq<u8>>);
-        let spec_parse_tail = |s| spec_parse_tail(s);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_tail, spec_serialize_tail, s, v) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_tail_correct_on(s, v)
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_tail_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<Seq<u8>>);
-        let spec_parse_tail = |s| spec_parse_tail(s);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_tail, spec_serialize_tail, s) by {
-            lemma_parse_tail_serialize_inverse_on(s)
-        }
-    }
-
-    pub proof fn lemma_parse_tail_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_tail(s))
-    {
-        lemma_parse_tail_serialize_inverse();
-        lemma_serialize_tail_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v));
-    }
-
-    proof fn lemma_parse_tail_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_tail(s), s)
-    {}
-
-    proof fn lemma_serialize_tail_well_behaved_on(s: SpecStream, v: Seq<u8>)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_tail(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_tail(s, v) {
-            assert(n == v.len());
-            assert(sout.data.len() =~= s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + n, s.data.len() as int) =~= s.data.subrange(s.start + n, s.data.len() as int));
-        }
-    }
-
-    proof fn lemma_serialize_tail_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_tail(s, v), s1, s2, v)
-    {
-        let n = v.len();
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_tail(s1, v), spec_serialize_tail(s2, v)) {
-            assert(n1 == n && n2 == n);
-            assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(s2.start, s2.start + n));
-        }
-    }
-
-    proof fn lemma_parse_tail_correct_on(s: SpecStream, v: Seq<u8>)
-        requires s.data.len() <= usize::MAX,
-        ensures
-            prop_parse_correct_on(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_tail(s, v) {
-            if let Ok((_, m, res)) = spec_parse_tail(SpecStream {start: s.start, ..sout}) {
-                assert(n == m);
-                assert(res =~= v);
-            }
-        }
-    }
-
-    proof fn lemma_parse_tail_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v), s)
-    {
-        if let Ok((sout, n, x)) = spec_parse_tail(s) {
-            if let Ok((sout2, m)) = spec_serialize_tail(s, x) {
-                assert(n == m);
-                assert(sout.data =~= sout2.data);
-            } else {
-                assert(false);
-            }
+pub proof fn lemma_parse_tail_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_parse_correct::<Seq<u8>>);
+    let spec_parse_tail = |s| spec_parse_tail(s);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_tail,
+            spec_serialize_tail,
+            s,
+            v,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_tail_correct_on(s, v)
         }
     }
 }
 
+pub proof fn lemma_parse_tail_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<Seq<u8>>);
+    let spec_parse_tail = |s| spec_parse_tail(s);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_tail, spec_serialize_tail, s) by {
+        lemma_parse_tail_serialize_inverse_on(s)
+    }
+}
+
+pub proof fn lemma_parse_tail_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_tail(s)),
+{
+    lemma_parse_tail_serialize_inverse();
+    lemma_serialize_tail_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_tail(s),
+        |s, v| spec_serialize_tail(s, v),
+    );
+}
+
+proof fn lemma_parse_tail_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_tail(s), s),
+{
+}
+
+proof fn lemma_serialize_tail_well_behaved_on(s: SpecStream, v: Seq<u8>)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_tail(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_tail(s, v) {
+        assert(n == v.len());
+        assert(sout.data.len() =~= s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + n, s.data.len() as int) =~= s.data.subrange(
+            s.start + n,
+            s.data.len() as int,
+        ));
+    }
+}
+
+proof fn lemma_serialize_tail_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_tail(s, v), s1, s2, v),
+{
+    let n = v.len();
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_tail(s1, v),
+        spec_serialize_tail(s2, v),
+    ) {
+        assert(n1 == n && n2 == n);
+        assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ));
+    }
+}
+
+proof fn lemma_parse_tail_correct_on(s: SpecStream, v: Seq<u8>)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_tail(s, v) {
+        if let Ok((_, m, res)) = spec_parse_tail(SpecStream { start: s.start, ..sout }) {
+            assert(n == m);
+            assert(res =~= v);
+        }
+    }
+}
+
+proof fn lemma_parse_tail_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_tail(s),
+            |s, v| spec_serialize_tail(s, v),
+            s,
+        ),
+{
+    if let Ok((sout, n, x)) = spec_parse_tail(s) {
+        if let Ok((sout2, m)) = spec_serialize_tail(s, x) {
+            assert(n == m);
+            assert(sout.data =~= sout2.data);
+        } else {
+            assert(false);
+        }
+    }
+}
+
+} // verus!
 // secret parsers and serializers
-
 verus! {
 
-    #[verifier(opaque)]
-    pub open spec fn prop_sec_parse_exec_spec_equiv<T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-        where
-            P: FnOnce(SecStream) -> SecParseResult<T>,
-            T: DView,
-    {
-        &&& forall |s| #[trigger] exec_parser.requires((s,))
-        &&& forall |s, res| #[trigger] exec_parser.ensures((s,), res) ==> prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser)
+#[verifier(opaque)]
+pub open spec fn prop_sec_parse_exec_spec_equiv<T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool where P: FnOnce(SecStream) -> SecParseResult<T>, T: DView {
+    &&& forall|s| #[trigger] exec_parser.requires((s,))
+    &&& forall|s, res| #[trigger]
+        exec_parser.ensures((s,), res) ==> prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_sec_serialize_exec_spec_equiv<T, P>(
+    exec_serializer: P,
+    spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+) -> bool where P: FnOnce(SecStream, T) -> SecSerializeResult, T: std::fmt::Debug + DView {
+    &&& forall|s, v| #[trigger] exec_serializer.requires((s, v))
+    &&& forall|s, v, res| #[trigger]
+        exec_serializer.ensures((s, v), res) ==> prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            spec_serializer,
+        )
+}
+
+pub proof fn lemma_sec_parse_exec_spec_equiv_on<T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+    s: SecStream,
+    res: SecParseResult<T>,
+) where P: FnOnce(SecStream) -> SecParseResult<T>, T: DView
+    requires
+        prop_sec_parse_exec_spec_equiv(exec_parser, spec_parser),
+        exec_parser.ensures((s,), res),
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser),
+{
+    reveal(prop_sec_parse_exec_spec_equiv);
+}
+
+pub proof fn lemma_sec_serialize_exec_spec_equiv_on<T, P>(
+    exec_serializer: P,
+    spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+    s: SecStream,
+    v: T,
+    res: SecSerializeResult,
+) where P: FnOnce(SecStream, T) -> SecSerializeResult, T: std::fmt::Debug + DView
+    requires
+        prop_sec_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
+        exec_serializer.ensures((s, v), res),
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serializer),
+{
+    reveal(prop_sec_serialize_exec_spec_equiv);
+}
+
+// would be great if Verus supports impl DView<V = SpecStream>
+pub open spec fn prop_sec_parse_exec_spec_equiv_on<T: DView>(
+    s: SecStream,
+    res: SecParseResult<T>,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool {
+    match spec_parser(s.dview()) {
+        Ok((sout, sn, sx)) => {
+            if let Ok((s, n, x)) = res {
+                &&& s.dview() == sout
+                &&& n == sn
+                &&& x.dview() == sx
+            } else {
+                false
+            }
+        },
+        Err(e) => {
+            if let Err(e2) = res {
+                e == e2
+            } else {
+                false
+            }
+        },
     }
+}
 
-    #[verifier(opaque)]
-    pub open spec fn prop_sec_serialize_exec_spec_equiv<T, P>(
-        exec_serializer: P,
-        spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
-        where
-            P: FnOnce(SecStream, T) -> SecSerializeResult,
-            T: std::fmt::Debug + DView,
-    {
-        &&& forall |s, v| #[trigger] exec_serializer.requires((s, v))
-        &&& forall |s, v, res| #[trigger] exec_serializer.ensures((s, v), res) ==> prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
+pub open spec fn prop_sec_serialize_exec_spec_equiv_on<T: DView>(
+    s: SecStream,
+    v: T,
+    res: SecSerializeResult,
+    spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+) -> bool where T: std::fmt::Debug + DView {
+    match spec_serializer(s.dview(), v.dview()) {
+        Ok((sout, sn)) => {
+            &&& res.is_ok()
+            &&& res.unwrap().0.dview() == sout
+            &&& res.unwrap().1 == sn
+        },
+        Err(e) => res.is_err() && res.unwrap_err() == e,
     }
+}
 
+} // verus!
+verus! {
 
-    pub proof fn lemma_sec_parse_exec_spec_equiv_on<T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
-        s: SecStream, res: SecParseResult<T>)
-        where
-            P: FnOnce(SecStream) -> SecParseResult<T>,
-            T: DView,
-        requires
-            prop_sec_parse_exec_spec_equiv(exec_parser, spec_parser),
-            exec_parser.ensures((s,), res)
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser)
-    {
+pub exec fn sec_parse_pair<P1, P2, R1, R2>(
+    exec_parser1: P1,
+    exec_parser2: P2,
+    Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
+    Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
+    s: SecStream,
+) -> (res: SecParseResult<(R1, R2)>) where
+    R1: DView,
+    R2: DView,
+    P1: FnOnce(SecStream) -> SecParseResult<R1>,
+    P2: FnOnce(SecStream) -> SecParseResult<R2>,
+
+    requires
+        prop_sec_parse_exec_spec_equiv(exec_parser1, spec_parser1),
+        prop_sec_parse_exec_spec_equiv(exec_parser2, spec_parser2),
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_pair(spec_parser1, spec_parser2),
+        ),
+        // prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
+
+{
+    proof {
         reveal(prop_sec_parse_exec_spec_equiv);
     }
+    let res1 = exec_parser1(s);
+    proof {
+        lemma_sec_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1);
+    }
+    match res1 {
+        Ok((s1, n1, r1)) => {
+            let res2 = exec_parser2(s1);
+            proof {
+                lemma_sec_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2);
+            }
+            match res2 {
+                Ok((s2, n2, r2)) => {
+                    if n1 > usize::MAX - n2 {
+                        Err(ParseError::IntegerOverflow)
+                    } else {
+                        Ok((s2, n1 + n2, (r1, r2)))
+                    }
+                },
+                Err(e) => Err(e),
+            }
+        },
+        Err(e) => Err(e),
+    }
+}
 
-    pub proof fn lemma_sec_serialize_exec_spec_equiv_on<T, P>(
-        exec_serializer: P,
-        spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
-        s: SecStream, v: T, res: SecSerializeResult)
-        where
-            P: FnOnce(SecStream, T) -> SecSerializeResult,
-            T: std::fmt::Debug + DView,
-        requires
-            prop_sec_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
-            exec_serializer.ensures((s, v), res)
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
-    {
+pub exec fn sec_serialize_pair<S1, S2, T1, T2>(
+    exec_serializer1: S1,
+    exec_serializer2: S2,
+    Ghost(spec_serializer1): Ghost<spec_fn(SpecStream, T1::V) -> SpecSerializeResult>,
+    Ghost(spec_serializer2): Ghost<spec_fn(SpecStream, T2::V) -> SpecSerializeResult>,
+    s: SecStream,
+    v: (T1, T2),
+) -> (res: SecSerializeResult) where
+    S1: FnOnce(SecStream, T1) -> SecSerializeResult,
+    S2: FnOnce(SecStream, T2) -> SecSerializeResult,
+    T1: std::fmt::Debug + DView,
+    T2: std::fmt::Debug + DView,
+
+    requires
+        prop_sec_serialize_exec_spec_equiv(exec_serializer1, spec_serializer1),
+        prop_sec_serialize_exec_spec_equiv(exec_serializer2, spec_serializer2),
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            spec_serialize_pair(spec_serializer1, spec_serializer2),
+        ),
+{
+    proof {
         reveal(prop_sec_serialize_exec_spec_equiv);
     }
-
-
-    // would be great if Verus supports impl DView<V = SpecStream>
-
-    pub open spec fn prop_sec_parse_exec_spec_equiv_on<T: DView>(
-        s: SecStream,
-        res: SecParseResult<T>,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-    {
-        match spec_parser(s.dview()) {
-            Ok((sout, sn, sx)) => {
-                if let Ok((s, n, x)) = res {
-                    &&& s.dview() == sout
-                    &&& n == sn
-                    &&& x.dview() == sx
-                } else {
-                    false
-                }
-            }
-            Err(e) => {
-                if let Err(e2) = res {
-                    e == e2
-                } else {
-                    false
-                }
-            }
-        }
+    let res1 = exec_serializer1(s, v.0);
+    proof {
+        lemma_sec_serialize_exec_spec_equiv_on(exec_serializer1, spec_serializer1, s, v.0, res1);
     }
-
-    pub open spec fn prop_sec_serialize_exec_spec_equiv_on<T: DView>(
-        s: SecStream,
-        v: T,
-        res: SecSerializeResult,
-        spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
-        where T: std::fmt::Debug + DView
-    {
-        match spec_serializer(s.dview(), v.dview()) {
-            Ok((sout, sn)) => {
-                &&& res.is_ok()
-                &&& res.unwrap().0.dview() == sout
-                &&& res.unwrap().1 == sn
+    match res1 {
+        Ok((s, n)) => {
+            let res2 = exec_serializer2(s, v.1);
+            proof {
+                lemma_sec_serialize_exec_spec_equiv_on(
+                    exec_serializer2,
+                    spec_serializer2,
+                    s,
+                    v.1,
+                    res2,
+                );
             }
-            Err(e) => res.is_err() && res.unwrap_err() == e
-        }
+            match res2 {
+                Ok((s, m)) => {
+                    if n > usize::MAX - m {
+                        Err(SerializeError::IntegerOverflow)
+                    } else {
+                        Ok((s, n + m))
+                    }
+                },
+                Err(e) => Err(e),
+            }
+        },
+        Err(e) => Err(e),
     }
-
 }
 
-verus! {
-    pub exec fn sec_parse_pair<P1, P2, R1, R2>(
-        exec_parser1: P1,
-        exec_parser2: P2,
-        Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
-        Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
-        s: SecStream) -> (res: SecParseResult<(R1,R2)>)
-        where
-            R1: DView,
-            R2: DView,
-            P1: FnOnce(SecStream) -> SecParseResult<R1>,
-            P2: FnOnce(SecStream) -> SecParseResult<R2>,
-        requires
-            prop_sec_parse_exec_spec_equiv(exec_parser1, spec_parser1),
-            prop_sec_parse_exec_spec_equiv(exec_parser2, spec_parser2),
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2))
-        // prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
-    {
-        proof { reveal(prop_sec_parse_exec_spec_equiv); }
-        let res1 = exec_parser1(s);
-        proof { lemma_sec_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1); }
-        match res1 {
-            Ok((s1, n1, r1)) => {
-                let res2 = exec_parser2(s1);
-                proof { lemma_sec_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2); }
-                match res2 {
-                    Ok((s2, n2, r2)) => {
-                        if n1 > usize::MAX - n2 {
-                            Err(ParseError::IntegerOverflow)
-                        } else {
-                            Ok((s2, n1 + n2, (r1, r2)))
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub exec fn sec_serialize_pair<S1, S2, T1, T2>(
-        exec_serializer1: S1,
-        exec_serializer2: S2,
-        Ghost(spec_serializer1): Ghost<spec_fn(SpecStream, T1::V) -> SpecSerializeResult>,
-        Ghost(spec_serializer2): Ghost<spec_fn(SpecStream, T2::V) -> SpecSerializeResult>,
-        s: SecStream, v: (T1, T2)) -> (res: SecSerializeResult)
-        where
-            S1: FnOnce(SecStream, T1) -> SecSerializeResult,
-            S2: FnOnce(SecStream, T2) -> SecSerializeResult,
-            T1: std::fmt::Debug + DView,
-            T2: std::fmt::Debug + DView,
-        requires
-            prop_sec_serialize_exec_spec_equiv(exec_serializer1, spec_serializer1),
-            prop_sec_serialize_exec_spec_equiv(exec_serializer2, spec_serializer2),
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serialize_pair(spec_serializer1, spec_serializer2))
-    {
-        proof { reveal(prop_sec_serialize_exec_spec_equiv); }
-        let res1 = exec_serializer1(s, v.0);
-        proof { lemma_sec_serialize_exec_spec_equiv_on(exec_serializer1, spec_serializer1, s, v.0, res1); }
-        match res1 {
-            Ok((s, n)) => {
-                let res2 = exec_serializer2(s, v.1);
-                proof { lemma_sec_serialize_exec_spec_equiv_on(exec_serializer2, spec_serializer2, s, v.1, res2); }
-                match res2 {
-                    Ok((s, m)) => {
-                        if n > usize::MAX - m {
-                            Err(SerializeError::IntegerOverflow)
-                        } else {
-                            Ok((s, n + m))
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-}
-
+} // verus!
 verus! {
 
-    pub exec fn parse_sec_bytes(s: SecStream, n: usize) -> (res: SecParseResult<SecBytes>)
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.start > usize::MAX - n {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start + n > s.data.length() {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = s.data.subrange(s.start, s.start + n);
-            Ok((
-                SecStream {
-                    start: s.start + n,
-                    ..s
-                },
-                n,
-                data,
-            ))
-        }
-    }
-
-    pub exec fn serialize_sec_bytes(s: SecStream, v: SecBytes, n: usize) -> (res: SecSerializeResult)
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_bytes(s, v, n as nat))
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.length() > s.data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != n {
-            Err(SerializeError::BytesLengthMismatch)
-        } else {
-            let mut data = s.data.subrange(0, s.start);
-            let mut rem = s.data.subrange(s.start + n, s.data.length());
-            let mut v = v;
-            data.append(&mut v);
-            data.append(&mut rem);
-            Ok((
-                SecStream {
-                    start: s.start + n,
-                    data,
-                },
-                n,
-            ))
-        }
-    }
-
-    pub exec fn sec_parse_tail(s: SecStream) -> (res: SecParseResult<SecBytes>)
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else {
-            let n = s.data.length();
-            // data is the rest of the input starting from s.start
-            let data = s.data.subrange(s.start, n);
-            Ok((
-                SecStream {
-                    start: n,
-                    ..s
-                },
-                (n - s.start),
-                data,
-            ))
-        }
-    }
-
-    pub exec fn sec_serialize_tail(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_tail(s, v))
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.length() > s.data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != s.data.length() - s.start {
-            Err(SerializeError::TailLengthMismatch)
-        } else {
-            let n = v.length();
-
-            let mut data = s.data.subrange(0, s.start);
-            let mut v = v;
-            data.append(&mut v);
-            Ok((
-                SecStream {
-                    start: s.start + n,
-                    data
-                },
-                n,
-            ))
-        }
-    }
-}
-verus!{
-
-pub open spec fn spec_parse_u8_le_255(s: SpecStream) -> SpecParseResult<u8>
+pub exec fn parse_sec_bytes(s: SecStream, n: usize) -> (res: SecParseResult<SecBytes>)
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat)),
 {
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.start > usize::MAX - n {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start + n > s.data.length() {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = s.data.subrange(s.start, s.start + n);
+        Ok((SecStream { start: s.start + n, ..s }, n, data))
+    }
+}
+
+pub exec fn serialize_sec_bytes(s: SecStream, v: SecBytes, n: usize) -> (res: SecSerializeResult)
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            |s, v| spec_serialize_bytes(s, v, n as nat),
+        ),
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.length() > s.data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != n {
+        Err(SerializeError::BytesLengthMismatch)
+    } else {
+        let mut data = s.data.subrange(0, s.start);
+        let mut rem = s.data.subrange(s.start + n, s.data.length());
+        let mut v = v;
+        data.append(&mut v);
+        data.append(&mut rem);
+        Ok((SecStream { start: s.start + n, data }, n))
+    }
+}
+
+pub exec fn sec_parse_tail(s: SecStream) -> (res: SecParseResult<SecBytes>)
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else {
+        let n = s.data.length();
+        // data is the rest of the input starting from s.start
+        let data = s.data.subrange(s.start, n);
+        Ok((SecStream { start: n, ..s }, (n - s.start), data))
+    }
+}
+
+pub exec fn sec_serialize_tail(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_tail(s, v)),
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.length() > s.data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != s.data.length() - s.start {
+        Err(SerializeError::TailLengthMismatch)
+    } else {
+        let n = v.length();
+
+        let mut data = s.data.subrange(0, s.start);
+        let mut v = v;
+        data.append(&mut v);
+        Ok((SecStream { start: s.start + n, data }, n))
+    }
+}
+
+} // verus!
+verus! {
+
+pub open spec fn spec_parse_u8_le_255(s: SpecStream) -> SpecParseResult<u8> {
     match spec_parse_u8_le(s) {
         Ok((s, n, v)) => {
             if v == 255 {
@@ -4049,13 +4571,12 @@ pub open spec fn spec_parse_u8_le_255(s: SpecStream) -> SpecParseResult<u8>
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_u8_le_255(s: SpecStream, v: u8) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_u8_le_255(s: SpecStream, v: u8) -> SpecSerializeResult {
     if v == 255 {
         spec_serialize_u8_le(s, v)
     } else {
@@ -4065,7 +4586,7 @@ pub open spec fn spec_serialize_u8_le_255(s: SpecStream, v: u8) -> SpecSerialize
 
 pub exec fn parse_u8_le_255(s: Stream) -> (res: ParseResult<u8>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_255(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_255(s)),
 {
     let (s, n, v) = parse_u8_le(s)?;
     if v == 255 {
@@ -4077,7 +4598,14 @@ pub exec fn parse_u8_le_255(s: Stream) -> (res: ParseResult<u8>)
 
 pub exec fn serialize_u8_le_255(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u8_le_255(s, v))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u8_le_255(s, v),
+        ),
 {
     if v == 255 {
         serialize_u8_le(data, start, v)
@@ -4088,101 +4616,109 @@ pub exec fn serialize_u8_le_255(data: &mut [u8], start: usize, v: u8) -> (res: S
 
 pub proof fn lemma_parse_u8_le_255_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_u8_le_255(s))
+        prop_parse_well_behaved(|s| spec_parse_u8_le_255(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_255, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_255, s) by {
         lemma_parse_u8_le_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_255_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_255(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_255(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_255, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_u8_le_255, s, v) by {
         lemma_serialize_u8_le_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_255_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_255(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_255(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u8_le_255, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u8_le_255, s1, s2, v) by {
         lemma_serialize_u8_le_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_255_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_u8_le_255(s))
+        prop_parse_strong_prefix(|s| spec_parse_u8_le_255(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_255, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_255, s1, s2) by {
         lemma_parse_u8_le_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_u8_le_255_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_u8_le_255(s), |s, v| spec_serialize_u8_le_255(s, v))
+        prop_parse_correct(|s| spec_parse_u8_le_255(s), |s, v| spec_serialize_u8_le_255(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
-    assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u8_le_255, spec_serialize_u8_le_255, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u8_le_255, spec_serialize_u8_le_255, s, v) by {
         lemma_parse_u8_le_correct_on(s, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_255_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_u8_le_255(s), |s, v| spec_serialize_u8_le_255(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_u8_le_255(s),
+            |s, v| spec_serialize_u8_le_255(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u8_le_255, spec_serialize_u8_le_255, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u8_le_255, spec_serialize_u8_le_255, s) by {
         lemma_parse_u8_le_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_u8_le_255_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_u8_le_255(s))
+        prop_parse_nonmalleable(|s| spec_parse_u8_le_255(s)),
 {
     lemma_parse_u8_le_255_serialize_inverse();
     lemma_serialize_u8_le_255_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u8_le_255(s), |s, v| spec_serialize_u8_le_255(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u8_le_255(s),
+        |s, v| spec_serialize_u8_le_255(s, v),
+    );
 }
+
 pub struct SpecTwoU8s {
     a: u8,
     b: u8,
-
 }
+
 pub struct TwoU8s {
     a: u8,
     b: u8,
-
 }
 
-pub open spec fn spec_parse_two_u8s(s: SpecStream) -> SpecParseResult<(u8, u8)>
-{
+pub open spec fn spec_parse_two_u8s(s: SpecStream) -> SpecParseResult<(u8, u8)> {
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
 
     spec_parse_pair(spec_parse_u8_le_255, spec_parse_u8_le)(s)
 }
 
-pub open spec fn spec_serialize_two_u8s(s: SpecStream, v: (u8, u8)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_two_u8s(s: SpecStream, v: (u8, u8)) -> SpecSerializeResult {
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
 
@@ -4190,42 +4726,53 @@ pub open spec fn spec_serialize_two_u8s(s: SpecStream, v: (u8, u8)) -> SpecSeria
 }
 
 pub proof fn lemma_parse_two_u8s_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_two_u8s(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_two_u8s(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_two_u8s = |s| spec_parse_two_u8s(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_two_u8s, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_two_u8s, s) by {
         lemma_parse_two_u8s_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_two_u8s_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_two_u8s(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_two_u8s(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_two_u8s = |s, v| spec_serialize_two_u8s(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_two_u8s, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_two_u8s, s, v) by {
         lemma_serialize_two_u8s_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_two_u8s_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_two_u8s(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_two_u8s(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_two_u8s = |s, v| spec_serialize_two_u8s(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_two_u8s, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_two_u8s, s1, s2, v) by {
         lemma_serialize_two_u8s_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_two_u8s_correct()
-    ensures prop_parse_correct(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_two_u8s = |s| spec_parse_two_u8s(s);
     let spec_serialize_two_u8s = |s, v| spec_serialize_two_u8s(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_two_u8s, spec_serialize_two_u8s, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_two_u8s,
+            spec_serialize_two_u8s,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_two_u8s_correct_on(s, v);
         }
@@ -4233,26 +4780,36 @@ pub proof fn lemma_parse_two_u8s_correct()
 }
 
 pub proof fn lemma_parse_two_u8s_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_two_u8s(s),
+            |s, v| spec_serialize_two_u8s(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_two_u8s = |s| spec_parse_two_u8s(s);
     let spec_serialize_two_u8s = |s, v| spec_serialize_two_u8s(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_two_u8s, spec_serialize_two_u8s, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_two_u8s, spec_serialize_two_u8s, s) by {
         lemma_parse_two_u8s_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_two_u8s_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_two_u8s(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_two_u8s(s)),
 {
     lemma_parse_two_u8s_serialize_inverse();
     lemma_serialize_two_u8s_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_two_u8s(s),
+        |s, v| spec_serialize_two_u8s(s, v),
+    );
 }
 
 pub proof fn lemma_parse_two_u8s_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_two_u8s(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_two_u8s(s), s),
 {
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
@@ -4262,7 +4819,8 @@ pub proof fn lemma_parse_two_u8s_well_behaved_on(s: SpecStream)
 }
 
 pub proof fn lemma_serialize_two_u8s_well_behaved_on(s: SpecStream, v: (u8, u8))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_two_u8s(s, v), s, v)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_two_u8s(s, v), s, v),
 {
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
@@ -4272,7 +4830,8 @@ pub proof fn lemma_serialize_two_u8s_well_behaved_on(s: SpecStream, v: (u8, u8))
 }
 
 pub proof fn lemma_serialize_two_u8s_deterministic_on(s1: SpecStream, s2: SpecStream, v: (u8, u8))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_two_u8s(s, v), s1, s2, v)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_two_u8s(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le_255 = |s, v| spec_serialize_u8_le_255(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
@@ -4280,12 +4839,20 @@ pub proof fn lemma_serialize_two_u8s_deterministic_on(s1: SpecStream, s2: SpecSt
     lemma_serialize_u8_le_well_behaved();
     lemma_serialize_u8_le_255_deterministic();
     lemma_serialize_u8_le_deterministic();
-    lemma_serialize_pair_deterministic_on(spec_serialize_u8_le_255, spec_serialize_u8_le, s1, s2, v);
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_u8_le_255,
+        spec_serialize_u8_le,
+        s1,
+        s2,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_two_u8s_correct_on(s: SpecStream, v: (u8, u8))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v), s, v)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v), s, v),
 {
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
@@ -4299,11 +4866,23 @@ pub proof fn lemma_parse_two_u8s_correct_on(s: SpecStream, v: (u8, u8))
     lemma_parse_u8_le_strong_prefix();
     lemma_parse_u8_le_255_correct();
     lemma_parse_u8_le_correct();
-    lemma_parse_pair_correct_on(spec_parse_u8_le_255, spec_parse_u8_le, spec_serialize_u8_le_255, spec_serialize_u8_le, s, v);
+    lemma_parse_pair_correct_on(
+        spec_parse_u8_le_255,
+        spec_parse_u8_le,
+        spec_serialize_u8_le_255,
+        spec_serialize_u8_le,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_two_u8s_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_two_u8s(s), |s, v| spec_serialize_two_u8s(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_two_u8s(s),
+            |s, v| spec_serialize_two_u8s(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
@@ -4315,21 +4894,29 @@ pub proof fn lemma_parse_two_u8s_serialize_inverse_on(s: SpecStream)
     lemma_serialize_u8_le_well_behaved();
     lemma_parse_u8_le_255_serialize_inverse();
     lemma_parse_u8_le_serialize_inverse();
-    lemma_parse_pair_serialize_inverse_on(spec_parse_u8_le_255, spec_parse_u8_le, spec_serialize_u8_le_255, spec_serialize_u8_le, s);
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_u8_le_255,
+        spec_parse_u8_le,
+        spec_serialize_u8_le_255,
+        spec_serialize_u8_le,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_two_u8s_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_two_u8s(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_two_u8s(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_two_u8s = |s| spec_parse_two_u8s(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_two_u8s, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_two_u8s, s1, s2) by {
         lemma_parse_two_u8s_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_two_u8s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_two_u8s(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_two_u8s(s), s1, s2),
 {
     let spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
@@ -4341,85 +4928,116 @@ pub proof fn lemma_parse_two_u8s_strong_prefix_on(s1: SpecStream, s2: SpecStream
 }
 
 pub exec fn parse_two_u8s(s: Stream) -> (res: ParseResult<(u8, u8)>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_two_u8s(s))
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_two_u8s(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le_255 = |s| spec_parse_u8_le_255(s);
     let ghost spec_parse_u8_le = |s| spec_parse_u8_le(s);
 
-    parse_pair(parse_u8_le_255, parse_u8_le, Ghost(spec_parse_u8_le_255), Ghost(spec_parse_u8_le), s)
+    parse_pair(
+        parse_u8_le_255,
+        parse_u8_le,
+        Ghost(spec_parse_u8_le_255),
+        Ghost(spec_parse_u8_le),
+        s,
+    )
 }
+
 pub exec fn serialize_two_u8s(data: &mut [u8], start: usize, v: (u8, u8)) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_two_u8s(s, v))
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_two_u8s(s, v),
+        ),
 {
     let (v0, v1) = v;
     let (new_start, n0) = serialize_u8_le_255(data, start, v0)?;
 
-let (new_start, n1) = serialize_u8_le(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_u8_le(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1))
 }
 
-                    
-pub open spec fn spec_parse_2_u16s(s: SpecStream) -> SpecParseResult<Seq<u16>>
-{
+pub open spec fn spec_parse_2_u16s(s: SpecStream) -> SpecParseResult<Seq<u16>> {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     spec_parse_repeat_n(spec_parse_u16_le, 2)(s)
 }
 
-pub open spec fn spec_serialize_2_u16s(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_2_u16s(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     spec_serialize_repeat_n(spec_serialize_u16_le, 2)(s, vs)
 }
 
 pub proof fn lemma_parse_2_u16s_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_2_u16s(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_2_u16s(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_2_u16s = |s| spec_parse_2_u16s(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_2_u16s, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_2_u16s, s) by {
         lemma_parse_2_u16s_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_2_u16s_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_2_u16s(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_2_u16s(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_2_u16s = |s, vs| spec_serialize_2_u16s(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_2_u16s, s, vs) by {
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_2_u16s, s, vs) by {
         lemma_serialize_2_u16s_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_2_u16s_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_2_u16s(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_2_u16s(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_2_u16s = |s, vs| spec_serialize_2_u16s(s, vs);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_2_u16s, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_2_u16s, s1, s2, v) by {
         lemma_serialize_2_u16s_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_2_u16s_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_2_u16s(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_2_u16s(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_2_u16s = |s| spec_parse_2_u16s(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_2_u16s, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_2_u16s, s1, s2) by {
         lemma_parse_2_u16s_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_2_u16s_correct()
-    ensures prop_parse_correct(|s| spec_parse_2_u16s(s), |s, vs| spec_serialize_2_u16s(s, vs))
+    ensures
+        prop_parse_correct(|s| spec_parse_2_u16s(s), |s, vs| spec_serialize_2_u16s(s, vs)),
 {
     reveal(prop_parse_correct);
     let spec_parse_2_u16s = |s| spec_parse_2_u16s(s);
     let spec_serialize_2_u16s = |s, vs| spec_serialize_2_u16s(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_2_u16s, spec_serialize_2_u16s, s, vs) by {
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_2_u16s,
+            spec_serialize_2_u16s,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_2_u16s_correct_on(s, vs);
         }
@@ -4427,26 +5045,33 @@ pub proof fn lemma_parse_2_u16s_correct()
 }
 
 pub proof fn lemma_parse_2_u16s_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_2_u16s(s), |s, v| spec_serialize_2_u16s(s, v))
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_2_u16s(s), |s, v| spec_serialize_2_u16s(s, v)),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_2_u16s = |s| spec_parse_2_u16s(s);
     let spec_serialize_2_u16s = |s, vs| spec_serialize_2_u16s(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_2_u16s, spec_serialize_2_u16s, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_2_u16s, spec_serialize_2_u16s, s) by {
         lemma_parse_2_u16s_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_2_u16s_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_2_u16s(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_2_u16s(s)),
 {
     lemma_parse_2_u16s_serialize_inverse();
     lemma_serialize_2_u16s_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_2_u16s(s), |s, v| spec_serialize_2_u16s(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_2_u16s(s),
+        |s, v| spec_serialize_2_u16s(s, v),
+    );
 }
 
 proof fn lemma_parse_2_u16s_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_2_u16s(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_2_u16s(s), s),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -4454,7 +5079,8 @@ proof fn lemma_parse_2_u16s_well_behaved_on(s: SpecStream)
 }
 
 proof fn lemma_serialize_2_u16s_well_behaved_on(s: SpecStream, vs: Seq<u16>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_2_u16s(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(|s, vs| spec_serialize_2_u16s(s, vs), s, vs),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -4462,7 +5088,8 @@ proof fn lemma_serialize_2_u16s_well_behaved_on(s: SpecStream, vs: Seq<u16>)
 }
 
 proof fn lemma_serialize_2_u16s_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u16>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_2_u16s(s, v), s1, s2, v)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_2_u16s(s, v), s1, s2, v),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -4471,7 +5098,8 @@ proof fn lemma_serialize_2_u16s_deterministic_on(s1: SpecStream, s2: SpecStream,
 }
 
 proof fn lemma_parse_2_u16s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_2_u16s(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_2_u16s(s), s1, s2),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -4480,8 +5108,15 @@ proof fn lemma_parse_2_u16s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
 }
 
 proof fn lemma_parse_2_u16s_correct_on(s: SpecStream, vs: Seq<u16>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_2_u16s(s), |s, vs| spec_serialize_2_u16s(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_2_u16s(s),
+            |s, vs| spec_serialize_2_u16s(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -4493,7 +5128,12 @@ proof fn lemma_parse_2_u16s_correct_on(s: SpecStream, vs: Seq<u16>)
 }
 
 proof fn lemma_parse_2_u16s_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_2_u16s(s), |s, v| spec_serialize_2_u16s(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_2_u16s(s),
+            |s, v| spec_serialize_2_u16s(s, v),
+            s,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -4505,9 +5145,11 @@ proof fn lemma_parse_2_u16s_serialize_inverse_on(s: SpecStream)
 
 pub exec fn parse_2_u16s(s: Stream) -> (res: ParseResult<Vec<u16>>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_2_u16s(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_2_u16s(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
 
     let ghost spec_parse_u16_le = |s| spec_parse_u16_le(s);
 
@@ -4517,7 +5159,14 @@ pub exec fn parse_2_u16s(s: Stream) -> (res: ParseResult<Vec<u16>>)
 #[verifier(external_body)]
 pub exec fn serialize_2_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_2_u16s(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_2_u16s(s, vs),
+        ),
 {
     if vs.length() != 2 {
         return Err(SerializeError::RepeatNMismatch);
@@ -4526,12 +5175,10 @@ pub exec fn serialize_2_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res:
     } else if start > data.length() {
         return Err(SerializeError::NotEnoughSpace);
     }
-
     let (mut start, mut i, mut m): (usize, usize, usize) = (start, 0, 0);
-    while i < 2
-    {
+    while i < 2 {
         i = i + 1;
-        let v = *slice_index_get(&vs, i - 1); // vs[i - 1]
+        let v = *slice_index_get(&vs, i - 1);  // vs[i - 1]
         let res1 = serialize_u16_le(data, start, v);
         match res1 {
             Ok((new_start, m1)) => {
@@ -4541,18 +5188,18 @@ pub exec fn serialize_2_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res:
                     start = new_start;
                     m = m + m1;
                 }
-            }
+            },
             Err(e) => {
                 return Err(e);
-            }
+            },
         }
     }
-
     Ok((start, m))
 }
 
-pub open spec fn spec_parse_2_u16s_11500448530008798961(s: SpecStream) -> SpecParseResult<Seq<u16>>
-{
+pub open spec fn spec_parse_2_u16s_11500448530008798961(s: SpecStream) -> SpecParseResult<
+    Seq<u16>,
+> {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     match spec_parse_repeat_n(spec_parse_u16_le, 2)(s) {
         Ok((s, n, xs)) => {
@@ -4561,13 +5208,15 @@ pub open spec fn spec_parse_2_u16s_11500448530008798961(s: SpecStream) -> SpecPa
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_2_u16s_11500448530008798961(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_2_u16s_11500448530008798961(
+    s: SpecStream,
+    vs: Seq<u16>,
+) -> SpecSerializeResult {
     if vs == seq![55u16, 77u16] {
         let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
         spec_serialize_repeat_n(spec_serialize_u16_le, 2)(s, vs)
@@ -4577,63 +5226,94 @@ pub open spec fn spec_serialize_2_u16s_11500448530008798961(s: SpecStream, vs: S
 }
 
 pub proof fn lemma_parse_2_u16s_11500448530008798961_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_2_u16s_11500448530008798961(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_2_u16s_11500448530008798961(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_2_u16s_11500448530008798961, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_well_behaved_on(spec_parse_2_u16s_11500448530008798961, s) by {
         lemma_parse_2_u16s_11500448530008798961_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_2_u16s_11500448530008798961_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_2_u16s_11500448530008798961, s, vs) by {
+    let spec_serialize_2_u16s_11500448530008798961 = |s, vs|
+        spec_serialize_2_u16s_11500448530008798961(s, vs);
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_2_u16s_11500448530008798961, s, vs) by {
         lemma_serialize_2_u16s_11500448530008798961_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_2_u16s_11500448530008798961_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_2_u16s_11500448530008798961(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_2_u16s_11500448530008798961(s, v)),
 {
     reveal(prop_serialize_deterministic);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, v| spec_serialize_2_u16s_11500448530008798961(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_2_u16s_11500448530008798961, s1, s2, v) by {
+    let spec_serialize_2_u16s_11500448530008798961 = |s, v|
+        spec_serialize_2_u16s_11500448530008798961(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_2_u16s_11500448530008798961, s1, s2, v) by {
         lemma_serialize_2_u16s_11500448530008798961_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_2_u16s_11500448530008798961_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_2_u16s_11500448530008798961(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_2_u16s_11500448530008798961(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_2_u16s_11500448530008798961, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_2_u16s_11500448530008798961, s1, s2) by {
         lemma_parse_2_u16s_11500448530008798961_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_2_u16s_11500448530008798961_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_2_u16s_11500448530008798961(s), |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_2_u16s_11500448530008798961(s),
+            |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_2_u16s_11500448530008798961, spec_serialize_2_u16s_11500448530008798961, s) by {
+    let spec_serialize_2_u16s_11500448530008798961 = |s, vs|
+        spec_serialize_2_u16s_11500448530008798961(s, vs);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(
+            spec_parse_2_u16s_11500448530008798961,
+            spec_serialize_2_u16s_11500448530008798961,
+            s,
+        ) by {
         lemma_parse_2_u16s_11500448530008798961_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_2_u16s_11500448530008798961_correct()
-    ensures prop_parse_correct(|s| spec_parse_2_u16s_11500448530008798961(s), |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs))
+    ensures
+        prop_parse_correct(
+            |s| spec_parse_2_u16s_11500448530008798961(s),
+            |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs),
+        ),
 {
     reveal(prop_parse_correct);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_2_u16s_11500448530008798961, spec_serialize_2_u16s_11500448530008798961, s, vs) by {
+    let spec_serialize_2_u16s_11500448530008798961 = |s, vs|
+        spec_serialize_2_u16s_11500448530008798961(s, vs);
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_2_u16s_11500448530008798961,
+            spec_serialize_2_u16s_11500448530008798961,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_2_u16s_11500448530008798961_correct_on(s, vs);
         }
@@ -4641,7 +5321,8 @@ pub proof fn lemma_parse_2_u16s_11500448530008798961_correct()
 }
 
 proof fn lemma_parse_2_u16s_11500448530008798961_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_2_u16s_11500448530008798961(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_2_u16s_11500448530008798961(s), s),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -4649,15 +5330,30 @@ proof fn lemma_parse_2_u16s_11500448530008798961_well_behaved_on(s: SpecStream)
 }
 
 proof fn lemma_serialize_2_u16s_11500448530008798961_well_behaved_on(s: SpecStream, vs: Seq<u16>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(
+            |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
     lemma_serialize_repeat_n_well_behaved_on(spec_serialize_u16_le, 2, s, vs);
 }
 
-pub proof fn lemma_serialize_2_u16s_11500448530008798961_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u16>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_2_u16s_11500448530008798961(s, v), s1, s2, v)
+pub proof fn lemma_serialize_2_u16s_11500448530008798961_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: Seq<u16>,
+)
+    ensures
+        prop_serialize_deterministic_on(
+            |s, v| spec_serialize_2_u16s_11500448530008798961(s, v),
+            s1,
+            s2,
+            v,
+        ),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -4666,7 +5362,8 @@ pub proof fn lemma_serialize_2_u16s_11500448530008798961_deterministic_on(s1: Sp
 }
 
 proof fn lemma_parse_2_u16s_11500448530008798961_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_2_u16s_11500448530008798961(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_2_u16s_11500448530008798961(s), s1, s2),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -4675,7 +5372,12 @@ proof fn lemma_parse_2_u16s_11500448530008798961_strong_prefix_on(s1: SpecStream
 }
 
 proof fn lemma_parse_2_u16s_11500448530008798961_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_2_u16s_11500448530008798961(s), |s, v| spec_serialize_2_u16s_11500448530008798961(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_2_u16s_11500448530008798961(s),
+            |s, v| spec_serialize_2_u16s_11500448530008798961(s, v),
+            s,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -4686,8 +5388,15 @@ proof fn lemma_parse_2_u16s_11500448530008798961_serialize_inverse_on(s: SpecStr
 }
 
 proof fn lemma_parse_2_u16s_11500448530008798961_correct_on(s: SpecStream, vs: Seq<u16>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_2_u16s_11500448530008798961(s), |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_2_u16s_11500448530008798961(s),
+            |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -4698,9 +5407,11 @@ proof fn lemma_parse_2_u16s_11500448530008798961_correct_on(s: SpecStream, vs: S
     lemma_parse_repeat_n_correct_on(spec_parse_u16_le, spec_serialize_u16_le, 2, s, vs);
 }
 
-pub exec fn slice_u16_check_11500448530008798961(xs : &[u16]) -> (res : bool)
-    requires xs.dview().len() == 2
-    ensures res <==> xs.dview() == seq![55u16, 77u16]
+pub exec fn slice_u16_check_11500448530008798961(xs: &[u16]) -> (res: bool)
+    requires
+        xs.dview().len() == 2,
+    ensures
+        res <==> xs.dview() == seq![55u16, 77u16],
 {
     let constant = [55u16, 77u16];
     assert(constant.view() =~= seq![55u16, 77u16]);
@@ -4715,7 +5426,9 @@ pub exec fn slice_u16_check_11500448530008798961(xs : &[u16]) -> (res : bool)
         let (constant_i, xi) = (*array_index_get(&constant, i), *slice_index_get(&xs, i));
         if constant_i == xi {
             i = i + 1;
-            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(xi));
+            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(
+                xi,
+            ));
         } else {
             return false;
         }
@@ -4723,25 +5436,26 @@ pub exec fn slice_u16_check_11500448530008798961(xs : &[u16]) -> (res : bool)
     assert(xs.dview() =~= seq![55u16, 77u16]) by {
         assert(xs.dview().subrange(0, 2) =~= xs.dview());
     }
-
     true
 }
 
 pub exec fn parse_2_u16s_11500448530008798961(s: Stream) -> (res: ParseResult<Vec<u16>>)
     ensures
         prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_2_u16s_11500448530008798961(s)),
-        res.is_ok() ==> res.unwrap().2.dview() == seq![55u16, 77u16]
+        res.is_ok() ==> res.unwrap().2.dview() == seq![55u16, 77u16],
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
 
     let ghost spec_parse_u16_le = |s| spec_parse_u16_le(s);
 
     let (s0, n, xs) = parse_repeat_n(parse_u16_le, Ghost(spec_parse_u16_le), 2, s)?;
 
     assert(xs.dview().len() == 2) by {
-        lemma_parse_u16_le_well_behaved(); lemma_parse_repeat_n_well_behaved(spec_parse_u16_le, 2);
+        lemma_parse_u16_le_well_behaved();
+        lemma_parse_repeat_n_well_behaved(spec_parse_u16_le, 2);
     }
-
     if slice_u16_check_11500448530008798961(vec_as_slice(&xs)) {
         Ok((s0, n, xs))
     } else {
@@ -4749,9 +5463,20 @@ pub exec fn parse_2_u16s_11500448530008798961(s: Stream) -> (res: ParseResult<Ve
     }
 }
 
-pub exec fn serialize_2_u16s_11500448530008798961(data: &mut [u8], start: usize, vs: &[u16]) -> (res: SerializeResult)
+pub exec fn serialize_2_u16s_11500448530008798961(
+    data: &mut [u8],
+    start: usize,
+    vs: &[u16],
+) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_2_u16s_11500448530008798961(s, vs),
+        ),
 {
     if vs.length() == 2 && slice_u16_check_11500448530008798961(vs) {
         serialize_2_u16s(data, start, vs)
@@ -4759,37 +5484,34 @@ pub exec fn serialize_2_u16s_11500448530008798961(data: &mut [u8], start: usize,
         Err(SerializeError::ConstMismatch)
     }
 }
+
 pub struct SpecTriple {
     a: u8,
     b: Seq<u16>,
     c: u64,
-
 }
+
 pub struct Triple {
     a: u8,
     b: Vec<u16>,
     c: u64,
-
 }
 
 pub open spec fn spec_parse_3_fold<R1, R2, R3>(
     parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
     parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
-    parser3: spec_fn(SpecStream) -> SpecParseResult<R3>) -> spec_fn(SpecStream) -> SpecParseResult<((R1, R2), R3)>
-{
+    parser3: spec_fn(SpecStream) -> SpecParseResult<R3>,
+) -> spec_fn(SpecStream) -> SpecParseResult<((R1, R2), R3)> {
     spec_parse_pair(spec_parse_pair(parser1, parser2), parser3)
 }
-
-
 
 pub open spec fn spec_serialize_3_fold<T1, T2, T3>(
     serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
     serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-    serializer3: spec_fn(SpecStream, T3) -> SpecSerializeResult) -> spec_fn(SpecStream, ((T1, T2), T3)) -> SpecSerializeResult
-{
+    serializer3: spec_fn(SpecStream, T3) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, ((T1, T2), T3)) -> SpecSerializeResult {
     spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3)
 }
-
 
 pub exec fn parse_3_fold<'a, P1, P2, P3, R1, R2, R3>(
     exec_parser1: P1,
@@ -4798,82 +5520,116 @@ pub exec fn parse_3_fold<'a, P1, P2, P3, R1, R2, R3>(
     Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
     Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
     Ghost(spec_parser3): Ghost<spec_fn(SpecStream) -> SpecParseResult<R3::V>>,
-    s: Stream<'a>) -> (res: ParseResult<((R1, R2), R3)>)
-    where
+    s: Stream<'a>,
+) -> (res: ParseResult<((R1, R2), R3)>) where
     R1: DView,
     P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
     R2: DView,
     P2: FnOnce(Stream<'a>) -> ParseResult<R2>,
     R3: DView,
     P3: FnOnce(Stream<'a>) -> ParseResult<R3>,
+
     requires
         prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
         prop_parse_exec_spec_equiv(exec_parser3, spec_parser3),
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, spec_parse_3_fold(spec_parser1, spec_parser2, spec_parser3))
+        prop_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_3_fold(spec_parser1, spec_parser2, spec_parser3),
+        ),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s)
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    parse_pair(
+        parse_2_fold,
+        exec_parser3,
+        Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+        Ghost(spec_parser3),
+        s,
+    )
 }
 
-
-pub open spec fn spec_parse_triple(s: SpecStream) -> SpecParseResult<((u8, Seq<u16>), u64)>
-{
+pub open spec fn spec_parse_triple(s: SpecStream) -> SpecParseResult<((u8, Seq<u16>), u64)> {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
 
-    spec_parse_3_fold(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961, spec_parse_u64_le)(s)
+    spec_parse_3_fold(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961, spec_parse_u64_le)(
+        s,
+    )
 }
 
-pub open spec fn spec_serialize_triple(s: SpecStream, v: ((u8, Seq<u16>), u64)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_triple(
+    s: SpecStream,
+    v: ((u8, Seq<u16>), u64),
+) -> SpecSerializeResult {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, v| spec_serialize_2_u16s_11500448530008798961(s, v);
+    let spec_serialize_2_u16s_11500448530008798961 = |s, v|
+        spec_serialize_2_u16s_11500448530008798961(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
 
-    spec_serialize_3_fold(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961, spec_serialize_u64_le)(s, v)
+    spec_serialize_3_fold(
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+        spec_serialize_u64_le,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_triple_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_triple(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_triple(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_triple = |s| spec_parse_triple(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_triple, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_triple, s) by {
         lemma_parse_triple_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_triple_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_triple(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_triple(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_triple = |s, v| spec_serialize_triple(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_triple, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_triple, s, v) by {
         lemma_serialize_triple_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_triple_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_triple(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_triple(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_triple = |s, v| spec_serialize_triple(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_triple, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_triple, s1, s2, v) by {
         lemma_serialize_triple_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_triple_correct()
-    ensures prop_parse_correct(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_triple = |s| spec_parse_triple(s);
     let spec_serialize_triple = |s, v| spec_serialize_triple(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_triple, spec_serialize_triple, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_triple,
+            spec_serialize_triple,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_triple_correct_on(s, v);
         }
@@ -4881,26 +5637,33 @@ pub proof fn lemma_parse_triple_correct()
 }
 
 pub proof fn lemma_parse_triple_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v))
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v)),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_triple = |s| spec_parse_triple(s);
     let spec_serialize_triple = |s, v| spec_serialize_triple(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_triple, spec_serialize_triple, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_triple, spec_serialize_triple, s) by {
         lemma_parse_triple_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_triple_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_triple(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_triple(s)),
 {
     lemma_parse_triple_serialize_inverse();
     lemma_serialize_triple_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_triple(s),
+        |s, v| spec_serialize_triple(s, v),
+    );
 }
 
 pub proof fn lemma_parse_triple_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_triple(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_triple(s), s),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
@@ -4909,27 +5672,47 @@ pub proof fn lemma_parse_triple_well_behaved_on(s: SpecStream)
     lemma_parse_2_u16s_11500448530008798961_well_behaved();
     lemma_parse_u64_le_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961), spec_parse_u64_le, s);
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961),
+        spec_parse_u64_le,
+        s,
+    );
 }
 
 pub proof fn lemma_serialize_triple_well_behaved_on(s: SpecStream, v: ((u8, Seq<u16>), u64))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_triple(s, v), s, v)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_triple(s, v), s, v),
 {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, v| spec_serialize_2_u16s_11500448530008798961(s, v);
+    let spec_serialize_2_u16s_11500448530008798961 = |s, v|
+        spec_serialize_2_u16s_11500448530008798961(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     lemma_serialize_u8_le_well_behaved();
     lemma_serialize_2_u16s_11500448530008798961_well_behaved();
     lemma_serialize_u64_le_well_behaved();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961), spec_serialize_u64_le, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961),
+        spec_serialize_u64_le,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_triple_deterministic_on(s1: SpecStream, s2: SpecStream, v: ((u8, Seq<u16>), u64))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_triple(s, v), s1, s2, v)
+pub proof fn lemma_serialize_triple_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: ((u8, Seq<u16>), u64),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_triple(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, v| spec_serialize_2_u16s_11500448530008798961(s, v);
+    let spec_serialize_2_u16s_11500448530008798961 = |s, v|
+        spec_serialize_2_u16s_11500448530008798961(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     lemma_serialize_u8_le_well_behaved();
     lemma_serialize_2_u16s_11500448530008798961_well_behaved();
@@ -4937,20 +5720,35 @@ pub proof fn lemma_serialize_triple_deterministic_on(s1: SpecStream, s2: SpecStr
     lemma_serialize_u8_le_deterministic();
     lemma_serialize_2_u16s_11500448530008798961_deterministic();
     lemma_serialize_u64_le_deterministic();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
-    lemma_serialize_pair_deterministic(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961), spec_serialize_u64_le, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961),
+        spec_serialize_u64_le,
+        s1,
+        s2,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_triple_correct_on(s: SpecStream, v: ((u8, Seq<u16>), u64))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v), s, v)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v), s, v),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, v| spec_serialize_2_u16s_11500448530008798961(s, v);
+    let spec_serialize_2_u16s_11500448530008798961 = |s, v|
+        spec_serialize_2_u16s_11500448530008798961(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     lemma_serialize_u8_le_well_behaved();
     lemma_serialize_2_u16s_11500448530008798961_well_behaved();
@@ -4965,20 +5763,41 @@ pub proof fn lemma_parse_triple_correct_on(s: SpecStream, v: ((u8, Seq<u16>), u6
     lemma_parse_2_u16s_11500448530008798961_correct();
     lemma_parse_u64_le_correct();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
     lemma_parse_pair_strong_prefix(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961);
-    lemma_parse_pair_correct(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961, spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961), spec_parse_u64_le, spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961), spec_serialize_u64_le, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u8_le,
+        spec_parse_2_u16s_11500448530008798961,
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961),
+        spec_parse_u64_le,
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961),
+        spec_serialize_u64_le,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_triple_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_triple(s), |s, v| spec_serialize_triple(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_triple(s),
+            |s, v| spec_serialize_triple(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-    let spec_serialize_2_u16s_11500448530008798961 = |s, v| spec_serialize_2_u16s_11500448530008798961(s, v);
+    let spec_serialize_2_u16s_11500448530008798961 = |s, v|
+        spec_serialize_2_u16s_11500448530008798961(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     lemma_parse_u8_le_well_behaved();
     lemma_parse_2_u16s_11500448530008798961_well_behaved();
@@ -4990,23 +5809,39 @@ pub proof fn lemma_parse_triple_serialize_inverse_on(s: SpecStream)
     lemma_parse_2_u16s_11500448530008798961_serialize_inverse();
     lemma_parse_u64_le_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
-    lemma_parse_pair_serialize_inverse(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961, spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961), spec_parse_u64_le, spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961), spec_serialize_u64_le, s);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u8_le,
+        spec_parse_2_u16s_11500448530008798961,
+        spec_serialize_u8_le,
+        spec_serialize_2_u16s_11500448530008798961,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961),
+        spec_parse_u64_le,
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_2_u16s_11500448530008798961),
+        spec_serialize_u64_le,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_triple_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_triple(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_triple(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_triple = |s| spec_parse_triple(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_triple, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_triple, s1, s2) by {
         lemma_parse_triple_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_triple_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_triple(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_triple(s), s1, s2),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
@@ -5019,95 +5854,130 @@ pub proof fn lemma_parse_triple_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     lemma_parse_u64_le_strong_prefix();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961);
-    lemma_parse_pair_strong_prefix_on(spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961), spec_parse_u64_le, s1, s2);
+    lemma_parse_pair_strong_prefix_on(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_2_u16s_11500448530008798961),
+        spec_parse_u64_le,
+        s1,
+        s2,
+    );
 }
 
 pub exec fn parse_triple(s: Stream) -> (res: ParseResult<((u8, Vec<u16>), u64)>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_triple(s))
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_triple(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le = |s| spec_parse_u8_le(s);
-    let ghost spec_parse_2_u16s_11500448530008798961 = |s| spec_parse_2_u16s_11500448530008798961(s);
+    let ghost spec_parse_2_u16s_11500448530008798961 = |s|
+        spec_parse_2_u16s_11500448530008798961(s);
     let ghost spec_parse_u64_le = |s| spec_parse_u64_le(s);
 
-    parse_3_fold(parse_u8_le, parse_2_u16s_11500448530008798961, parse_u64_le, Ghost(spec_parse_u8_le), Ghost(spec_parse_2_u16s_11500448530008798961), Ghost(spec_parse_u64_le), s)
+    parse_3_fold(
+        parse_u8_le,
+        parse_2_u16s_11500448530008798961,
+        parse_u64_le,
+        Ghost(spec_parse_u8_le),
+        Ghost(spec_parse_2_u16s_11500448530008798961),
+        Ghost(spec_parse_u64_le),
+        s,
+    )
 }
-pub exec fn serialize_triple(data: &mut [u8], start: usize, v: ((u8, &[u16]), u64)) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_triple(s, v))
+
+pub exec fn serialize_triple(data: &mut [u8], start: usize, v: ((u8, &[u16]), u64)) -> (res:
+    SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_triple(s, v),
+        ),
 {
     let ((v0, v1), v2) = v;
     let (new_start, n0) = serialize_u8_le(data, start, v0)?;
 
-let (new_start, n1) = serialize_2_u16s_11500448530008798961(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_u64_le(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_2_u16s_11500448530008798961(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_u64_le(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2))
 }
 
-                    
-pub open spec fn spec_parse_8_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_8_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 8)
 }
 
-pub open spec fn spec_serialize_8_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_8_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 8)
 }
 
 pub proof fn lemma_parse_8_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_8_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_8_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_8_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_8_bytes, s) by {
         lemma_parse_8_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_8_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_8_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_8_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_8_bytes, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_8_bytes, s, v) by {
         lemma_serialize_8_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_8_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_8_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_8_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_8_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_8_bytes, s1, s2, v) by {
         lemma_serialize_8_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_8_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_8_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_8_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_8_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_8_bytes, s1, s2) by {
         lemma_parse_8_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_8_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_8_bytes, spec_serialize_8_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_8_bytes,
+            spec_serialize_8_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_8_bytes_correct_on(s, v)
         }
@@ -5116,85 +5986,102 @@ pub proof fn lemma_parse_8_bytes_correct()
 
 pub proof fn lemma_parse_8_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_8_bytes(s),
+            |s, v| spec_serialize_8_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_8_bytes, spec_serialize_8_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_8_bytes, spec_serialize_8_bytes, s) by {
         lemma_parse_8_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_8_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_8_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_8_bytes(s)),
 {
     lemma_parse_8_bytes_serialize_inverse();
     lemma_serialize_8_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_8_bytes(s),
+        |s, v| spec_serialize_8_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_8_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_8_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_8_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 8);
 }
 
 proof fn lemma_serialize_8_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_8_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_8_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 8);
 }
 
 proof fn lemma_serialize_8_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_8_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_8_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 8);
 }
 
 proof fn lemma_parse_8_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_8_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_8_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 8);
 }
 
 proof fn lemma_parse_8_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v), s, v)
+        prop_parse_correct_on(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v), s, v),
 {
     lemma_parse_bytes_correct_on(s, v, 8);
 }
 
 proof fn lemma_parse_8_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_8_bytes(s), |s, v| spec_serialize_8_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_8_bytes(s),
+            |s, v| spec_serialize_8_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 8);
 }
 
 pub exec fn parse_8_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_8_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_8_bytes(s)),
 {
     parse_bytes(s, 8)
 }
+
 pub exec fn serialize_8_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 8 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 8 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 8)
 }
 
-            
-pub open spec fn spec_parse_u64_le_88888888888(s: SpecStream) -> SpecParseResult<u64>
-{
+pub open spec fn spec_parse_u64_le_88888888888(s: SpecStream) -> SpecParseResult<u64> {
     match spec_parse_u64_le(s) {
         Ok((s, n, v)) => {
             if v == 88888888888 {
@@ -5202,13 +6089,12 @@ pub open spec fn spec_parse_u64_le_88888888888(s: SpecStream) -> SpecParseResult
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_u64_le_88888888888(s: SpecStream, v: u64) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_u64_le_88888888888(s: SpecStream, v: u64) -> SpecSerializeResult {
     if v == 88888888888 {
         spec_serialize_u64_le(s, v)
     } else {
@@ -5218,7 +6104,7 @@ pub open spec fn spec_serialize_u64_le_88888888888(s: SpecStream, v: u64) -> Spe
 
 pub exec fn parse_u64_le_88888888888(s: Stream) -> (res: ParseResult<u64>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u64_le_88888888888(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u64_le_88888888888(s)),
 {
     let (s, n, v) = parse_u64_le(s)?;
     if v == 88888888888 {
@@ -5228,9 +6114,17 @@ pub exec fn parse_u64_le_88888888888(s: Stream) -> (res: ParseResult<u64>)
     }
 }
 
-pub exec fn serialize_u64_le_88888888888(data: &mut [u8], start: usize, v: u64) -> (res: SerializeResult)
+pub exec fn serialize_u64_le_88888888888(data: &mut [u8], start: usize, v: u64) -> (res:
+    SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u64_le_88888888888(s, v))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u64_le_88888888888(s, v),
+        ),
 {
     if v == 88888888888 {
         serialize_u64_le(data, start, v)
@@ -5241,143 +6135,168 @@ pub exec fn serialize_u64_le_88888888888(data: &mut [u8], start: usize, v: u64) 
 
 pub proof fn lemma_parse_u64_le_88888888888_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_u64_le_88888888888(s))
+        prop_parse_well_behaved(|s| spec_parse_u64_le_88888888888(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_u64_le_88888888888 = |s| spec_parse_u64_le_88888888888(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u64_le_88888888888, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u64_le_88888888888, s) by {
         lemma_parse_u64_le_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_u64_le_88888888888_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_u64_le_88888888888(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_u64_le_88888888888(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_u64_le_88888888888 = |s, v| spec_serialize_u64_le_88888888888(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u64_le_88888888888, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_u64_le_88888888888, s, v) by {
         lemma_serialize_u64_le_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_u64_le_88888888888_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_u64_le_88888888888(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_u64_le_88888888888(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_u64_le_88888888888 = |s, v| spec_serialize_u64_le_88888888888(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u64_le_88888888888, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u64_le_88888888888, s1, s2, v) by {
         lemma_serialize_u64_le_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_u64_le_88888888888_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_u64_le_88888888888(s))
+        prop_parse_strong_prefix(|s| spec_parse_u64_le_88888888888(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_u64_le_88888888888 = |s| spec_parse_u64_le_88888888888(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u64_le_88888888888, s1, s2) by {
+    assert forall|s1, s2| #[trigger]
+        prop_parse_strong_prefix_on(spec_parse_u64_le_88888888888, s1, s2) by {
         lemma_parse_u64_le_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_u64_le_88888888888_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_u64_le_88888888888(s), |s, v| spec_serialize_u64_le_88888888888(s, v))
+        prop_parse_correct(
+            |s| spec_parse_u64_le_88888888888(s),
+            |s, v| spec_serialize_u64_le_88888888888(s, v),
+        ),
 {
     reveal(prop_parse_correct);
     let spec_parse_u64_le_88888888888 = |s| spec_parse_u64_le_88888888888(s);
     let spec_serialize_u64_le_88888888888 = |s, v| spec_serialize_u64_le_88888888888(s, v);
-    assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u64_le_88888888888, spec_serialize_u64_le_88888888888, s, v) by {
-        lemma_parse_u64_le_correct_on(s, v)
-    }
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(
+            spec_parse_u64_le_88888888888,
+            spec_serialize_u64_le_88888888888,
+            s,
+            v,
+        ) by { lemma_parse_u64_le_correct_on(s, v) }
 }
 
 pub proof fn lemma_parse_u64_le_88888888888_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_u64_le_88888888888(s), |s, v| spec_serialize_u64_le_88888888888(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_u64_le_88888888888(s),
+            |s, v| spec_serialize_u64_le_88888888888(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_u64_le_88888888888 = |s| spec_parse_u64_le_88888888888(s);
     let spec_serialize_u64_le_88888888888 = |s, v| spec_serialize_u64_le_88888888888(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u64_le_88888888888, spec_serialize_u64_le_88888888888, s) by {
-        lemma_parse_u64_le_serialize_inverse_on(s)
-    }
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(
+            spec_parse_u64_le_88888888888,
+            spec_serialize_u64_le_88888888888,
+            s,
+        ) by { lemma_parse_u64_le_serialize_inverse_on(s) }
 }
 
 pub proof fn lemma_parse_u64_le_88888888888_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_u64_le_88888888888(s))
+        prop_parse_nonmalleable(|s| spec_parse_u64_le_88888888888(s)),
 {
     lemma_parse_u64_le_88888888888_serialize_inverse();
     lemma_serialize_u64_le_88888888888_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u64_le_88888888888(s), |s, v| spec_serialize_u64_le_88888888888(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u64_le_88888888888(s),
+        |s, v| spec_serialize_u64_le_88888888888(s, v),
+    );
 }
 
-pub open spec fn spec_parse_256_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_256_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 256)
 }
 
-pub open spec fn spec_serialize_256_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_256_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 256)
 }
 
 pub proof fn lemma_parse_256_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_256_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_256_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_256_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_256_bytes, s) by {
         lemma_parse_256_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_256_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_256_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_256_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_256_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_256_bytes, s, v) by {
         lemma_serialize_256_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_256_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_256_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_256_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_256_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_256_bytes, s1, s2, v) by {
         lemma_serialize_256_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_256_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_256_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_256_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_256_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_256_bytes, s1, s2) by {
         lemma_parse_256_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_256_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_256_bytes(s), |s, v| spec_serialize_256_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_256_bytes(s), |s, v| spec_serialize_256_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_256_bytes, spec_serialize_256_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_256_bytes,
+            spec_serialize_256_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_256_bytes_correct_on(s, v)
         }
@@ -5386,117 +6305,140 @@ pub proof fn lemma_parse_256_bytes_correct()
 
 pub proof fn lemma_parse_256_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_256_bytes(s), |s, v| spec_serialize_256_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_256_bytes(s),
+            |s, v| spec_serialize_256_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_256_bytes, spec_serialize_256_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_256_bytes, spec_serialize_256_bytes, s) by {
         lemma_parse_256_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_256_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_256_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_256_bytes(s)),
 {
     lemma_parse_256_bytes_serialize_inverse();
     lemma_serialize_256_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_256_bytes(s), |s, v| spec_serialize_256_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_256_bytes(s),
+        |s, v| spec_serialize_256_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_256_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_256_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_256_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 256);
 }
 
 proof fn lemma_serialize_256_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_256_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_256_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 256);
 }
 
 proof fn lemma_serialize_256_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_256_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_256_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 256);
 }
 
 proof fn lemma_parse_256_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_256_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_256_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 256);
 }
 
 proof fn lemma_parse_256_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_256_bytes(s), |s, v| spec_serialize_256_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_256_bytes(s),
+            |s, v| spec_serialize_256_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 256);
 }
 
 proof fn lemma_parse_256_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_256_bytes(s), |s, v| spec_serialize_256_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_256_bytes(s),
+            |s, v| spec_serialize_256_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 256);
 }
 
 pub exec fn parse_256_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_256_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_256_bytes(s)),
 {
     parse_bytes(s, 256)
 }
+
 pub exec fn serialize_256_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 256 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 256 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 256)
 }
 
-            pub struct SpecQuadruple {
+pub struct SpecQuadruple {
     a: u8,
     b: Seq<u8>,
     c: u64,
     d: Seq<u8>,
-
 }
+
 pub struct Quadruple {
     a: u8,
     b: Vec<u8>,
     c: u64,
     d: Vec<u8>,
-
 }
 
 pub open spec fn spec_parse_4_fold<R1, R2, R3, R4>(
     parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
     parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
     parser3: spec_fn(SpecStream) -> SpecParseResult<R3>,
-    parser4: spec_fn(SpecStream) -> SpecParseResult<R4>) -> spec_fn(SpecStream) -> SpecParseResult<(((R1, R2), R3), R4)>
-{
+    parser4: spec_fn(SpecStream) -> SpecParseResult<R4>,
+) -> spec_fn(SpecStream) -> SpecParseResult<(((R1, R2), R3), R4)> {
     spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4)
 }
-
-
 
 pub open spec fn spec_serialize_4_fold<T1, T2, T3, T4>(
     serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
     serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
     serializer3: spec_fn(SpecStream, T3) -> SpecSerializeResult,
-    serializer4: spec_fn(SpecStream, T4) -> SpecSerializeResult) -> spec_fn(SpecStream, (((T1, T2), T3), T4)) -> SpecSerializeResult
-{
-    spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3), serializer4)
+    serializer4: spec_fn(SpecStream, T4) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, (((T1, T2), T3), T4)) -> SpecSerializeResult {
+    spec_serialize_pair(
+        spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3),
+        serializer4,
+    )
 }
-
 
 pub exec fn parse_4_fold<'a, P1, P2, P3, P4, R1, R2, R3, R4>(
     exec_parser1: P1,
@@ -5507,8 +6449,8 @@ pub exec fn parse_4_fold<'a, P1, P2, P3, P4, R1, R2, R3, R4>(
     Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
     Ghost(spec_parser3): Ghost<spec_fn(SpecStream) -> SpecParseResult<R3::V>>,
     Ghost(spec_parser4): Ghost<spec_fn(SpecStream) -> SpecParseResult<R4::V>>,
-    s: Stream<'a>) -> (res: ParseResult<(((R1, R2), R3), R4)>)
-    where
+    s: Stream<'a>,
+) -> (res: ParseResult<(((R1, R2), R3), R4)>) where
     R1: DView,
     P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
     R2: DView,
@@ -5517,78 +6459,133 @@ pub exec fn parse_4_fold<'a, P1, P2, P3, P4, R1, R2, R3, R4>(
     P3: FnOnce(Stream<'a>) -> ParseResult<R3>,
     R4: DView,
     P4: FnOnce(Stream<'a>) -> ParseResult<R4>,
+
     requires
         prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
         prop_parse_exec_spec_equiv(exec_parser3, spec_parser3),
         prop_parse_exec_spec_equiv(exec_parser4, spec_parser4),
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, spec_parse_4_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4))
+        prop_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_4_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4),
+        ),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), { parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s) };
-    parse_pair(parse_3_fold, exec_parser4, Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), Ghost(spec_parser4), s)
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+            ),
+        {
+            parse_pair(
+                parse_2_fold,
+                exec_parser3,
+                Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+                Ghost(spec_parser3),
+                s,
+            )
+        };
+    parse_pair(
+        parse_3_fold,
+        exec_parser4,
+        Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)),
+        Ghost(spec_parser4),
+        s,
+    )
 }
 
-
-pub open spec fn spec_parse_quadruple(s: SpecStream) -> SpecParseResult<(((u8, Seq<u8>), u64), Seq<u8>)>
-{
+pub open spec fn spec_parse_quadruple(s: SpecStream) -> SpecParseResult<
+    (((u8, Seq<u8>), u64), Seq<u8>),
+> {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
     let spec_parse_u64_le_88888888888 = |s| spec_parse_u64_le_88888888888(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
 
-    spec_parse_4_fold(spec_parse_u8_le, spec_parse_8_bytes, spec_parse_u64_le_88888888888, spec_parse_256_bytes)(s)
+    spec_parse_4_fold(
+        spec_parse_u8_le,
+        spec_parse_8_bytes,
+        spec_parse_u64_le_88888888888,
+        spec_parse_256_bytes,
+    )(s)
 }
 
-pub open spec fn spec_serialize_quadruple(s: SpecStream, v: (((u8, Seq<u8>), u64), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_quadruple(
+    s: SpecStream,
+    v: (((u8, Seq<u8>), u64), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
     let spec_serialize_u64_le_88888888888 = |s, v| spec_serialize_u64_le_88888888888(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
 
-    spec_serialize_4_fold(spec_serialize_u8_le, spec_serialize_8_bytes, spec_serialize_u64_le_88888888888, spec_serialize_256_bytes)(s, v)
+    spec_serialize_4_fold(
+        spec_serialize_u8_le,
+        spec_serialize_8_bytes,
+        spec_serialize_u64_le_88888888888,
+        spec_serialize_256_bytes,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_quadruple_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_quadruple(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_quadruple(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_quadruple = |s| spec_parse_quadruple(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_quadruple, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_quadruple, s) by {
         lemma_parse_quadruple_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_quadruple_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_quadruple(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_quadruple(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_quadruple = |s, v| spec_serialize_quadruple(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_quadruple, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_quadruple, s, v) by {
         lemma_serialize_quadruple_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_quadruple_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_quadruple(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_quadruple(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_quadruple = |s, v| spec_serialize_quadruple(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_quadruple, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_quadruple, s1, s2, v) by {
         lemma_serialize_quadruple_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_quadruple_correct()
-    ensures prop_parse_correct(|s| spec_parse_quadruple(s), |s, v| spec_serialize_quadruple(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_quadruple(s), |s, v| spec_serialize_quadruple(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_quadruple = |s| spec_parse_quadruple(s);
     let spec_serialize_quadruple = |s, v| spec_serialize_quadruple(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_quadruple, spec_serialize_quadruple, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_quadruple,
+            spec_serialize_quadruple,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_quadruple_correct_on(s, v);
         }
@@ -5596,26 +6593,36 @@ pub proof fn lemma_parse_quadruple_correct()
 }
 
 pub proof fn lemma_parse_quadruple_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_quadruple(s), |s, v| spec_serialize_quadruple(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_quadruple(s),
+            |s, v| spec_serialize_quadruple(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_quadruple = |s| spec_parse_quadruple(s);
     let spec_serialize_quadruple = |s, v| spec_serialize_quadruple(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_quadruple, spec_serialize_quadruple, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_quadruple, spec_serialize_quadruple, s) by {
         lemma_parse_quadruple_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_quadruple_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_quadruple(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_quadruple(s)),
 {
     lemma_parse_quadruple_serialize_inverse();
     lemma_serialize_quadruple_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_quadruple(s), |s, v| spec_serialize_quadruple(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_quadruple(s),
+        |s, v| spec_serialize_quadruple(s, v),
+    );
 }
 
 pub proof fn lemma_parse_quadruple_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_quadruple(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_quadruple(s), s),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
@@ -5626,12 +6633,26 @@ pub proof fn lemma_parse_quadruple_well_behaved_on(s: SpecStream)
     lemma_parse_u64_le_88888888888_well_behaved();
     lemma_parse_256_bytes_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_8_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888), spec_parse_256_bytes, s);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+    );
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+            spec_parse_u64_le_88888888888,
+        ),
+        spec_parse_256_bytes,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_quadruple_well_behaved_on(s: SpecStream, v: (((u8, Seq<u8>), u64), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_quadruple(s, v), s, v)
+pub proof fn lemma_serialize_quadruple_well_behaved_on(
+    s: SpecStream,
+    v: (((u8, Seq<u8>), u64), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_quadruple(s, v), s, v),
 {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
@@ -5642,12 +6663,28 @@ pub proof fn lemma_serialize_quadruple_well_behaved_on(s: SpecStream, v: (((u8, 
     lemma_serialize_u64_le_88888888888_well_behaved();
     lemma_serialize_256_bytes_well_behaved();
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_8_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888), spec_serialize_256_bytes, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+            spec_serialize_u64_le_88888888888,
+        ),
+        spec_serialize_256_bytes,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_quadruple_deterministic_on(s1: SpecStream, s2: SpecStream, v: (((u8, Seq<u8>), u64), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_quadruple(s, v), s1, s2, v)
+pub proof fn lemma_serialize_quadruple_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (((u8, Seq<u8>), u64), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_quadruple(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_8_bytes = |s, v| spec_serialize_8_bytes(s, v);
@@ -5663,14 +6700,36 @@ pub proof fn lemma_serialize_quadruple_deterministic_on(s1: SpecStream, s2: Spec
     lemma_serialize_256_bytes_deterministic();
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_8_bytes);
     lemma_serialize_pair_deterministic(spec_serialize_u8_le, spec_serialize_8_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888), spec_serialize_256_bytes, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+            spec_serialize_u64_le_88888888888,
+        ),
+        spec_serialize_256_bytes,
+        s1,
+        s2,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_quadruple_correct_on(s: SpecStream, v: (((u8, Seq<u8>), u64), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_quadruple(s), |s, v| spec_serialize_quadruple(s, v), s, v)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_quadruple(s),
+            |s, v| spec_serialize_quadruple(s, v),
+            s,
+            v,
+        ),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
@@ -5699,16 +6758,53 @@ pub proof fn lemma_parse_quadruple_correct_on(s: SpecStream, v: (((u8, Seq<u8>),
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_8_bytes);
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_8_bytes);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le, spec_parse_8_bytes);
-    lemma_parse_pair_correct(spec_parse_u8_le, spec_parse_8_bytes, spec_serialize_u8_le, spec_serialize_8_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888, spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888), spec_parse_256_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888), spec_serialize_256_bytes, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u8_le,
+        spec_parse_8_bytes,
+        spec_serialize_u8_le,
+        spec_serialize_8_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+            spec_parse_u64_le_88888888888,
+        ),
+        spec_parse_256_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+            spec_serialize_u64_le_88888888888,
+        ),
+        spec_serialize_256_bytes,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_quadruple_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_quadruple(s), |s, v| spec_serialize_quadruple(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_quadruple(s),
+            |s, v| spec_serialize_quadruple(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
@@ -5732,25 +6828,55 @@ pub proof fn lemma_parse_quadruple_serialize_inverse_on(s: SpecStream)
     lemma_parse_256_bytes_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_8_bytes);
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_8_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_u8_le, spec_parse_8_bytes, spec_serialize_u8_le, spec_serialize_8_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888, spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888), spec_parse_256_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes), spec_serialize_u64_le_88888888888), spec_serialize_256_bytes, s);
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u8_le,
+        spec_parse_8_bytes,
+        spec_serialize_u8_le,
+        spec_serialize_8_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+        spec_serialize_u64_le_88888888888,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+            spec_parse_u64_le_88888888888,
+        ),
+        spec_parse_256_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_8_bytes),
+            spec_serialize_u64_le_88888888888,
+        ),
+        spec_serialize_256_bytes,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_quadruple_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_quadruple(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_quadruple(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_quadruple = |s| spec_parse_quadruple(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_quadruple, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_quadruple, s1, s2) by {
         lemma_parse_quadruple_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_quadruple_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_quadruple(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_quadruple(s), s1, s2),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
@@ -5766,40 +6892,84 @@ pub proof fn lemma_parse_quadruple_strong_prefix_on(s1: SpecStream, s2: SpecStre
     lemma_parse_256_bytes_strong_prefix();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_8_bytes);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le, spec_parse_8_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888);
-    lemma_parse_pair_strong_prefix_on(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes), spec_parse_u64_le_88888888888), spec_parse_256_bytes, s1, s2);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+        spec_parse_u64_le_88888888888,
+    );
+    lemma_parse_pair_strong_prefix_on(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_8_bytes),
+            spec_parse_u64_le_88888888888,
+        ),
+        spec_parse_256_bytes,
+        s1,
+        s2,
+    );
 }
 
 pub exec fn parse_quadruple(s: Stream) -> (res: ParseResult<(((u8, &[u8]), u64), &[u8])>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_quadruple(s))
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_quadruple(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let ghost spec_parse_8_bytes = |s| spec_parse_8_bytes(s);
     let ghost spec_parse_u64_le_88888888888 = |s| spec_parse_u64_le_88888888888(s);
     let ghost spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
 
-    parse_4_fold(parse_u8_le, parse_8_bytes, parse_u64_le_88888888888, parse_256_bytes, Ghost(spec_parse_u8_le), Ghost(spec_parse_8_bytes), Ghost(spec_parse_u64_le_88888888888), Ghost(spec_parse_256_bytes), s)
+    parse_4_fold(
+        parse_u8_le,
+        parse_8_bytes,
+        parse_u64_le_88888888888,
+        parse_256_bytes,
+        Ghost(spec_parse_u8_le),
+        Ghost(spec_parse_8_bytes),
+        Ghost(spec_parse_u64_le_88888888888),
+        Ghost(spec_parse_256_bytes),
+        s,
+    )
 }
-pub exec fn serialize_quadruple(data: &mut [u8], start: usize, v: (((u8, &[u8]), u64), &[u8])) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_quadruple(s, v))
+
+pub exec fn serialize_quadruple(
+    data: &mut [u8],
+    start: usize,
+    v: (((u8, &[u8]), u64), &[u8]),
+) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_quadruple(s, v),
+        ),
 {
     let (((v0, v1), v2), v3) = v;
     let (new_start, n0) = serialize_u8_le(data, start, v0)?;
 
-let (new_start, n1) = serialize_8_bytes(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_u64_le_88888888888(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n3) = serialize_256_bytes(data, new_start, v3)?;
-    if n0 + n1 + n2 > usize::MAX - n3 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_8_bytes(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_u64_le_88888888888(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n3) = serialize_256_bytes(data, new_start, v3)?;
+    if n0 + n1 + n2 > usize::MAX - n3 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2 + n3))
 }
 
-                    
-pub open spec fn spec_parse_u16_le_100(s: SpecStream) -> SpecParseResult<u16>
-{
+pub open spec fn spec_parse_u16_le_100(s: SpecStream) -> SpecParseResult<u16> {
     match spec_parse_u16_le(s) {
         Ok((s, n, v)) => {
             if v == 100 {
@@ -5807,13 +6977,12 @@ pub open spec fn spec_parse_u16_le_100(s: SpecStream) -> SpecParseResult<u16>
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_u16_le_100(s: SpecStream, v: u16) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_u16_le_100(s: SpecStream, v: u16) -> SpecSerializeResult {
     if v == 100 {
         spec_serialize_u16_le(s, v)
     } else {
@@ -5823,7 +6992,7 @@ pub open spec fn spec_serialize_u16_le_100(s: SpecStream, v: u16) -> SpecSeriali
 
 pub exec fn parse_u16_le_100(s: Stream) -> (res: ParseResult<u16>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u16_le_100(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u16_le_100(s)),
 {
     let (s, n, v) = parse_u16_le(s)?;
     if v == 100 {
@@ -5835,7 +7004,14 @@ pub exec fn parse_u16_le_100(s: Stream) -> (res: ParseResult<u16>)
 
 pub exec fn serialize_u16_le_100(data: &mut [u8], start: usize, v: u16) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u16_le_100(s, v))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u16_le_100(s, v),
+        ),
 {
     if v == 100 {
         serialize_u16_le(data, start, v)
@@ -5846,84 +7022,92 @@ pub exec fn serialize_u16_le_100(data: &mut [u8], start: usize, v: u16) -> (res:
 
 pub proof fn lemma_parse_u16_le_100_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_u16_le_100(s))
+        prop_parse_well_behaved(|s| spec_parse_u16_le_100(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u16_le_100, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u16_le_100, s) by {
         lemma_parse_u16_le_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_u16_le_100_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_u16_le_100(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_u16_le_100(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u16_le_100, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_u16_le_100, s, v) by {
         lemma_serialize_u16_le_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_u16_le_100_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_u16_le_100(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_u16_le_100(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u16_le_100, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u16_le_100, s1, s2, v) by {
         lemma_serialize_u16_le_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_u16_le_100_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_u16_le_100(s))
+        prop_parse_strong_prefix(|s| spec_parse_u16_le_100(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u16_le_100, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u16_le_100, s1, s2) by {
         lemma_parse_u16_le_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_u16_le_100_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_u16_le_100(s), |s, v| spec_serialize_u16_le_100(s, v))
+        prop_parse_correct(|s| spec_parse_u16_le_100(s), |s, v| spec_serialize_u16_le_100(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u16_le_100, spec_serialize_u16_le_100, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u16_le_100, spec_serialize_u16_le_100, s, v) by {
         lemma_parse_u16_le_correct_on(s, v)
     }
 }
 
 pub proof fn lemma_parse_u16_le_100_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_u16_le_100(s), |s, v| spec_serialize_u16_le_100(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_u16_le_100(s),
+            |s, v| spec_serialize_u16_le_100(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u16_le_100, spec_serialize_u16_le_100, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u16_le_100, spec_serialize_u16_le_100, s) by {
         lemma_parse_u16_le_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_u16_le_100_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_u16_le_100(s))
+        prop_parse_nonmalleable(|s| spec_parse_u16_le_100(s)),
 {
     lemma_parse_u16_le_100_serialize_inverse();
     lemma_serialize_u16_le_100_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u16_le_100(s), |s, v| spec_serialize_u16_le_100(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u16_le_100(s),
+        |s, v| spec_serialize_u16_le_100(s, v),
+    );
 }
 
-
-pub open spec fn spec_parse_5_bytes_9634846430650598249(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_5_bytes_9634846430650598249(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     match spec_parse_bytes(s, 5) {
         Ok((s, n, xs)) => {
             if xs == seq![1u8, 2u8, 3u8, 4u8, 5u8] {
@@ -5931,13 +7115,15 @@ pub open spec fn spec_parse_5_bytes_9634846430650598249(s: SpecStream) -> SpecPa
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_5_bytes_9634846430650598249(s: SpecStream, vs: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_5_bytes_9634846430650598249(
+    s: SpecStream,
+    vs: Seq<u8>,
+) -> SpecSerializeResult {
     if vs == seq![1u8, 2u8, 3u8, 4u8, 5u8] {
         spec_serialize_bytes(s, vs, 5)
     } else {
@@ -5945,65 +7131,95 @@ pub open spec fn spec_serialize_5_bytes_9634846430650598249(s: SpecStream, vs: S
     }
 }
 
-
 pub proof fn lemma_parse_5_bytes_9634846430650598249_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_5_bytes_9634846430650598249(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_5_bytes_9634846430650598249(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_5_bytes_9634846430650598249 = |s| spec_parse_5_bytes_9634846430650598249(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_5_bytes_9634846430650598249, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_well_behaved_on(spec_parse_5_bytes_9634846430650598249, s) by {
         lemma_parse_5_bytes_9634846430650598249_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_5_bytes_9634846430650598249_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_5_bytes_9634846430650598249, s, vs) by {
+    let spec_serialize_5_bytes_9634846430650598249 = |s, vs|
+        spec_serialize_5_bytes_9634846430650598249(s, vs);
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_5_bytes_9634846430650598249, s, vs) by {
         lemma_serialize_5_bytes_9634846430650598249_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_5_bytes_9634846430650598249_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_5_bytes_9634846430650598249(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_5_bytes_9634846430650598249(s, v)),
 {
     reveal(prop_serialize_deterministic);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, v| spec_serialize_5_bytes_9634846430650598249(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_5_bytes_9634846430650598249, s1, s2, v) by {
+    let spec_serialize_5_bytes_9634846430650598249 = |s, v|
+        spec_serialize_5_bytes_9634846430650598249(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_5_bytes_9634846430650598249, s1, s2, v) by {
         lemma_serialize_5_bytes_9634846430650598249_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_5_bytes_9634846430650598249_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_5_bytes_9634846430650598249(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_5_bytes_9634846430650598249(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_5_bytes_9634846430650598249 = |s| spec_parse_5_bytes_9634846430650598249(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_5_bytes_9634846430650598249, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_5_bytes_9634846430650598249, s1, s2) by {
         lemma_parse_5_bytes_9634846430650598249_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_5_bytes_9634846430650598249_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_5_bytes_9634846430650598249(s), |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_5_bytes_9634846430650598249(s),
+            |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_5_bytes_9634846430650598249 = |s| spec_parse_5_bytes_9634846430650598249(s);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_5_bytes_9634846430650598249, spec_serialize_5_bytes_9634846430650598249, s) by {
+    let spec_serialize_5_bytes_9634846430650598249 = |s, vs|
+        spec_serialize_5_bytes_9634846430650598249(s, vs);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(
+            spec_parse_5_bytes_9634846430650598249,
+            spec_serialize_5_bytes_9634846430650598249,
+            s,
+        ) by {
         lemma_parse_5_bytes_9634846430650598249_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_5_bytes_9634846430650598249_correct()
-    ensures prop_parse_correct(|s| spec_parse_5_bytes_9634846430650598249(s), |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs))
+    ensures
+        prop_parse_correct(
+            |s| spec_parse_5_bytes_9634846430650598249(s),
+            |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs),
+        ),
 {
     reveal(prop_parse_correct);
     let spec_parse_5_bytes_9634846430650598249 = |s| spec_parse_5_bytes_9634846430650598249(s);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_5_bytes_9634846430650598249, spec_serialize_5_bytes_9634846430650598249, s, vs) by {
+    let spec_serialize_5_bytes_9634846430650598249 = |s, vs|
+        spec_serialize_5_bytes_9634846430650598249(s, vs);
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_5_bytes_9634846430650598249,
+            spec_serialize_5_bytes_9634846430650598249,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_5_bytes_9634846430650598249_correct_on(s, vs);
         }
@@ -6011,45 +7227,76 @@ pub proof fn lemma_parse_5_bytes_9634846430650598249_correct()
 }
 
 proof fn lemma_parse_5_bytes_9634846430650598249_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_5_bytes_9634846430650598249(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_5_bytes_9634846430650598249(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 5)
 }
 
 proof fn lemma_serialize_5_bytes_9634846430650598249_well_behaved_on(s: SpecStream, vs: Seq<u8>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(
+            |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs),
+            s,
+            vs,
+        ),
 {
     lemma_serialize_bytes_well_behaved_on(s, vs, 5)
 }
 
-proof fn lemma_serialize_5_bytes_9634846430650598249_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_5_bytes_9634846430650598249(s, v), s1, s2, v)
+proof fn lemma_serialize_5_bytes_9634846430650598249_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: Seq<u8>,
+)
+    ensures
+        prop_serialize_deterministic_on(
+            |s, v| spec_serialize_5_bytes_9634846430650598249(s, v),
+            s1,
+            s2,
+            v,
+        ),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 5)
 }
 
 proof fn lemma_parse_5_bytes_9634846430650598249_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_5_bytes_9634846430650598249(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_5_bytes_9634846430650598249(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 5)
 }
 
 proof fn lemma_parse_5_bytes_9634846430650598249_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_5_bytes_9634846430650598249(s), |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_5_bytes_9634846430650598249(s),
+            |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 5)
 }
 
 proof fn lemma_parse_5_bytes_9634846430650598249_correct_on(s: SpecStream, vs: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_5_bytes_9634846430650598249(s), |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_5_bytes_9634846430650598249(s),
+            |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs),
+            s,
+            vs,
+        ),
 {
     lemma_parse_bytes_correct_on(s, vs, 5)
 }
 
-pub exec fn slice_u8_check_9634846430650598249(xs : &[u8]) -> (res : bool)
-    requires xs.dview().len() == 5
-    ensures res <==> xs.dview() == seq![1u8, 2u8, 3u8, 4u8, 5u8]
+pub exec fn slice_u8_check_9634846430650598249(xs: &[u8]) -> (res: bool)
+    requires
+        xs.dview().len() == 5,
+    ensures
+        res <==> xs.dview() == seq![1u8, 2u8, 3u8, 4u8, 5u8],
 {
     let constant: [u8; 5] = [1u8, 2u8, 3u8, 4u8, 5u8];
     assert(constant.view() =~= seq![1u8, 2u8, 3u8, 4u8, 5u8]);
@@ -6064,7 +7311,9 @@ pub exec fn slice_u8_check_9634846430650598249(xs : &[u8]) -> (res : bool)
         let (constant_i, xi) = (*array_index_get(&constant, i), *slice_index_get(&xs, i));
         if constant_i == xi {
             i = i + 1;
-            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(xi));
+            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(
+                xi,
+            ));
         } else {
             return false;
         }
@@ -6072,14 +7321,13 @@ pub exec fn slice_u8_check_9634846430650598249(xs : &[u8]) -> (res : bool)
     assert(xs.dview() =~= seq![1u8, 2u8, 3u8, 4u8, 5u8]) by {
         assert(xs.dview().subrange(0, 5) =~= xs.dview());
     }
-
     true
 }
 
 pub exec fn parse_5_bytes_9634846430650598249(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
         prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_5_bytes_9634846430650598249(s)),
-        res.is_ok() ==> res.unwrap().2.dview() == seq![1u8, 2u8, 3u8, 4u8, 5u8]
+        res.is_ok() ==> res.unwrap().2.dview() == seq![1u8, 2u8, 3u8, 4u8, 5u8],
 {
     let (s0, n, xs) = parse_bytes(s, 5)?;
     assert(xs.dview().len() == 5);
@@ -6091,9 +7339,17 @@ pub exec fn parse_5_bytes_9634846430650598249(s: Stream) -> (res: ParseResult<&[
     }
 }
 
-pub exec fn serialize_5_bytes_9634846430650598249(data: &mut [u8], start: usize, vs: &[u8]) -> (res: SerializeResult)
+pub exec fn serialize_5_bytes_9634846430650598249(data: &mut [u8], start: usize, vs: &[u8]) -> (res:
+    SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_5_bytes_9634846430650598249(s, vs),
+        ),
 {
     if vs.length() == 5 && slice_u8_check_9634846430650598249(vs) {
         serialize_bytes(data, start, vs, 5)
@@ -6101,21 +7357,21 @@ pub exec fn serialize_5_bytes_9634846430650598249(data: &mut [u8], start: usize,
         Err(SerializeError::ConstMismatch)
     }
 }
+
 pub struct SpecQuintuple {
     a: u8,
     b: u16,
     c: Seq<u8>,
     d: u32,
     e: Seq<u8>,
-
 }
+
 pub struct Quintuple {
     a: u8,
     b: u16,
     c: Vec<u8>,
     d: u32,
     e: Vec<u8>,
-
 }
 
 pub open spec fn spec_parse_5_fold<R1, R2, R3, R4, R5>(
@@ -6123,23 +7379,29 @@ pub open spec fn spec_parse_5_fold<R1, R2, R3, R4, R5>(
     parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
     parser3: spec_fn(SpecStream) -> SpecParseResult<R3>,
     parser4: spec_fn(SpecStream) -> SpecParseResult<R4>,
-    parser5: spec_fn(SpecStream) -> SpecParseResult<R5>) -> spec_fn(SpecStream) -> SpecParseResult<((((R1, R2), R3), R4), R5)>
-{
-    spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4), parser5)
+    parser5: spec_fn(SpecStream) -> SpecParseResult<R5>,
+) -> spec_fn(SpecStream) -> SpecParseResult<((((R1, R2), R3), R4), R5)> {
+    spec_parse_pair(
+        spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4),
+        parser5,
+    )
 }
-
-
 
 pub open spec fn spec_serialize_5_fold<T1, T2, T3, T4, T5>(
     serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
     serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
     serializer3: spec_fn(SpecStream, T3) -> SpecSerializeResult,
     serializer4: spec_fn(SpecStream, T4) -> SpecSerializeResult,
-    serializer5: spec_fn(SpecStream, T5) -> SpecSerializeResult) -> spec_fn(SpecStream, ((((T1, T2), T3), T4), T5)) -> SpecSerializeResult
-{
-    spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3), serializer4), serializer5)
+    serializer5: spec_fn(SpecStream, T5) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, ((((T1, T2), T3), T4), T5)) -> SpecSerializeResult {
+    spec_serialize_pair(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3),
+            serializer4,
+        ),
+        serializer5,
+    )
 }
-
 
 pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
     exec_parser1: P1,
@@ -6152,8 +7414,8 @@ pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
     Ghost(spec_parser3): Ghost<spec_fn(SpecStream) -> SpecParseResult<R3::V>>,
     Ghost(spec_parser4): Ghost<spec_fn(SpecStream) -> SpecParseResult<R4::V>>,
     Ghost(spec_parser5): Ghost<spec_fn(SpecStream) -> SpecParseResult<R5::V>>,
-    s: Stream<'a>) -> (res: ParseResult<((((R1, R2), R3), R4), R5)>)
-    where
+    s: Stream<'a>,
+) -> (res: ParseResult<((((R1, R2), R3), R4), R5)>) where
     R1: DView,
     P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
     R2: DView,
@@ -6164,6 +7426,7 @@ pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
     P4: FnOnce(Stream<'a>) -> ParseResult<R4>,
     R5: DView,
     P5: FnOnce(Stream<'a>) -> ParseResult<R5>,
+
     requires
         prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
@@ -6171,75 +7434,155 @@ pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
         prop_parse_exec_spec_equiv(exec_parser4, spec_parser4),
         prop_parse_exec_spec_equiv(exec_parser5, spec_parser5),
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, spec_parse_5_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4, spec_parser5))
+        prop_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_5_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4, spec_parser5),
+        ),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), { parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s) };
-    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), { parse_pair(parse_3_fold, exec_parser4, Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), Ghost(spec_parser4), s) };
-    parse_pair(parse_4_fold, exec_parser5, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), Ghost(spec_parser5), s)
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+            ),
+        {
+            parse_pair(
+                parse_2_fold,
+                exec_parser3,
+                Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+                Ghost(spec_parser3),
+                s,
+            )
+        };
+    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                    spec_parser4,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_3_fold,
+                exec_parser4,
+                Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)),
+                Ghost(spec_parser4),
+                s,
+            )
+        };
+    parse_pair(
+        parse_4_fold,
+        exec_parser5,
+        Ghost(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                spec_parser4,
+            ),
+        ),
+        Ghost(spec_parser5),
+        s,
+    )
 }
 
-
-pub open spec fn spec_parse_quintuple(s: SpecStream) -> SpecParseResult<((((u8, u16), Seq<u8>), u32), Seq<u8>)>
-{
+pub open spec fn spec_parse_quintuple(s: SpecStream) -> SpecParseResult<
+    ((((u8, u16), Seq<u8>), u32), Seq<u8>),
+> {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
     let spec_parse_5_bytes_9634846430650598249 = |s| spec_parse_5_bytes_9634846430650598249(s);
     let spec_parse_u32_le = |s| spec_parse_u32_le(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
 
-    spec_parse_5_fold(spec_parse_u8_le, spec_parse_u16_le_100, spec_parse_5_bytes_9634846430650598249, spec_parse_u32_le, spec_parse_256_bytes)(s)
+    spec_parse_5_fold(
+        spec_parse_u8_le,
+        spec_parse_u16_le_100,
+        spec_parse_5_bytes_9634846430650598249,
+        spec_parse_u32_le,
+        spec_parse_256_bytes,
+    )(s)
 }
 
-pub open spec fn spec_serialize_quintuple(s: SpecStream, v: ((((u8, u16), Seq<u8>), u32), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_quintuple(
+    s: SpecStream,
+    v: ((((u8, u16), Seq<u8>), u32), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, v| spec_serialize_5_bytes_9634846430650598249(s, v);
+    let spec_serialize_5_bytes_9634846430650598249 = |s, v|
+        spec_serialize_5_bytes_9634846430650598249(s, v);
     let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
 
-    spec_serialize_5_fold(spec_serialize_u8_le, spec_serialize_u16_le_100, spec_serialize_5_bytes_9634846430650598249, spec_serialize_u32_le, spec_serialize_256_bytes)(s, v)
+    spec_serialize_5_fold(
+        spec_serialize_u8_le,
+        spec_serialize_u16_le_100,
+        spec_serialize_5_bytes_9634846430650598249,
+        spec_serialize_u32_le,
+        spec_serialize_256_bytes,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_quintuple_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_quintuple(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_quintuple(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_quintuple = |s| spec_parse_quintuple(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_quintuple, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_quintuple, s) by {
         lemma_parse_quintuple_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_quintuple_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_quintuple(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_quintuple(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_quintuple = |s, v| spec_serialize_quintuple(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_quintuple, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_quintuple, s, v) by {
         lemma_serialize_quintuple_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_quintuple_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_quintuple(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_quintuple(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_quintuple = |s, v| spec_serialize_quintuple(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_quintuple, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_quintuple, s1, s2, v) by {
         lemma_serialize_quintuple_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_quintuple_correct()
-    ensures prop_parse_correct(|s| spec_parse_quintuple(s), |s, v| spec_serialize_quintuple(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_quintuple(s), |s, v| spec_serialize_quintuple(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_quintuple = |s| spec_parse_quintuple(s);
     let spec_serialize_quintuple = |s, v| spec_serialize_quintuple(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_quintuple, spec_serialize_quintuple, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_quintuple,
+            spec_serialize_quintuple,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_quintuple_correct_on(s, v);
         }
@@ -6247,26 +7590,36 @@ pub proof fn lemma_parse_quintuple_correct()
 }
 
 pub proof fn lemma_parse_quintuple_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_quintuple(s), |s, v| spec_serialize_quintuple(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_quintuple(s),
+            |s, v| spec_serialize_quintuple(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_quintuple = |s| spec_parse_quintuple(s);
     let spec_serialize_quintuple = |s, v| spec_serialize_quintuple(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_quintuple, spec_serialize_quintuple, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_quintuple, spec_serialize_quintuple, s) by {
         lemma_parse_quintuple_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_quintuple_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_quintuple(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_quintuple(s)),
 {
     lemma_parse_quintuple_serialize_inverse();
     lemma_serialize_quintuple_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_quintuple(s), |s, v| spec_serialize_quintuple(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_quintuple(s),
+        |s, v| spec_serialize_quintuple(s, v),
+    );
 }
 
 pub proof fn lemma_parse_quintuple_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_quintuple(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_quintuple(s), s),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -6279,17 +7632,41 @@ pub proof fn lemma_parse_quintuple_well_behaved_on(s: SpecStream)
     lemma_parse_u32_le_well_behaved();
     lemma_parse_256_bytes_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le), spec_parse_256_bytes, s);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+    );
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+                spec_parse_5_bytes_9634846430650598249,
+            ),
+            spec_parse_u32_le,
+        ),
+        spec_parse_256_bytes,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_quintuple_well_behaved_on(s: SpecStream, v: ((((u8, u16), Seq<u8>), u32), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_quintuple(s, v), s, v)
+pub proof fn lemma_serialize_quintuple_well_behaved_on(
+    s: SpecStream,
+    v: ((((u8, u16), Seq<u8>), u32), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_quintuple(s, v), s, v),
 {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, v| spec_serialize_5_bytes_9634846430650598249(s, v);
+    let spec_serialize_5_bytes_9634846430650598249 = |s, v|
+        spec_serialize_5_bytes_9634846430650598249(s, v);
     let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
     lemma_serialize_u8_le_well_behaved();
@@ -6298,17 +7675,43 @@ pub proof fn lemma_serialize_quintuple_well_behaved_on(s: SpecStream, v: ((((u8,
     lemma_serialize_u32_le_well_behaved();
     lemma_serialize_256_bytes_well_behaved();
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_u16_le_100);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le), spec_serialize_256_bytes, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+                spec_serialize_5_bytes_9634846430650598249,
+            ),
+            spec_serialize_u32_le,
+        ),
+        spec_serialize_256_bytes,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_quintuple_deterministic_on(s1: SpecStream, s2: SpecStream, v: ((((u8, u16), Seq<u8>), u32), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_quintuple(s, v), s1, s2, v)
+pub proof fn lemma_serialize_quintuple_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: ((((u8, u16), Seq<u8>), u32), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_quintuple(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, v| spec_serialize_5_bytes_9634846430650598249(s, v);
+    let spec_serialize_5_bytes_9634846430650598249 = |s, v|
+        spec_serialize_5_bytes_9634846430650598249(s, v);
     let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
     lemma_serialize_u8_le_well_behaved();
@@ -6323,16 +7726,56 @@ pub proof fn lemma_serialize_quintuple_deterministic_on(s1: SpecStream, s2: Spec
     lemma_serialize_256_bytes_deterministic();
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_u16_le_100);
     lemma_serialize_pair_deterministic(spec_serialize_u8_le, spec_serialize_u16_le_100);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le), spec_serialize_256_bytes, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+                spec_serialize_5_bytes_9634846430650598249,
+            ),
+            spec_serialize_u32_le,
+        ),
+        spec_serialize_256_bytes,
+        s1,
+        s2,
+        v,
+    );
 }
 
-pub proof fn lemma_parse_quintuple_correct_on(s: SpecStream, v: ((((u8, u16), Seq<u8>), u32), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_quintuple(s), |s, v| spec_serialize_quintuple(s, v), s, v)
+pub proof fn lemma_parse_quintuple_correct_on(
+    s: SpecStream,
+    v: ((((u8, u16), Seq<u8>), u32), Seq<u8>),
+)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_quintuple(s),
+            |s, v| spec_serialize_quintuple(s, v),
+            s,
+            v,
+        ),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -6341,7 +7784,8 @@ pub proof fn lemma_parse_quintuple_correct_on(s: SpecStream, v: ((((u8, u16), Se
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, v| spec_serialize_5_bytes_9634846430650598249(s, v);
+    let spec_serialize_5_bytes_9634846430650598249 = |s, v|
+        spec_serialize_5_bytes_9634846430650598249(s, v);
     let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
     lemma_serialize_u8_le_well_behaved();
@@ -6367,20 +7811,92 @@ pub proof fn lemma_parse_quintuple_correct_on(s: SpecStream, v: ((((u8, u16), Se
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_u16_le_100);
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_u16_le_100);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le, spec_parse_u16_le_100);
-    lemma_parse_pair_correct(spec_parse_u8_le, spec_parse_u16_le_100, spec_serialize_u8_le, spec_serialize_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249, spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le), spec_parse_256_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le), spec_serialize_256_bytes, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u8_le,
+        spec_parse_u16_le_100,
+        spec_serialize_u8_le,
+        spec_serialize_u16_le_100,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+                spec_parse_5_bytes_9634846430650598249,
+            ),
+            spec_parse_u32_le,
+        ),
+        spec_parse_256_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+                spec_serialize_5_bytes_9634846430650598249,
+            ),
+            spec_serialize_u32_le,
+        ),
+        spec_serialize_256_bytes,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_quintuple_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_quintuple(s), |s, v| spec_serialize_quintuple(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_quintuple(s),
+            |s, v| spec_serialize_quintuple(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -6389,7 +7905,8 @@ pub proof fn lemma_parse_quintuple_serialize_inverse_on(s: SpecStream)
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_5_bytes_9634846430650598249 = |s, v| spec_serialize_5_bytes_9634846430650598249(s, v);
+    let spec_serialize_5_bytes_9634846430650598249 = |s, v|
+        spec_serialize_5_bytes_9634846430650598249(s, v);
     let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
     lemma_parse_u8_le_well_behaved();
@@ -6409,28 +7926,87 @@ pub proof fn lemma_parse_quintuple_serialize_inverse_on(s: SpecStream)
     lemma_parse_256_bytes_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_u16_le_100);
     lemma_serialize_pair_well_behaved(spec_serialize_u8_le, spec_serialize_u16_le_100);
-    lemma_parse_pair_serialize_inverse(spec_parse_u8_le, spec_parse_u16_le_100, spec_serialize_u8_le, spec_serialize_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249, spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le), spec_parse_256_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100), spec_serialize_5_bytes_9634846430650598249), spec_serialize_u32_le), spec_serialize_256_bytes, s);
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u8_le,
+        spec_parse_u16_le_100,
+        spec_serialize_u8_le,
+        spec_serialize_u16_le_100,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+        spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+        spec_serialize_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+            spec_serialize_5_bytes_9634846430650598249,
+        ),
+        spec_serialize_u32_le,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+                spec_parse_5_bytes_9634846430650598249,
+            ),
+            spec_parse_u32_le,
+        ),
+        spec_parse_256_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u8_le, spec_serialize_u16_le_100),
+                spec_serialize_5_bytes_9634846430650598249,
+            ),
+            spec_serialize_u32_le,
+        ),
+        spec_serialize_256_bytes,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_quintuple_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_quintuple(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_quintuple(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_quintuple = |s| spec_parse_quintuple(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_quintuple, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_quintuple, s1, s2) by {
         lemma_parse_quintuple_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_quintuple_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_quintuple(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_quintuple(s), s1, s2),
 {
     let spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -6449,102 +8025,179 @@ pub proof fn lemma_parse_quintuple_strong_prefix_on(s1: SpecStream, s2: SpecStre
     lemma_parse_256_bytes_strong_prefix();
     lemma_parse_pair_well_behaved(spec_parse_u8_le, spec_parse_u16_le_100);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le, spec_parse_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le);
-    lemma_parse_pair_strong_prefix_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100), spec_parse_5_bytes_9634846430650598249), spec_parse_u32_le), spec_parse_256_bytes, s1, s2);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+        spec_parse_5_bytes_9634846430650598249,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+            spec_parse_5_bytes_9634846430650598249,
+        ),
+        spec_parse_u32_le,
+    );
+    lemma_parse_pair_strong_prefix_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le, spec_parse_u16_le_100),
+                spec_parse_5_bytes_9634846430650598249,
+            ),
+            spec_parse_u32_le,
+        ),
+        spec_parse_256_bytes,
+        s1,
+        s2,
+    );
 }
 
 pub exec fn parse_quintuple(s: Stream) -> (res: ParseResult<((((u8, u16), &[u8]), u32), &[u8])>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_quintuple(s))
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_quintuple(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le = |s| spec_parse_u8_le(s);
     let ghost spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
-    let ghost spec_parse_5_bytes_9634846430650598249 = |s| spec_parse_5_bytes_9634846430650598249(s);
+    let ghost spec_parse_5_bytes_9634846430650598249 = |s|
+        spec_parse_5_bytes_9634846430650598249(s);
     let ghost spec_parse_u32_le = |s| spec_parse_u32_le(s);
     let ghost spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
 
-    parse_5_fold(parse_u8_le, parse_u16_le_100, parse_5_bytes_9634846430650598249, parse_u32_le, parse_256_bytes, Ghost(spec_parse_u8_le), Ghost(spec_parse_u16_le_100), Ghost(spec_parse_5_bytes_9634846430650598249), Ghost(spec_parse_u32_le), Ghost(spec_parse_256_bytes), s)
+    parse_5_fold(
+        parse_u8_le,
+        parse_u16_le_100,
+        parse_5_bytes_9634846430650598249,
+        parse_u32_le,
+        parse_256_bytes,
+        Ghost(spec_parse_u8_le),
+        Ghost(spec_parse_u16_le_100),
+        Ghost(spec_parse_5_bytes_9634846430650598249),
+        Ghost(spec_parse_u32_le),
+        Ghost(spec_parse_256_bytes),
+        s,
+    )
 }
-pub exec fn serialize_quintuple(data: &mut [u8], start: usize, v: ((((u8, u16), &[u8]), u32), &[u8])) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_quintuple(s, v))
+
+pub exec fn serialize_quintuple(
+    data: &mut [u8],
+    start: usize,
+    v: ((((u8, u16), &[u8]), u32), &[u8]),
+) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_quintuple(s, v),
+        ),
 {
     let ((((v0, v1), v2), v3), v4) = v;
     let (new_start, n0) = serialize_u8_le(data, start, v0)?;
 
-let (new_start, n1) = serialize_u16_le_100(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_5_bytes_9634846430650598249(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n3) = serialize_u32_le(data, new_start, v3)?;
-    if n0 + n1 + n2 > usize::MAX - n3 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n4) = serialize_256_bytes(data, new_start, v4)?;
-    if n0 + n1 + n2 + n3 > usize::MAX - n4 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_u16_le_100(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_5_bytes_9634846430650598249(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n3) = serialize_u32_le(data, new_start, v3)?;
+    if n0 + n1 + n2 > usize::MAX - n3 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n4) = serialize_256_bytes(data, new_start, v4)?;
+    if n0 + n1 + n2 + n3 > usize::MAX - n4 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2 + n3 + n4))
 }
 
-                    
-pub open spec fn spec_parse_3_u16s(s: SpecStream) -> SpecParseResult<Seq<u16>>
-{
+pub open spec fn spec_parse_3_u16s(s: SpecStream) -> SpecParseResult<Seq<u16>> {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     spec_parse_repeat_n(spec_parse_u16_le, 3)(s)
 }
 
-pub open spec fn spec_serialize_3_u16s(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_3_u16s(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     spec_serialize_repeat_n(spec_serialize_u16_le, 3)(s, vs)
 }
 
 pub proof fn lemma_parse_3_u16s_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_3_u16s(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_3_u16s(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_3_u16s = |s| spec_parse_3_u16s(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_3_u16s, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_3_u16s, s) by {
         lemma_parse_3_u16s_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_3_u16s_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_3_u16s(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_3_u16s(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_3_u16s = |s, vs| spec_serialize_3_u16s(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_3_u16s, s, vs) by {
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_3_u16s, s, vs) by {
         lemma_serialize_3_u16s_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_3_u16s_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_3_u16s(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_3_u16s(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_3_u16s = |s, vs| spec_serialize_3_u16s(s, vs);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_3_u16s, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_3_u16s, s1, s2, v) by {
         lemma_serialize_3_u16s_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_3_u16s_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_3_u16s(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_3_u16s(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_3_u16s = |s| spec_parse_3_u16s(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_3_u16s, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_3_u16s, s1, s2) by {
         lemma_parse_3_u16s_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_3_u16s_correct()
-    ensures prop_parse_correct(|s| spec_parse_3_u16s(s), |s, vs| spec_serialize_3_u16s(s, vs))
+    ensures
+        prop_parse_correct(|s| spec_parse_3_u16s(s), |s, vs| spec_serialize_3_u16s(s, vs)),
 {
     reveal(prop_parse_correct);
     let spec_parse_3_u16s = |s| spec_parse_3_u16s(s);
     let spec_serialize_3_u16s = |s, vs| spec_serialize_3_u16s(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_3_u16s, spec_serialize_3_u16s, s, vs) by {
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_3_u16s,
+            spec_serialize_3_u16s,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_3_u16s_correct_on(s, vs);
         }
@@ -6552,26 +8205,33 @@ pub proof fn lemma_parse_3_u16s_correct()
 }
 
 pub proof fn lemma_parse_3_u16s_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_3_u16s(s), |s, v| spec_serialize_3_u16s(s, v))
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_3_u16s(s), |s, v| spec_serialize_3_u16s(s, v)),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_3_u16s = |s| spec_parse_3_u16s(s);
     let spec_serialize_3_u16s = |s, vs| spec_serialize_3_u16s(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_3_u16s, spec_serialize_3_u16s, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_3_u16s, spec_serialize_3_u16s, s) by {
         lemma_parse_3_u16s_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_3_u16s_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_3_u16s(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_3_u16s(s)),
 {
     lemma_parse_3_u16s_serialize_inverse();
     lemma_serialize_3_u16s_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_3_u16s(s), |s, v| spec_serialize_3_u16s(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_3_u16s(s),
+        |s, v| spec_serialize_3_u16s(s, v),
+    );
 }
 
 proof fn lemma_parse_3_u16s_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_3_u16s(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_3_u16s(s), s),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -6579,7 +8239,8 @@ proof fn lemma_parse_3_u16s_well_behaved_on(s: SpecStream)
 }
 
 proof fn lemma_serialize_3_u16s_well_behaved_on(s: SpecStream, vs: Seq<u16>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_3_u16s(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(|s, vs| spec_serialize_3_u16s(s, vs), s, vs),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -6587,7 +8248,8 @@ proof fn lemma_serialize_3_u16s_well_behaved_on(s: SpecStream, vs: Seq<u16>)
 }
 
 proof fn lemma_serialize_3_u16s_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u16>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_3_u16s(s, v), s1, s2, v)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_3_u16s(s, v), s1, s2, v),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -6596,7 +8258,8 @@ proof fn lemma_serialize_3_u16s_deterministic_on(s1: SpecStream, s2: SpecStream,
 }
 
 proof fn lemma_parse_3_u16s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_3_u16s(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_3_u16s(s), s1, s2),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -6605,8 +8268,15 @@ proof fn lemma_parse_3_u16s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
 }
 
 proof fn lemma_parse_3_u16s_correct_on(s: SpecStream, vs: Seq<u16>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_3_u16s(s), |s, vs| spec_serialize_3_u16s(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_3_u16s(s),
+            |s, vs| spec_serialize_3_u16s(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -6618,7 +8288,12 @@ proof fn lemma_parse_3_u16s_correct_on(s: SpecStream, vs: Seq<u16>)
 }
 
 proof fn lemma_parse_3_u16s_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_3_u16s(s), |s, v| spec_serialize_3_u16s(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_3_u16s(s),
+            |s, v| spec_serialize_3_u16s(s, v),
+            s,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -6630,9 +8305,11 @@ proof fn lemma_parse_3_u16s_serialize_inverse_on(s: SpecStream)
 
 pub exec fn parse_3_u16s(s: Stream) -> (res: ParseResult<Vec<u16>>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_3_u16s(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_3_u16s(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
 
     let ghost spec_parse_u16_le = |s| spec_parse_u16_le(s);
 
@@ -6642,7 +8319,14 @@ pub exec fn parse_3_u16s(s: Stream) -> (res: ParseResult<Vec<u16>>)
 #[verifier(external_body)]
 pub exec fn serialize_3_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_3_u16s(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_3_u16s(s, vs),
+        ),
 {
     if vs.length() != 3 {
         return Err(SerializeError::RepeatNMismatch);
@@ -6651,12 +8335,10 @@ pub exec fn serialize_3_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res:
     } else if start > data.length() {
         return Err(SerializeError::NotEnoughSpace);
     }
-
     let (mut start, mut i, mut m): (usize, usize, usize) = (start, 0, 0);
-    while i < 3
-    {
+    while i < 3 {
         i = i + 1;
-        let v = *slice_index_get(&vs, i - 1); // vs[i - 1]
+        let v = *slice_index_get(&vs, i - 1);  // vs[i - 1]
         let res1 = serialize_u16_le(data, start, v);
         match res1 {
             Ok((new_start, m1)) => {
@@ -6666,18 +8348,16 @@ pub exec fn serialize_3_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res:
                     start = new_start;
                     m = m + m1;
                 }
-            }
+            },
             Err(e) => {
                 return Err(e);
-            }
+            },
         }
     }
-
     Ok((start, m))
 }
 
-pub open spec fn spec_parse_3_u16s_1168375106280276899(s: SpecStream) -> SpecParseResult<Seq<u16>>
-{
+pub open spec fn spec_parse_3_u16s_1168375106280276899(s: SpecStream) -> SpecParseResult<Seq<u16>> {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     match spec_parse_repeat_n(spec_parse_u16_le, 3)(s) {
         Ok((s, n, xs)) => {
@@ -6686,13 +8366,15 @@ pub open spec fn spec_parse_3_u16s_1168375106280276899(s: SpecStream) -> SpecPar
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_3_u16s_1168375106280276899(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_3_u16s_1168375106280276899(
+    s: SpecStream,
+    vs: Seq<u16>,
+) -> SpecSerializeResult {
     if vs == seq![0u16, 1u16, 2u16] {
         let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
         spec_serialize_repeat_n(spec_serialize_u16_le, 3)(s, vs)
@@ -6702,63 +8384,94 @@ pub open spec fn spec_serialize_3_u16s_1168375106280276899(s: SpecStream, vs: Se
 }
 
 pub proof fn lemma_parse_3_u16s_1168375106280276899_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_3_u16s_1168375106280276899(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_3_u16s_1168375106280276899(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_3_u16s_1168375106280276899 = |s| spec_parse_3_u16s_1168375106280276899(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_3_u16s_1168375106280276899, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_well_behaved_on(spec_parse_3_u16s_1168375106280276899, s) by {
         lemma_parse_3_u16s_1168375106280276899_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_3_u16s_1168375106280276899_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_3_u16s_1168375106280276899, s, vs) by {
+    let spec_serialize_3_u16s_1168375106280276899 = |s, vs|
+        spec_serialize_3_u16s_1168375106280276899(s, vs);
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_3_u16s_1168375106280276899, s, vs) by {
         lemma_serialize_3_u16s_1168375106280276899_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_3_u16s_1168375106280276899_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_3_u16s_1168375106280276899(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_3_u16s_1168375106280276899(s, v)),
 {
     reveal(prop_serialize_deterministic);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, v| spec_serialize_3_u16s_1168375106280276899(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_3_u16s_1168375106280276899, s1, s2, v) by {
+    let spec_serialize_3_u16s_1168375106280276899 = |s, v|
+        spec_serialize_3_u16s_1168375106280276899(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_3_u16s_1168375106280276899, s1, s2, v) by {
         lemma_serialize_3_u16s_1168375106280276899_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_3_u16s_1168375106280276899_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_3_u16s_1168375106280276899(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_3_u16s_1168375106280276899(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_3_u16s_1168375106280276899 = |s| spec_parse_3_u16s_1168375106280276899(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_3_u16s_1168375106280276899, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_3_u16s_1168375106280276899, s1, s2) by {
         lemma_parse_3_u16s_1168375106280276899_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_3_u16s_1168375106280276899_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_3_u16s_1168375106280276899(s), |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_3_u16s_1168375106280276899(s),
+            |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_3_u16s_1168375106280276899 = |s| spec_parse_3_u16s_1168375106280276899(s);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_3_u16s_1168375106280276899, spec_serialize_3_u16s_1168375106280276899, s) by {
+    let spec_serialize_3_u16s_1168375106280276899 = |s, vs|
+        spec_serialize_3_u16s_1168375106280276899(s, vs);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(
+            spec_parse_3_u16s_1168375106280276899,
+            spec_serialize_3_u16s_1168375106280276899,
+            s,
+        ) by {
         lemma_parse_3_u16s_1168375106280276899_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_3_u16s_1168375106280276899_correct()
-    ensures prop_parse_correct(|s| spec_parse_3_u16s_1168375106280276899(s), |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs))
+    ensures
+        prop_parse_correct(
+            |s| spec_parse_3_u16s_1168375106280276899(s),
+            |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs),
+        ),
 {
     reveal(prop_parse_correct);
     let spec_parse_3_u16s_1168375106280276899 = |s| spec_parse_3_u16s_1168375106280276899(s);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_3_u16s_1168375106280276899, spec_serialize_3_u16s_1168375106280276899, s, vs) by {
+    let spec_serialize_3_u16s_1168375106280276899 = |s, vs|
+        spec_serialize_3_u16s_1168375106280276899(s, vs);
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_3_u16s_1168375106280276899,
+            spec_serialize_3_u16s_1168375106280276899,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_3_u16s_1168375106280276899_correct_on(s, vs);
         }
@@ -6766,7 +8479,8 @@ pub proof fn lemma_parse_3_u16s_1168375106280276899_correct()
 }
 
 proof fn lemma_parse_3_u16s_1168375106280276899_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_3_u16s_1168375106280276899(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_3_u16s_1168375106280276899(s), s),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -6774,15 +8488,30 @@ proof fn lemma_parse_3_u16s_1168375106280276899_well_behaved_on(s: SpecStream)
 }
 
 proof fn lemma_serialize_3_u16s_1168375106280276899_well_behaved_on(s: SpecStream, vs: Seq<u16>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(
+            |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
     lemma_serialize_repeat_n_well_behaved_on(spec_serialize_u16_le, 3, s, vs);
 }
 
-pub proof fn lemma_serialize_3_u16s_1168375106280276899_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u16>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_3_u16s_1168375106280276899(s, v), s1, s2, v)
+pub proof fn lemma_serialize_3_u16s_1168375106280276899_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: Seq<u16>,
+)
+    ensures
+        prop_serialize_deterministic_on(
+            |s, v| spec_serialize_3_u16s_1168375106280276899(s, v),
+            s1,
+            s2,
+            v,
+        ),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -6791,7 +8520,8 @@ pub proof fn lemma_serialize_3_u16s_1168375106280276899_deterministic_on(s1: Spe
 }
 
 proof fn lemma_parse_3_u16s_1168375106280276899_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_3_u16s_1168375106280276899(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_3_u16s_1168375106280276899(s), s1, s2),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -6800,7 +8530,12 @@ proof fn lemma_parse_3_u16s_1168375106280276899_strong_prefix_on(s1: SpecStream,
 }
 
 proof fn lemma_parse_3_u16s_1168375106280276899_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_3_u16s_1168375106280276899(s), |s, v| spec_serialize_3_u16s_1168375106280276899(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_3_u16s_1168375106280276899(s),
+            |s, v| spec_serialize_3_u16s_1168375106280276899(s, v),
+            s,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -6811,8 +8546,15 @@ proof fn lemma_parse_3_u16s_1168375106280276899_serialize_inverse_on(s: SpecStre
 }
 
 proof fn lemma_parse_3_u16s_1168375106280276899_correct_on(s: SpecStream, vs: Seq<u16>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_3_u16s_1168375106280276899(s), |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_3_u16s_1168375106280276899(s),
+            |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -6823,9 +8565,11 @@ proof fn lemma_parse_3_u16s_1168375106280276899_correct_on(s: SpecStream, vs: Se
     lemma_parse_repeat_n_correct_on(spec_parse_u16_le, spec_serialize_u16_le, 3, s, vs);
 }
 
-pub exec fn slice_u16_check_1168375106280276899(xs : &[u16]) -> (res : bool)
-    requires xs.dview().len() == 3
-    ensures res <==> xs.dview() == seq![0u16, 1u16, 2u16]
+pub exec fn slice_u16_check_1168375106280276899(xs: &[u16]) -> (res: bool)
+    requires
+        xs.dview().len() == 3,
+    ensures
+        res <==> xs.dview() == seq![0u16, 1u16, 2u16],
 {
     let constant = [0u16, 1u16, 2u16];
     assert(constant.view() =~= seq![0u16, 1u16, 2u16]);
@@ -6840,7 +8584,9 @@ pub exec fn slice_u16_check_1168375106280276899(xs : &[u16]) -> (res : bool)
         let (constant_i, xi) = (*array_index_get(&constant, i), *slice_index_get(&xs, i));
         if constant_i == xi {
             i = i + 1;
-            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(xi));
+            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(
+                xi,
+            ));
         } else {
             return false;
         }
@@ -6848,25 +8594,26 @@ pub exec fn slice_u16_check_1168375106280276899(xs : &[u16]) -> (res : bool)
     assert(xs.dview() =~= seq![0u16, 1u16, 2u16]) by {
         assert(xs.dview().subrange(0, 3) =~= xs.dview());
     }
-
     true
 }
 
 pub exec fn parse_3_u16s_1168375106280276899(s: Stream) -> (res: ParseResult<Vec<u16>>)
     ensures
         prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_3_u16s_1168375106280276899(s)),
-        res.is_ok() ==> res.unwrap().2.dview() == seq![0u16, 1u16, 2u16]
+        res.is_ok() ==> res.unwrap().2.dview() == seq![0u16, 1u16, 2u16],
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
 
     let ghost spec_parse_u16_le = |s| spec_parse_u16_le(s);
 
     let (s0, n, xs) = parse_repeat_n(parse_u16_le, Ghost(spec_parse_u16_le), 3, s)?;
 
     assert(xs.dview().len() == 3) by {
-        lemma_parse_u16_le_well_behaved(); lemma_parse_repeat_n_well_behaved(spec_parse_u16_le, 3);
+        lemma_parse_u16_le_well_behaved();
+        lemma_parse_repeat_n_well_behaved(spec_parse_u16_le, 3);
     }
-
     if slice_u16_check_1168375106280276899(vec_as_slice(&xs)) {
         Ok((s0, n, xs))
     } else {
@@ -6874,9 +8621,17 @@ pub exec fn parse_3_u16s_1168375106280276899(s: Stream) -> (res: ParseResult<Vec
     }
 }
 
-pub exec fn serialize_3_u16s_1168375106280276899(data: &mut [u8], start: usize, vs: &[u16]) -> (res: SerializeResult)
+pub exec fn serialize_3_u16s_1168375106280276899(data: &mut [u8], start: usize, vs: &[u16]) -> (res:
+    SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_3_u16s_1168375106280276899(s, vs),
+        ),
 {
     if vs.length() == 3 && slice_u16_check_1168375106280276899(vs) {
         serialize_3_u16s(data, start, vs)
@@ -6885,65 +8640,77 @@ pub exec fn serialize_3_u16s_1168375106280276899(data: &mut [u8], start: usize, 
     }
 }
 
-pub open spec fn spec_parse_100_u16s(s: SpecStream) -> SpecParseResult<Seq<u16>>
-{
+pub open spec fn spec_parse_100_u16s(s: SpecStream) -> SpecParseResult<Seq<u16>> {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     spec_parse_repeat_n(spec_parse_u16_le, 100)(s)
 }
 
-pub open spec fn spec_serialize_100_u16s(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_100_u16s(s: SpecStream, vs: Seq<u16>) -> SpecSerializeResult {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     spec_serialize_repeat_n(spec_serialize_u16_le, 100)(s, vs)
 }
 
 pub proof fn lemma_parse_100_u16s_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_100_u16s(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_100_u16s(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_100_u16s = |s| spec_parse_100_u16s(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_100_u16s, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_100_u16s, s) by {
         lemma_parse_100_u16s_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_100_u16s_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_100_u16s(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_100_u16s(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_100_u16s = |s, vs| spec_serialize_100_u16s(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_100_u16s, s, vs) by {
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_100_u16s, s, vs) by {
         lemma_serialize_100_u16s_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_100_u16s_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_100_u16s(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_100_u16s(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_100_u16s = |s, vs| spec_serialize_100_u16s(s, vs);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_100_u16s, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_100_u16s, s1, s2, v) by {
         lemma_serialize_100_u16s_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_100_u16s_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_100_u16s(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_100_u16s(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_100_u16s = |s| spec_parse_100_u16s(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_100_u16s, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_100_u16s, s1, s2) by {
         lemma_parse_100_u16s_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_100_u16s_correct()
-    ensures prop_parse_correct(|s| spec_parse_100_u16s(s), |s, vs| spec_serialize_100_u16s(s, vs))
+    ensures
+        prop_parse_correct(|s| spec_parse_100_u16s(s), |s, vs| spec_serialize_100_u16s(s, vs)),
 {
     reveal(prop_parse_correct);
     let spec_parse_100_u16s = |s| spec_parse_100_u16s(s);
     let spec_serialize_100_u16s = |s, vs| spec_serialize_100_u16s(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_100_u16s, spec_serialize_100_u16s, s, vs) by {
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_100_u16s,
+            spec_serialize_100_u16s,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_100_u16s_correct_on(s, vs);
         }
@@ -6951,26 +8718,36 @@ pub proof fn lemma_parse_100_u16s_correct()
 }
 
 pub proof fn lemma_parse_100_u16s_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_100_u16s(s), |s, v| spec_serialize_100_u16s(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_100_u16s(s),
+            |s, v| spec_serialize_100_u16s(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_100_u16s = |s| spec_parse_100_u16s(s);
     let spec_serialize_100_u16s = |s, vs| spec_serialize_100_u16s(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_100_u16s, spec_serialize_100_u16s, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_100_u16s, spec_serialize_100_u16s, s) by {
         lemma_parse_100_u16s_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_100_u16s_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_100_u16s(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_100_u16s(s)),
 {
     lemma_parse_100_u16s_serialize_inverse();
     lemma_serialize_100_u16s_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_100_u16s(s), |s, v| spec_serialize_100_u16s(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_100_u16s(s),
+        |s, v| spec_serialize_100_u16s(s, v),
+    );
 }
 
 proof fn lemma_parse_100_u16s_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_100_u16s(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_100_u16s(s), s),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -6978,7 +8755,8 @@ proof fn lemma_parse_100_u16s_well_behaved_on(s: SpecStream)
 }
 
 proof fn lemma_serialize_100_u16s_well_behaved_on(s: SpecStream, vs: Seq<u16>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_100_u16s(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(|s, vs| spec_serialize_100_u16s(s, vs), s, vs),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -6986,7 +8764,8 @@ proof fn lemma_serialize_100_u16s_well_behaved_on(s: SpecStream, vs: Seq<u16>)
 }
 
 proof fn lemma_serialize_100_u16s_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u16>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_100_u16s(s, v), s1, s2, v)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_100_u16s(s, v), s1, s2, v),
 {
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
     lemma_serialize_u16_le_well_behaved();
@@ -6995,7 +8774,8 @@ proof fn lemma_serialize_100_u16s_deterministic_on(s1: SpecStream, s2: SpecStrea
 }
 
 proof fn lemma_parse_100_u16s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_100_u16s(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_100_u16s(s), s1, s2),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     lemma_parse_u16_le_well_behaved();
@@ -7004,8 +8784,15 @@ proof fn lemma_parse_100_u16s_strong_prefix_on(s1: SpecStream, s2: SpecStream)
 }
 
 proof fn lemma_parse_100_u16s_correct_on(s: SpecStream, vs: Seq<u16>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_100_u16s(s), |s, vs| spec_serialize_100_u16s(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_100_u16s(s),
+            |s, vs| spec_serialize_100_u16s(s, vs),
+            s,
+            vs,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -7017,7 +8804,12 @@ proof fn lemma_parse_100_u16s_correct_on(s: SpecStream, vs: Seq<u16>)
 }
 
 proof fn lemma_parse_100_u16s_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_100_u16s(s), |s, v| spec_serialize_100_u16s(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_100_u16s(s),
+            |s, v| spec_serialize_100_u16s(s, v),
+            s,
+        ),
 {
     let spec_parse_u16_le = |s| spec_parse_u16_le(s);
     let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
@@ -7029,9 +8821,11 @@ proof fn lemma_parse_100_u16s_serialize_inverse_on(s: SpecStream)
 
 pub exec fn parse_100_u16s(s: Stream) -> (res: ParseResult<Vec<u16>>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_100_u16s(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_100_u16s(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
 
     let ghost spec_parse_u16_le = |s| spec_parse_u16_le(s);
 
@@ -7041,7 +8835,14 @@ pub exec fn parse_100_u16s(s: Stream) -> (res: ParseResult<Vec<u16>>)
 #[verifier(external_body)]
 pub exec fn serialize_100_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_100_u16s(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_100_u16s(s, vs),
+        ),
 {
     if vs.length() != 100 {
         return Err(SerializeError::RepeatNMismatch);
@@ -7050,12 +8851,10 @@ pub exec fn serialize_100_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (re
     } else if start > data.length() {
         return Err(SerializeError::NotEnoughSpace);
     }
-
     let (mut start, mut i, mut m): (usize, usize, usize) = (start, 0, 0);
-    while i < 100
-    {
+    while i < 100 {
         i = i + 1;
-        let v = *slice_index_get(&vs, i - 1); // vs[i - 1]
+        let v = *slice_index_get(&vs, i - 1);  // vs[i - 1]
         let res1 = serialize_u16_le(data, start, v);
         match res1 {
             Ok((new_start, m1)) => {
@@ -7065,15 +8864,15 @@ pub exec fn serialize_100_u16s(data: &mut [u8], start: usize, vs: &[u16]) -> (re
                     start = new_start;
                     m = m + m1;
                 }
-            }
+            },
             Err(e) => {
                 return Err(e);
-            }
+            },
         }
     }
-
     Ok((start, m))
 }
+
 pub struct SpecSextuple {
     a: u64,
     b: u16,
@@ -7081,8 +8880,8 @@ pub struct SpecSextuple {
     d: u8,
     e: Seq<u16>,
     f: Seq<u8>,
-
 }
+
 pub struct Sextuple {
     a: u64,
     b: u16,
@@ -7090,7 +8889,6 @@ pub struct Sextuple {
     d: u8,
     e: Vec<u16>,
     f: Vec<u8>,
-
 }
 
 pub open spec fn spec_parse_6_fold<R1, R2, R3, R4, R5, R6>(
@@ -7099,12 +8897,16 @@ pub open spec fn spec_parse_6_fold<R1, R2, R3, R4, R5, R6>(
     parser3: spec_fn(SpecStream) -> SpecParseResult<R3>,
     parser4: spec_fn(SpecStream) -> SpecParseResult<R4>,
     parser5: spec_fn(SpecStream) -> SpecParseResult<R5>,
-    parser6: spec_fn(SpecStream) -> SpecParseResult<R6>) -> spec_fn(SpecStream) -> SpecParseResult<(((((R1, R2), R3), R4), R5), R6)>
-{
-    spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4), parser5), parser6)
+    parser6: spec_fn(SpecStream) -> SpecParseResult<R6>,
+) -> spec_fn(SpecStream) -> SpecParseResult<(((((R1, R2), R3), R4), R5), R6)> {
+    spec_parse_pair(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4),
+            parser5,
+        ),
+        parser6,
+    )
 }
-
-
 
 pub open spec fn spec_serialize_6_fold<T1, T2, T3, T4, T5, T6>(
     serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
@@ -7112,11 +8914,19 @@ pub open spec fn spec_serialize_6_fold<T1, T2, T3, T4, T5, T6>(
     serializer3: spec_fn(SpecStream, T3) -> SpecSerializeResult,
     serializer4: spec_fn(SpecStream, T4) -> SpecSerializeResult,
     serializer5: spec_fn(SpecStream, T5) -> SpecSerializeResult,
-    serializer6: spec_fn(SpecStream, T6) -> SpecSerializeResult) -> spec_fn(SpecStream, (((((T1, T2), T3), T4), T5), T6)) -> SpecSerializeResult
-{
-    spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3), serializer4), serializer5), serializer6)
+    serializer6: spec_fn(SpecStream, T6) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, (((((T1, T2), T3), T4), T5), T6)) -> SpecSerializeResult {
+    spec_serialize_pair(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3),
+                serializer4,
+            ),
+            serializer5,
+        ),
+        serializer6,
+    )
 }
-
 
 pub exec fn parse_6_fold<'a, P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6>(
     exec_parser1: P1,
@@ -7131,8 +8941,8 @@ pub exec fn parse_6_fold<'a, P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6>(
     Ghost(spec_parser4): Ghost<spec_fn(SpecStream) -> SpecParseResult<R4::V>>,
     Ghost(spec_parser5): Ghost<spec_fn(SpecStream) -> SpecParseResult<R5::V>>,
     Ghost(spec_parser6): Ghost<spec_fn(SpecStream) -> SpecParseResult<R6::V>>,
-    s: Stream<'a>) -> (res: ParseResult<(((((R1, R2), R3), R4), R5), R6)>)
-    where
+    s: Stream<'a>,
+) -> (res: ParseResult<(((((R1, R2), R3), R4), R5), R6)>) where
     R1: DView,
     P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
     R2: DView,
@@ -7145,6 +8955,7 @@ pub exec fn parse_6_fold<'a, P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6>(
     P5: FnOnce(Stream<'a>) -> ParseResult<R5>,
     R6: DView,
     P6: FnOnce(Stream<'a>) -> ParseResult<R6>,
+
     requires
         prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
@@ -7153,19 +8964,108 @@ pub exec fn parse_6_fold<'a, P1, P2, P3, P4, P5, P6, R1, R2, R3, R4, R5, R6>(
         prop_parse_exec_spec_equiv(exec_parser5, spec_parser5),
         prop_parse_exec_spec_equiv(exec_parser6, spec_parser6),
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, spec_parse_6_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4, spec_parser5, spec_parser6))
+        prop_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_6_fold(
+                spec_parser1,
+                spec_parser2,
+                spec_parser3,
+                spec_parser4,
+                spec_parser5,
+                spec_parser6,
+            ),
+        ),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), { parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s) };
-    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), { parse_pair(parse_3_fold, exec_parser4, Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), Ghost(spec_parser4), s) };
-    let parse_5_fold = |s| -> (res: ParseResult<((((R1, R2), R3), R4), R5)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5)), { parse_pair(parse_4_fold, exec_parser5, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), Ghost(spec_parser5), s) };
-    parse_pair(parse_5_fold, exec_parser6, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5)), Ghost(spec_parser6), s)
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+            ),
+        {
+            parse_pair(
+                parse_2_fold,
+                exec_parser3,
+                Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+                Ghost(spec_parser3),
+                s,
+            )
+        };
+    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                    spec_parser4,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_3_fold,
+                exec_parser4,
+                Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)),
+                Ghost(spec_parser4),
+                s,
+            )
+        };
+    let parse_5_fold = |s| -> (res: ParseResult<((((R1, R2), R3), R4), R5)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                        spec_parser4,
+                    ),
+                    spec_parser5,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_4_fold,
+                exec_parser5,
+                Ghost(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                        spec_parser4,
+                    ),
+                ),
+                Ghost(spec_parser5),
+                s,
+            )
+        };
+    parse_pair(
+        parse_5_fold,
+        exec_parser6,
+        Ghost(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                    spec_parser4,
+                ),
+                spec_parser5,
+            ),
+        ),
+        Ghost(spec_parser6),
+        s,
+    )
 }
 
-
-pub open spec fn spec_parse_sextuple(s: SpecStream) -> SpecParseResult<(((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>)>
-{
+pub open spec fn spec_parse_sextuple(s: SpecStream) -> SpecParseResult<
+    (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>),
+> {
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
     let spec_parse_3_u16s_1168375106280276899 = |s| spec_parse_3_u16s_1168375106280276899(s);
@@ -7173,58 +9073,87 @@ pub open spec fn spec_parse_sextuple(s: SpecStream) -> SpecParseResult<(((((u64,
     let spec_parse_100_u16s = |s| spec_parse_100_u16s(s);
     let spec_parse_tail = |s| spec_parse_tail(s);
 
-    spec_parse_6_fold(spec_parse_u64_le, spec_parse_u16_le_100, spec_parse_3_u16s_1168375106280276899, spec_parse_u8_le, spec_parse_100_u16s, spec_parse_tail)(s)
+    spec_parse_6_fold(
+        spec_parse_u64_le,
+        spec_parse_u16_le_100,
+        spec_parse_3_u16s_1168375106280276899,
+        spec_parse_u8_le,
+        spec_parse_100_u16s,
+        spec_parse_tail,
+    )(s)
 }
 
-pub open spec fn spec_serialize_sextuple(s: SpecStream, v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_sextuple(
+    s: SpecStream,
+    v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, v| spec_serialize_3_u16s_1168375106280276899(s, v);
+    let spec_serialize_3_u16s_1168375106280276899 = |s, v|
+        spec_serialize_3_u16s_1168375106280276899(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_100_u16s = |s, v| spec_serialize_100_u16s(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
 
-    spec_serialize_6_fold(spec_serialize_u64_le, spec_serialize_u16_le_100, spec_serialize_3_u16s_1168375106280276899, spec_serialize_u8_le, spec_serialize_100_u16s, spec_serialize_tail)(s, v)
+    spec_serialize_6_fold(
+        spec_serialize_u64_le,
+        spec_serialize_u16_le_100,
+        spec_serialize_3_u16s_1168375106280276899,
+        spec_serialize_u8_le,
+        spec_serialize_100_u16s,
+        spec_serialize_tail,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_sextuple_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_sextuple(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_sextuple(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_sextuple = |s| spec_parse_sextuple(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_sextuple, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_sextuple, s) by {
         lemma_parse_sextuple_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_sextuple_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_sextuple(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_sextuple(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_sextuple = |s, v| spec_serialize_sextuple(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_sextuple, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_sextuple, s, v) by {
         lemma_serialize_sextuple_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_sextuple_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_sextuple(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_sextuple(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_sextuple = |s, v| spec_serialize_sextuple(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_sextuple, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_sextuple, s1, s2, v) by {
         lemma_serialize_sextuple_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_sextuple_correct()
-    ensures prop_parse_correct(|s| spec_parse_sextuple(s), |s, v| spec_serialize_sextuple(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_sextuple(s), |s, v| spec_serialize_sextuple(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_sextuple = |s| spec_parse_sextuple(s);
     let spec_serialize_sextuple = |s, v| spec_serialize_sextuple(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_sextuple, spec_serialize_sextuple, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_sextuple,
+            spec_serialize_sextuple,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_sextuple_correct_on(s, v);
         }
@@ -7232,26 +9161,36 @@ pub proof fn lemma_parse_sextuple_correct()
 }
 
 pub proof fn lemma_parse_sextuple_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_sextuple(s), |s, v| spec_serialize_sextuple(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_sextuple(s),
+            |s, v| spec_serialize_sextuple(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_sextuple = |s| spec_parse_sextuple(s);
     let spec_serialize_sextuple = |s, v| spec_serialize_sextuple(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_sextuple, spec_serialize_sextuple, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_sextuple, spec_serialize_sextuple, s) by {
         lemma_parse_sextuple_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_sextuple_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_sextuple(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_sextuple(s)),
 {
     lemma_parse_sextuple_serialize_inverse();
     lemma_serialize_sextuple_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_sextuple(s), |s, v| spec_serialize_sextuple(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_sextuple(s),
+        |s, v| spec_serialize_sextuple(s, v),
+    );
 }
 
 pub proof fn lemma_parse_sextuple_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_sextuple(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_sextuple(s), s),
 {
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -7266,18 +9205,54 @@ pub proof fn lemma_parse_sextuple_well_behaved_on(s: SpecStream)
     lemma_parse_100_u16s_well_behaved();
     lemma_parse_tail_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u64_le, spec_parse_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s), spec_parse_tail, s);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+        spec_parse_3_u16s_1168375106280276899,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+            spec_parse_3_u16s_1168375106280276899,
+        ),
+        spec_parse_u8_le,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                spec_parse_3_u16s_1168375106280276899,
+            ),
+            spec_parse_u8_le,
+        ),
+        spec_parse_100_u16s,
+    );
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                    spec_parse_3_u16s_1168375106280276899,
+                ),
+                spec_parse_u8_le,
+            ),
+            spec_parse_100_u16s,
+        ),
+        spec_parse_tail,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_sextuple_well_behaved_on(s: SpecStream, v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_sextuple(s, v), s, v)
+pub proof fn lemma_serialize_sextuple_well_behaved_on(
+    s: SpecStream,
+    v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_sextuple(s, v), s, v),
 {
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, v| spec_serialize_3_u16s_1168375106280276899(s, v);
+    let spec_serialize_3_u16s_1168375106280276899 = |s, v|
+        spec_serialize_3_u16s_1168375106280276899(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_100_u16s = |s, v| spec_serialize_100_u16s(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -7288,18 +9263,56 @@ pub proof fn lemma_serialize_sextuple_well_behaved_on(s: SpecStream, v: (((((u64
     lemma_serialize_100_u16s_well_behaved();
     lemma_serialize_tail_well_behaved();
     lemma_serialize_pair_well_behaved(spec_serialize_u64_le, spec_serialize_u16_le_100);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s), spec_serialize_tail, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                    spec_serialize_3_u16s_1168375106280276899,
+                ),
+                spec_serialize_u8_le,
+            ),
+            spec_serialize_100_u16s,
+        ),
+        spec_serialize_tail,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_sextuple_deterministic_on(s1: SpecStream, s2: SpecStream, v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_sextuple(s, v), s1, s2, v)
+pub proof fn lemma_serialize_sextuple_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_sextuple(s, v), s1, s2, v),
 {
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, v| spec_serialize_3_u16s_1168375106280276899(s, v);
+    let spec_serialize_3_u16s_1168375106280276899 = |s, v|
+        spec_serialize_3_u16s_1168375106280276899(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_100_u16s = |s, v| spec_serialize_100_u16s(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -7317,18 +9330,79 @@ pub proof fn lemma_serialize_sextuple_deterministic_on(s1: SpecStream, s2: SpecS
     lemma_serialize_tail_deterministic();
     lemma_serialize_pair_well_behaved(spec_serialize_u64_le, spec_serialize_u16_le_100);
     lemma_serialize_pair_deterministic(spec_serialize_u64_le, spec_serialize_u16_le_100);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s), spec_serialize_tail, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                    spec_serialize_3_u16s_1168375106280276899,
+                ),
+                spec_serialize_u8_le,
+            ),
+            spec_serialize_100_u16s,
+        ),
+        spec_serialize_tail,
+        s1,
+        s2,
+        v,
+    );
 }
 
-pub proof fn lemma_parse_sextuple_correct_on(s: SpecStream, v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_sextuple(s), |s, v| spec_serialize_sextuple(s, v), s, v)
+pub proof fn lemma_parse_sextuple_correct_on(
+    s: SpecStream,
+    v: (((((u64, u16), Seq<u16>), u8), Seq<u16>), Seq<u8>),
+)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_sextuple(s),
+            |s, v| spec_serialize_sextuple(s, v),
+            s,
+            v,
+        ),
 {
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -7338,7 +9412,8 @@ pub proof fn lemma_parse_sextuple_correct_on(s: SpecStream, v: (((((u64, u16), S
     let spec_parse_tail = |s| spec_parse_tail(s);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, v| spec_serialize_3_u16s_1168375106280276899(s, v);
+    let spec_serialize_3_u16s_1168375106280276899 = |s, v|
+        spec_serialize_3_u16s_1168375106280276899(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_100_u16s = |s, v| spec_serialize_100_u16s(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -7359,7 +9434,7 @@ pub proof fn lemma_parse_sextuple_correct_on(s: SpecStream, v: (((((u64, u16), S
     lemma_parse_3_u16s_1168375106280276899_strong_prefix();
     lemma_parse_u8_le_strong_prefix();
     lemma_parse_100_u16s_strong_prefix();
-    
+
     lemma_parse_u64_le_correct();
     lemma_parse_u16_le_100_correct();
     lemma_parse_3_u16s_1168375106280276899_correct();
@@ -7369,24 +9444,146 @@ pub proof fn lemma_parse_sextuple_correct_on(s: SpecStream, v: (((((u64, u16), S
     lemma_parse_pair_well_behaved(spec_parse_u64_le, spec_parse_u16_le_100);
     lemma_serialize_pair_well_behaved(spec_serialize_u64_le, spec_serialize_u16_le_100);
     lemma_parse_pair_strong_prefix(spec_parse_u64_le, spec_parse_u16_le_100);
-    lemma_parse_pair_correct(spec_parse_u64_le, spec_parse_u16_le_100, spec_serialize_u64_le, spec_serialize_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899, spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le, spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s), spec_parse_tail, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s), spec_serialize_tail, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u64_le,
+        spec_parse_u16_le_100,
+        spec_serialize_u64_le,
+        spec_serialize_u16_le_100,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+        spec_parse_3_u16s_1168375106280276899,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+        spec_parse_3_u16s_1168375106280276899,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+        spec_parse_3_u16s_1168375106280276899,
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+            spec_parse_3_u16s_1168375106280276899,
+        ),
+        spec_parse_u8_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+            spec_parse_3_u16s_1168375106280276899,
+        ),
+        spec_parse_u8_le,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+            spec_parse_3_u16s_1168375106280276899,
+        ),
+        spec_parse_u8_le,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                spec_parse_3_u16s_1168375106280276899,
+            ),
+            spec_parse_u8_le,
+        ),
+        spec_parse_100_u16s,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                spec_parse_3_u16s_1168375106280276899,
+            ),
+            spec_parse_u8_le,
+        ),
+        spec_parse_100_u16s,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                spec_parse_3_u16s_1168375106280276899,
+            ),
+            spec_parse_u8_le,
+        ),
+        spec_parse_100_u16s,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                    spec_parse_3_u16s_1168375106280276899,
+                ),
+                spec_parse_u8_le,
+            ),
+            spec_parse_100_u16s,
+        ),
+        spec_parse_tail,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                    spec_serialize_3_u16s_1168375106280276899,
+                ),
+                spec_serialize_u8_le,
+            ),
+            spec_serialize_100_u16s,
+        ),
+        spec_serialize_tail,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_sextuple_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_sextuple(s), |s, v| spec_serialize_sextuple(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_sextuple(s),
+            |s, v| spec_serialize_sextuple(s, v),
+            s,
+        ),
 {
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
@@ -7396,7 +9593,8 @@ pub proof fn lemma_parse_sextuple_serialize_inverse_on(s: SpecStream)
     let spec_parse_tail = |s| spec_parse_tail(s);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_u16_le_100 = |s, v| spec_serialize_u16_le_100(s, v);
-    let spec_serialize_3_u16s_1168375106280276899 = |s, v| spec_serialize_3_u16s_1168375106280276899(s, v);
+    let spec_serialize_3_u16s_1168375106280276899 = |s, v|
+        spec_serialize_3_u16s_1168375106280276899(s, v);
     let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
     let spec_serialize_100_u16s = |s, v| spec_serialize_100_u16s(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -7420,22 +9618,126 @@ pub proof fn lemma_parse_sextuple_serialize_inverse_on(s: SpecStream)
     lemma_parse_tail_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u64_le, spec_parse_u16_le_100);
     lemma_serialize_pair_well_behaved(spec_serialize_u64_le, spec_serialize_u16_le_100);
-    lemma_parse_pair_serialize_inverse(spec_parse_u64_le, spec_parse_u16_le_100, spec_serialize_u64_le, spec_serialize_u16_le_100);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899, spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le, spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100), spec_parse_3_u16s_1168375106280276899), spec_parse_u8_le), spec_parse_100_u16s), spec_parse_tail, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100), spec_serialize_3_u16s_1168375106280276899), spec_serialize_u8_le), spec_serialize_100_u16s), spec_serialize_tail, s);
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u64_le,
+        spec_parse_u16_le_100,
+        spec_serialize_u64_le,
+        spec_serialize_u16_le_100,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+        spec_parse_3_u16s_1168375106280276899,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+        spec_parse_3_u16s_1168375106280276899,
+        spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+        spec_serialize_3_u16s_1168375106280276899,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+            spec_parse_3_u16s_1168375106280276899,
+        ),
+        spec_parse_u8_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+            spec_parse_3_u16s_1168375106280276899,
+        ),
+        spec_parse_u8_le,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+            spec_serialize_3_u16s_1168375106280276899,
+        ),
+        spec_serialize_u8_le,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                spec_parse_3_u16s_1168375106280276899,
+            ),
+            spec_parse_u8_le,
+        ),
+        spec_parse_100_u16s,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                spec_parse_3_u16s_1168375106280276899,
+            ),
+            spec_parse_u8_le,
+        ),
+        spec_parse_100_u16s,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                spec_serialize_3_u16s_1168375106280276899,
+            ),
+            spec_serialize_u8_le,
+        ),
+        spec_serialize_100_u16s,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u64_le, spec_parse_u16_le_100),
+                    spec_parse_3_u16s_1168375106280276899,
+                ),
+                spec_parse_u8_le,
+            ),
+            spec_parse_100_u16s,
+        ),
+        spec_parse_tail,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(spec_serialize_u64_le, spec_serialize_u16_le_100),
+                    spec_serialize_3_u16s_1168375106280276899,
+                ),
+                spec_serialize_u8_le,
+            ),
+            spec_serialize_100_u16s,
+        ),
+        spec_serialize_tail,
+        s,
+    );
 }
-pub exec fn parse_sextuple(s: Stream) -> (res: ParseResult<(((((u64, u16), Vec<u16>), u8), Vec<u16>), &[u8])>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_sextuple(s))
+
+pub exec fn parse_sextuple(s: Stream) -> (res: ParseResult<
+    (((((u64, u16), Vec<u16>), u8), Vec<u16>), &[u8]),
+>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_sextuple(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let ghost spec_parse_u16_le_100 = |s| spec_parse_u16_le_100(s);
     let ghost spec_parse_3_u16s_1168375106280276899 = |s| spec_parse_3_u16s_1168375106280276899(s);
@@ -7443,90 +9745,132 @@ pub exec fn parse_sextuple(s: Stream) -> (res: ParseResult<(((((u64, u16), Vec<u
     let ghost spec_parse_100_u16s = |s| spec_parse_100_u16s(s);
     let ghost spec_parse_tail = |s| spec_parse_tail(s);
 
-    parse_6_fold(parse_u64_le, parse_u16_le_100, parse_3_u16s_1168375106280276899, parse_u8_le, parse_100_u16s, parse_tail, Ghost(spec_parse_u64_le), Ghost(spec_parse_u16_le_100), Ghost(spec_parse_3_u16s_1168375106280276899), Ghost(spec_parse_u8_le), Ghost(spec_parse_100_u16s), Ghost(spec_parse_tail), s)
+    parse_6_fold(
+        parse_u64_le,
+        parse_u16_le_100,
+        parse_3_u16s_1168375106280276899,
+        parse_u8_le,
+        parse_100_u16s,
+        parse_tail,
+        Ghost(spec_parse_u64_le),
+        Ghost(spec_parse_u16_le_100),
+        Ghost(spec_parse_3_u16s_1168375106280276899),
+        Ghost(spec_parse_u8_le),
+        Ghost(spec_parse_100_u16s),
+        Ghost(spec_parse_tail),
+        s,
+    )
 }
-pub exec fn serialize_sextuple(data: &mut [u8], start: usize, v: (((((u64, u16), &[u16]), u8), &[u16]), &[u8])) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_sextuple(s, v))
+
+pub exec fn serialize_sextuple(
+    data: &mut [u8],
+    start: usize,
+    v: (((((u64, u16), &[u16]), u8), &[u16]), &[u8]),
+) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_sextuple(s, v),
+        ),
 {
     let (((((v0, v1), v2), v3), v4), v5) = v;
     let (new_start, n0) = serialize_u64_le(data, start, v0)?;
 
-let (new_start, n1) = serialize_u16_le_100(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_3_u16s_1168375106280276899(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n3) = serialize_u8_le(data, new_start, v3)?;
-    if n0 + n1 + n2 > usize::MAX - n3 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n4) = serialize_100_u16s(data, new_start, v4)?;
-    if n0 + n1 + n2 + n3 > usize::MAX - n4 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n5) = serialize_tail(data, new_start, v5)?;
-    if n0 + n1 + n2 + n3 + n4 > usize::MAX - n5 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_u16_le_100(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_3_u16s_1168375106280276899(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n3) = serialize_u8_le(data, new_start, v3)?;
+    if n0 + n1 + n2 > usize::MAX - n3 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n4) = serialize_100_u16s(data, new_start, v4)?;
+    if n0 + n1 + n2 + n3 > usize::MAX - n4 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n5) = serialize_tail(data, new_start, v5)?;
+    if n0 + n1 + n2 + n3 + n4 > usize::MAX - n5 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2 + n3 + n4 + n5))
 }
 
-                    
-pub open spec fn spec_parse_64_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_64_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 64)
 }
 
-pub open spec fn spec_serialize_64_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_64_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 64)
 }
 
 pub proof fn lemma_parse_64_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_64_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_64_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_64_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_64_bytes, s) by {
         lemma_parse_64_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_64_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_64_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_64_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_64_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_64_bytes, s, v) by {
         lemma_serialize_64_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_64_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_64_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_64_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_64_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_64_bytes, s1, s2, v) by {
         lemma_serialize_64_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_64_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_64_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_64_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_64_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_64_bytes, s1, s2) by {
         lemma_parse_64_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_64_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_64_bytes(s), |s, v| spec_serialize_64_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_64_bytes(s), |s, v| spec_serialize_64_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_64_bytes, spec_serialize_64_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_64_bytes,
+            spec_serialize_64_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_64_bytes_correct_on(s, v)
         }
@@ -7535,145 +9879,167 @@ pub proof fn lemma_parse_64_bytes_correct()
 
 pub proof fn lemma_parse_64_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_64_bytes(s), |s, v| spec_serialize_64_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_64_bytes(s),
+            |s, v| spec_serialize_64_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_64_bytes, spec_serialize_64_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_64_bytes, spec_serialize_64_bytes, s) by {
         lemma_parse_64_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_64_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_64_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_64_bytes(s)),
 {
     lemma_parse_64_bytes_serialize_inverse();
     lemma_serialize_64_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_64_bytes(s), |s, v| spec_serialize_64_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_64_bytes(s),
+        |s, v| spec_serialize_64_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_64_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_64_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_64_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 64);
 }
 
 proof fn lemma_serialize_64_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_64_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_64_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 64);
 }
 
 proof fn lemma_serialize_64_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_64_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_64_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 64);
 }
 
 proof fn lemma_parse_64_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_64_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_64_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 64);
 }
 
 proof fn lemma_parse_64_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_64_bytes(s), |s, v| spec_serialize_64_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_64_bytes(s),
+            |s, v| spec_serialize_64_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 64);
 }
 
 proof fn lemma_parse_64_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_64_bytes(s), |s, v| spec_serialize_64_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_64_bytes(s),
+            |s, v| spec_serialize_64_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 64);
 }
 
 pub exec fn sec_parse_64_bytes(s: SecStream) -> (res: SecParseResult<SecBytes>)
     ensures
-        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_64_bytes(s))
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_64_bytes(s)),
 {
     parse_sec_bytes(s, 64)
 }
 
 pub exec fn sec_serialize_64_bytes(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
     ensures
-        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_64_bytes(s, v))
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_64_bytes(s, v)),
 {
     serialize_sec_bytes(s, v, 64)
 }
 
-pub open spec fn spec_parse_32_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_32_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 32)
 }
 
-pub open spec fn spec_serialize_32_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_32_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 32)
 }
 
 pub proof fn lemma_parse_32_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_32_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_32_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_32_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_32_bytes, s) by {
         lemma_parse_32_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_32_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_32_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_32_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_32_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_32_bytes, s, v) by {
         lemma_serialize_32_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_32_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_32_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_32_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_32_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_32_bytes, s1, s2, v) by {
         lemma_serialize_32_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_32_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_32_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_32_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_32_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_32_bytes, s1, s2) by {
         lemma_parse_32_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_32_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_32_bytes, spec_serialize_32_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_32_bytes,
+            spec_serialize_32_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_32_bytes_correct_on(s, v)
         }
@@ -7682,93 +10048,109 @@ pub proof fn lemma_parse_32_bytes_correct()
 
 pub proof fn lemma_parse_32_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_32_bytes(s),
+            |s, v| spec_serialize_32_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_32_bytes, spec_serialize_32_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_32_bytes, spec_serialize_32_bytes, s) by {
         lemma_parse_32_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_32_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_32_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_32_bytes(s)),
 {
     lemma_parse_32_bytes_serialize_inverse();
     lemma_serialize_32_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_32_bytes(s),
+        |s, v| spec_serialize_32_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_32_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_32_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_32_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 32);
 }
 
 proof fn lemma_serialize_32_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_32_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_32_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 32);
 }
 
 proof fn lemma_serialize_32_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_32_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_32_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 32);
 }
 
 proof fn lemma_parse_32_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_32_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_32_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 32);
 }
 
 proof fn lemma_parse_32_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_32_bytes(s),
+            |s, v| spec_serialize_32_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 32);
 }
 
 proof fn lemma_parse_32_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_32_bytes(s),
+            |s, v| spec_serialize_32_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 32);
 }
 
 pub exec fn sec_parse_32_bytes(s: SecStream) -> (res: SecParseResult<SecBytes>)
     ensures
-        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_32_bytes(s))
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_32_bytes(s)),
 {
     parse_sec_bytes(s, 32)
 }
 
 pub exec fn sec_serialize_32_bytes(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
     ensures
-        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_32_bytes(s, v))
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_32_bytes(s, v)),
 {
     serialize_sec_bytes(s, v, 32)
 }
+
 pub struct SpecSecMsg {
     m1: Seq<u8>,
     m2: Seq<u8>,
     mt: Seq<u8>,
-
 }
+
 pub struct SecMsg {
     m1: SecBytes,
     m2: SecBytes,
     mt: SecBytes,
-
 }
 
 pub exec fn sec_parse_3_fold<'a, P1, P2, P3, R1, R2, R3>(
@@ -7778,27 +10160,41 @@ pub exec fn sec_parse_3_fold<'a, P1, P2, P3, R1, R2, R3>(
     Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
     Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
     Ghost(spec_parser3): Ghost<spec_fn(SpecStream) -> SpecParseResult<R3::V>>,
-    s: SecStream) -> (res: SecParseResult<((R1, R2), R3)>)
-    where
+    s: SecStream,
+) -> (res: SecParseResult<((R1, R2), R3)>) where
     R1: DView,
     P1: FnOnce(SecStream) -> SecParseResult<R1>,
     R2: DView,
     P2: FnOnce(SecStream) -> SecParseResult<R2>,
     R3: DView,
     P3: FnOnce(SecStream) -> SecParseResult<R3>,
+
     requires
         prop_sec_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_sec_parse_exec_spec_equiv(exec_parser2, spec_parser2),
         prop_sec_parse_exec_spec_equiv(exec_parser3, spec_parser3),
     ensures
-        prop_sec_parse_exec_spec_equiv_on(s, res, spec_parse_3_fold(spec_parser1, spec_parser2, spec_parser3))
+        prop_sec_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_3_fold(spec_parser1, spec_parser2, spec_parser3),
+        ),
 {
-    proof { reveal(prop_sec_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: SecParseResult<(R1, R2)>) ensures prop_sec_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { sec_parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    sec_parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s)
+    proof {
+        reveal(prop_sec_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: SecParseResult<(R1, R2)>)
+        ensures
+            prop_sec_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { sec_parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    sec_parse_pair(
+        parse_2_fold,
+        exec_parser3,
+        Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+        Ghost(spec_parser3),
+        s,
+    )
 }
-
-
 
 pub exec fn sec_serialize_3_fold<S1, S2, S3, T1, T2, T3>(
     exec_serializer1: S1,
@@ -7807,29 +10203,62 @@ pub exec fn sec_serialize_3_fold<S1, S2, S3, T1, T2, T3>(
     Ghost(spec_serializer1): Ghost<spec_fn(SpecStream, T1::V) -> SpecSerializeResult>,
     Ghost(spec_serializer2): Ghost<spec_fn(SpecStream, T2::V) -> SpecSerializeResult>,
     Ghost(spec_serializer3): Ghost<spec_fn(SpecStream, T3::V) -> SpecSerializeResult>,
-    s: SecStream, v: ((T1, T2), T3)) -> (res: SecSerializeResult)
-    where
+    s: SecStream,
+    v: ((T1, T2), T3),
+) -> (res: SecSerializeResult) where
     T1: std::fmt::Debug + DView,
     S1: FnOnce(SecStream, T1) -> SecSerializeResult,
     T2: std::fmt::Debug + DView,
     S2: FnOnce(SecStream, T2) -> SecSerializeResult,
     T3: std::fmt::Debug + DView,
     S3: FnOnce(SecStream, T3) -> SecSerializeResult,
+
     requires
         prop_sec_serialize_exec_spec_equiv(exec_serializer1, spec_serializer1),
         prop_sec_serialize_exec_spec_equiv(exec_serializer2, spec_serializer2),
         prop_sec_serialize_exec_spec_equiv(exec_serializer3, spec_serializer3),
     ensures
-        prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serialize_3_fold(spec_serializer1, spec_serializer2, spec_serializer3))
+        prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            spec_serialize_3_fold(spec_serializer1, spec_serializer2, spec_serializer3),
+        ),
 {
-    proof { reveal(prop_sec_serialize_exec_spec_equiv); }
-    let serialize_2_fold = |s, v| -> (res: SecSerializeResult) ensures prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serialize_pair(spec_serializer1, spec_serializer2)), { sec_serialize_pair(exec_serializer1, exec_serializer2, Ghost(spec_serializer1), Ghost(spec_serializer2), s, v) };
-    sec_serialize_pair(serialize_2_fold, exec_serializer3, Ghost(spec_serialize_pair(spec_serializer1, spec_serializer2)), Ghost(spec_serializer3), s, v)
+    proof {
+        reveal(prop_sec_serialize_exec_spec_equiv);
+    }
+    let serialize_2_fold = |s, v| -> (res: SecSerializeResult)
+        ensures
+            prop_sec_serialize_exec_spec_equiv_on(
+                s,
+                v,
+                res,
+                spec_serialize_pair(spec_serializer1, spec_serializer2),
+            ),
+        {
+            sec_serialize_pair(
+                exec_serializer1,
+                exec_serializer2,
+                Ghost(spec_serializer1),
+                Ghost(spec_serializer2),
+                s,
+                v,
+            )
+        };
+    sec_serialize_pair(
+        serialize_2_fold,
+        exec_serializer3,
+        Ghost(spec_serialize_pair(spec_serializer1, spec_serializer2)),
+        Ghost(spec_serializer3),
+        s,
+        v,
+    )
 }
 
-
-pub open spec fn spec_parse_sec_msg(s: SpecStream) -> SpecParseResult<((Seq<u8>, Seq<u8>), Seq<u8>)>
-{
+pub open spec fn spec_parse_sec_msg(s: SpecStream) -> SpecParseResult<
+    ((Seq<u8>, Seq<u8>), Seq<u8>),
+> {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_parse_tail = |s| spec_parse_tail(s);
@@ -7837,52 +10266,68 @@ pub open spec fn spec_parse_sec_msg(s: SpecStream) -> SpecParseResult<((Seq<u8>,
     spec_parse_3_fold(spec_parse_64_bytes, spec_parse_32_bytes, spec_parse_tail)(s)
 }
 
-pub open spec fn spec_serialize_sec_msg(s: SpecStream, v: ((Seq<u8>, Seq<u8>), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_sec_msg(
+    s: SpecStream,
+    v: ((Seq<u8>, Seq<u8>), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
 
-    spec_serialize_3_fold(spec_serialize_64_bytes, spec_serialize_32_bytes, spec_serialize_tail)(s, v)
+    spec_serialize_3_fold(spec_serialize_64_bytes, spec_serialize_32_bytes, spec_serialize_tail)(
+        s,
+        v,
+    )
 }
 
 pub proof fn lemma_parse_sec_msg_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_sec_msg(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_sec_msg(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_sec_msg = |s| spec_parse_sec_msg(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_sec_msg, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_sec_msg, s) by {
         lemma_parse_sec_msg_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_sec_msg_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_sec_msg(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_sec_msg(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_sec_msg = |s, v| spec_serialize_sec_msg(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_sec_msg, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_sec_msg, s, v) by {
         lemma_serialize_sec_msg_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_sec_msg_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_sec_msg(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_sec_msg(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_sec_msg = |s, v| spec_serialize_sec_msg(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_sec_msg, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_sec_msg, s1, s2, v) by {
         lemma_serialize_sec_msg_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_sec_msg_correct()
-    ensures prop_parse_correct(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_sec_msg = |s| spec_parse_sec_msg(s);
     let spec_serialize_sec_msg = |s, v| spec_serialize_sec_msg(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_sec_msg, spec_serialize_sec_msg, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_sec_msg,
+            spec_serialize_sec_msg,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_sec_msg_correct_on(s, v);
         }
@@ -7890,26 +10335,36 @@ pub proof fn lemma_parse_sec_msg_correct()
 }
 
 pub proof fn lemma_parse_sec_msg_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_sec_msg(s),
+            |s, v| spec_serialize_sec_msg(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_sec_msg = |s| spec_parse_sec_msg(s);
     let spec_serialize_sec_msg = |s, v| spec_serialize_sec_msg(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_sec_msg, spec_serialize_sec_msg, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_sec_msg, spec_serialize_sec_msg, s) by {
         lemma_parse_sec_msg_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_sec_msg_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_sec_msg(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_sec_msg(s)),
 {
     lemma_parse_sec_msg_serialize_inverse();
     lemma_serialize_sec_msg_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_sec_msg(s),
+        |s, v| spec_serialize_sec_msg(s, v),
+    );
 }
 
 pub proof fn lemma_parse_sec_msg_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_sec_msg(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_sec_msg(s), s),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
@@ -7918,11 +10373,19 @@ pub proof fn lemma_parse_sec_msg_well_behaved_on(s: SpecStream)
     lemma_parse_32_bytes_well_behaved();
     lemma_parse_tail_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_64_bytes, spec_parse_32_bytes);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_64_bytes, spec_parse_32_bytes), spec_parse_tail, s);
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(spec_parse_64_bytes, spec_parse_32_bytes),
+        spec_parse_tail,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_sec_msg_well_behaved_on(s: SpecStream, v: ((Seq<u8>, Seq<u8>), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_sec_msg(s, v), s, v)
+pub proof fn lemma_serialize_sec_msg_well_behaved_on(
+    s: SpecStream,
+    v: ((Seq<u8>, Seq<u8>), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_sec_msg(s, v), s, v),
 {
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
@@ -7931,11 +10394,21 @@ pub proof fn lemma_serialize_sec_msg_well_behaved_on(s: SpecStream, v: ((Seq<u8>
     lemma_serialize_32_bytes_well_behaved();
     lemma_serialize_tail_well_behaved();
     lemma_serialize_pair_well_behaved(spec_serialize_64_bytes, spec_serialize_32_bytes);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes), spec_serialize_tail, s, v);
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes),
+        spec_serialize_tail,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_sec_msg_deterministic_on(s1: SpecStream, s2: SpecStream, v: ((Seq<u8>, Seq<u8>), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_sec_msg(s, v), s1, s2, v)
+pub proof fn lemma_serialize_sec_msg_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: ((Seq<u8>, Seq<u8>), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_sec_msg(s, v), s1, s2, v),
 {
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
@@ -7948,12 +10421,20 @@ pub proof fn lemma_serialize_sec_msg_deterministic_on(s1: SpecStream, s2: SpecSt
     lemma_serialize_tail_deterministic();
     lemma_serialize_pair_well_behaved(spec_serialize_64_bytes, spec_serialize_32_bytes);
     lemma_serialize_pair_deterministic(spec_serialize_64_bytes, spec_serialize_32_bytes);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes), spec_serialize_tail, s1, s2, v);
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes),
+        spec_serialize_tail,
+        s1,
+        s2,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_sec_msg_correct_on(s: SpecStream, v: ((Seq<u8>, Seq<u8>), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v), s, v)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v), s, v),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
@@ -7969,19 +10450,36 @@ pub proof fn lemma_parse_sec_msg_correct_on(s: SpecStream, v: ((Seq<u8>, Seq<u8>
     lemma_parse_tail_well_behaved();
     lemma_parse_64_bytes_strong_prefix();
     lemma_parse_32_bytes_strong_prefix();
-    
+
     lemma_parse_64_bytes_correct();
     lemma_parse_32_bytes_correct();
     lemma_parse_tail_correct();
     lemma_parse_pair_well_behaved(spec_parse_64_bytes, spec_parse_32_bytes);
     lemma_serialize_pair_well_behaved(spec_serialize_64_bytes, spec_serialize_32_bytes);
     lemma_parse_pair_strong_prefix(spec_parse_64_bytes, spec_parse_32_bytes);
-    lemma_parse_pair_correct(spec_parse_64_bytes, spec_parse_32_bytes, spec_serialize_64_bytes, spec_serialize_32_bytes);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_64_bytes, spec_parse_32_bytes), spec_parse_tail, spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes), spec_serialize_tail, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_64_bytes,
+        spec_parse_32_bytes,
+        spec_serialize_64_bytes,
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(spec_parse_64_bytes, spec_parse_32_bytes),
+        spec_parse_tail,
+        spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes),
+        spec_serialize_tail,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_sec_msg_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_sec_msg(s), |s, v| spec_serialize_sec_msg(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_sec_msg(s),
+            |s, v| spec_serialize_sec_msg(s, v),
+            s,
+        ),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
@@ -8000,65 +10498,104 @@ pub proof fn lemma_parse_sec_msg_serialize_inverse_on(s: SpecStream)
     lemma_parse_tail_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_64_bytes, spec_parse_32_bytes);
     lemma_serialize_pair_well_behaved(spec_serialize_64_bytes, spec_serialize_32_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_64_bytes, spec_parse_32_bytes, spec_serialize_64_bytes, spec_serialize_32_bytes);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_64_bytes, spec_parse_32_bytes), spec_parse_tail, spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes), spec_serialize_tail, s);
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_64_bytes,
+        spec_parse_32_bytes,
+        spec_serialize_64_bytes,
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(spec_parse_64_bytes, spec_parse_32_bytes),
+        spec_parse_tail,
+        spec_serialize_pair(spec_serialize_64_bytes, spec_serialize_32_bytes),
+        spec_serialize_tail,
+        s,
+    );
 }
-pub exec fn sec_parse_sec_msg(s: SecStream) -> (res: SecParseResult<((SecBytes, SecBytes), SecBytes)>)
-    ensures prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_sec_msg(s))
+
+pub exec fn sec_parse_sec_msg(s: SecStream) -> (res: SecParseResult<
+    ((SecBytes, SecBytes), SecBytes),
+>)
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_sec_msg(s)),
 {
-    proof { reveal(prop_sec_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_sec_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let ghost spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let ghost spec_parse_tail = |s| spec_parse_tail(s);
 
-    sec_parse_3_fold(sec_parse_64_bytes, sec_parse_32_bytes, sec_parse_tail, Ghost(spec_parse_64_bytes), Ghost(spec_parse_32_bytes), Ghost(spec_parse_tail), s)
+    sec_parse_3_fold(
+        sec_parse_64_bytes,
+        sec_parse_32_bytes,
+        sec_parse_tail,
+        Ghost(spec_parse_64_bytes),
+        Ghost(spec_parse_32_bytes),
+        Ghost(spec_parse_tail),
+        s,
+    )
 }
-pub exec fn sec_serialize_sec_msg(s: SecStream, v: ((SecBytes, SecBytes), SecBytes)) -> (res: SecSerializeResult)
-    ensures prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_sec_msg(s, v))
+
+pub exec fn sec_serialize_sec_msg(s: SecStream, v: ((SecBytes, SecBytes), SecBytes)) -> (res:
+    SecSerializeResult)
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_sec_msg(s, v)),
 {
-    proof { reveal(prop_sec_serialize_exec_spec_equiv); }
+    proof {
+        reveal(prop_sec_serialize_exec_spec_equiv);
+    }
     let ghost spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let ghost spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let ghost spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
 
-    sec_serialize_3_fold(sec_serialize_64_bytes, sec_serialize_32_bytes, sec_serialize_tail, Ghost(spec_serialize_64_bytes), Ghost(spec_serialize_32_bytes), Ghost(spec_serialize_tail), s, v)
+    sec_serialize_3_fold(
+        sec_serialize_64_bytes,
+        sec_serialize_32_bytes,
+        sec_serialize_tail,
+        Ghost(spec_serialize_64_bytes),
+        Ghost(spec_serialize_32_bytes),
+        Ghost(spec_serialize_tail),
+        s,
+        v,
+    )
 }
 
-                    
 pub exec fn sec_parse_256_bytes(s: SecStream) -> (res: SecParseResult<SecBytes>)
     ensures
-        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_256_bytes(s))
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_256_bytes(s)),
 {
     parse_sec_bytes(s, 256)
 }
 
 pub exec fn sec_serialize_256_bytes(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
     ensures
-        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_256_bytes(s, v))
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_256_bytes(s, v)),
 {
     serialize_sec_bytes(s, v, 256)
 }
+
 pub struct SpecSecMsg2 {
     m1: Seq<u8>,
     m2: Seq<u8>,
-
 }
+
 pub struct SecMsg2 {
     m1: SecBytes,
     m2: SecBytes,
-
 }
 
-pub open spec fn spec_parse_sec_msg2(s: SpecStream) -> SpecParseResult<(Seq<u8>, Seq<u8>)>
-{
+pub open spec fn spec_parse_sec_msg2(s: SpecStream) -> SpecParseResult<(Seq<u8>, Seq<u8>)> {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
 
     spec_parse_pair(spec_parse_64_bytes, spec_parse_256_bytes)(s)
 }
 
-pub open spec fn spec_serialize_sec_msg2(s: SpecStream, v: (Seq<u8>, Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_sec_msg2(
+    s: SpecStream,
+    v: (Seq<u8>, Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
 
@@ -8066,42 +10603,54 @@ pub open spec fn spec_serialize_sec_msg2(s: SpecStream, v: (Seq<u8>, Seq<u8>)) -
 }
 
 pub proof fn lemma_parse_sec_msg2_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_sec_msg2(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_sec_msg2(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_sec_msg2 = |s| spec_parse_sec_msg2(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_sec_msg2, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_sec_msg2, s) by {
         lemma_parse_sec_msg2_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_sec_msg2_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_sec_msg2(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_sec_msg2(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_sec_msg2 = |s, v| spec_serialize_sec_msg2(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_sec_msg2, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_sec_msg2, s, v) by {
         lemma_serialize_sec_msg2_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_sec_msg2_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_sec_msg2(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_sec_msg2(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_sec_msg2 = |s, v| spec_serialize_sec_msg2(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_sec_msg2, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_sec_msg2, s1, s2, v) by {
         lemma_serialize_sec_msg2_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_sec_msg2_correct()
-    ensures prop_parse_correct(|s| spec_parse_sec_msg2(s), |s, v| spec_serialize_sec_msg2(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_sec_msg2(s), |s, v| spec_serialize_sec_msg2(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_sec_msg2 = |s| spec_parse_sec_msg2(s);
     let spec_serialize_sec_msg2 = |s, v| spec_serialize_sec_msg2(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_sec_msg2, spec_serialize_sec_msg2, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_sec_msg2,
+            spec_serialize_sec_msg2,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_sec_msg2_correct_on(s, v);
         }
@@ -8109,26 +10658,36 @@ pub proof fn lemma_parse_sec_msg2_correct()
 }
 
 pub proof fn lemma_parse_sec_msg2_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_sec_msg2(s), |s, v| spec_serialize_sec_msg2(s, v))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_sec_msg2(s),
+            |s, v| spec_serialize_sec_msg2(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_sec_msg2 = |s| spec_parse_sec_msg2(s);
     let spec_serialize_sec_msg2 = |s, v| spec_serialize_sec_msg2(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_sec_msg2, spec_serialize_sec_msg2, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_sec_msg2, spec_serialize_sec_msg2, s) by {
         lemma_parse_sec_msg2_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_sec_msg2_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_sec_msg2(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_sec_msg2(s)),
 {
     lemma_parse_sec_msg2_serialize_inverse();
     lemma_serialize_sec_msg2_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_sec_msg2(s), |s, v| spec_serialize_sec_msg2(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_sec_msg2(s),
+        |s, v| spec_serialize_sec_msg2(s, v),
+    );
 }
 
 pub proof fn lemma_parse_sec_msg2_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_sec_msg2(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_sec_msg2(s), s),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
@@ -8138,7 +10697,8 @@ pub proof fn lemma_parse_sec_msg2_well_behaved_on(s: SpecStream)
 }
 
 pub proof fn lemma_serialize_sec_msg2_well_behaved_on(s: SpecStream, v: (Seq<u8>, Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_sec_msg2(s, v), s, v)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_sec_msg2(s, v), s, v),
 {
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
@@ -8147,8 +10707,13 @@ pub proof fn lemma_serialize_sec_msg2_well_behaved_on(s: SpecStream, v: (Seq<u8>
     lemma_serialize_pair_well_behaved_on(spec_serialize_64_bytes, spec_serialize_256_bytes, s, v);
 }
 
-pub proof fn lemma_serialize_sec_msg2_deterministic_on(s1: SpecStream, s2: SpecStream, v: (Seq<u8>, Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_sec_msg2(s, v), s1, s2, v)
+pub proof fn lemma_serialize_sec_msg2_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (Seq<u8>, Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_sec_msg2(s, v), s1, s2, v),
 {
     let spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
@@ -8156,12 +10721,25 @@ pub proof fn lemma_serialize_sec_msg2_deterministic_on(s1: SpecStream, s2: SpecS
     lemma_serialize_256_bytes_well_behaved();
     lemma_serialize_64_bytes_deterministic();
     lemma_serialize_256_bytes_deterministic();
-    lemma_serialize_pair_deterministic_on(spec_serialize_64_bytes, spec_serialize_256_bytes, s1, s2, v);
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_64_bytes,
+        spec_serialize_256_bytes,
+        s1,
+        s2,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_sec_msg2_correct_on(s: SpecStream, v: (Seq<u8>, Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_sec_msg2(s), |s, v| spec_serialize_sec_msg2(s, v), s, v)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_sec_msg2(s),
+            |s, v| spec_serialize_sec_msg2(s, v),
+            s,
+            v,
+        ),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
@@ -8175,11 +10753,23 @@ pub proof fn lemma_parse_sec_msg2_correct_on(s: SpecStream, v: (Seq<u8>, Seq<u8>
     lemma_parse_256_bytes_strong_prefix();
     lemma_parse_64_bytes_correct();
     lemma_parse_256_bytes_correct();
-    lemma_parse_pair_correct_on(spec_parse_64_bytes, spec_parse_256_bytes, spec_serialize_64_bytes, spec_serialize_256_bytes, s, v);
+    lemma_parse_pair_correct_on(
+        spec_parse_64_bytes,
+        spec_parse_256_bytes,
+        spec_serialize_64_bytes,
+        spec_serialize_256_bytes,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_sec_msg2_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_sec_msg2(s), |s, v| spec_serialize_sec_msg2(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_sec_msg2(s),
+            |s, v| spec_serialize_sec_msg2(s, v),
+            s,
+        ),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
@@ -8191,21 +10781,29 @@ pub proof fn lemma_parse_sec_msg2_serialize_inverse_on(s: SpecStream)
     lemma_serialize_256_bytes_well_behaved();
     lemma_parse_64_bytes_serialize_inverse();
     lemma_parse_256_bytes_serialize_inverse();
-    lemma_parse_pair_serialize_inverse_on(spec_parse_64_bytes, spec_parse_256_bytes, spec_serialize_64_bytes, spec_serialize_256_bytes, s);
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_64_bytes,
+        spec_parse_256_bytes,
+        spec_serialize_64_bytes,
+        spec_serialize_256_bytes,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_sec_msg2_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_sec_msg2(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_sec_msg2(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_sec_msg2 = |s| spec_parse_sec_msg2(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_sec_msg2, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_sec_msg2, s1, s2) by {
         lemma_parse_sec_msg2_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_sec_msg2_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_sec_msg2(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_sec_msg2(s), s1, s2),
 {
     let spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
@@ -8217,24 +10815,46 @@ pub proof fn lemma_parse_sec_msg2_strong_prefix_on(s1: SpecStream, s2: SpecStrea
 }
 
 pub exec fn sec_parse_sec_msg2(s: SecStream) -> (res: SecParseResult<(SecBytes, SecBytes)>)
-    ensures prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_sec_msg2(s))
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_sec_msg2(s)),
 {
-    proof { reveal(prop_sec_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_sec_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_64_bytes = |s| spec_parse_64_bytes(s);
     let ghost spec_parse_256_bytes = |s| spec_parse_256_bytes(s);
 
-    sec_parse_pair(sec_parse_64_bytes, sec_parse_256_bytes, Ghost(spec_parse_64_bytes), Ghost(spec_parse_256_bytes), s)
+    sec_parse_pair(
+        sec_parse_64_bytes,
+        sec_parse_256_bytes,
+        Ghost(spec_parse_64_bytes),
+        Ghost(spec_parse_256_bytes),
+        s,
+    )
 }
-pub exec fn sec_serialize_sec_msg2(s: SecStream, v: (SecBytes, SecBytes)) -> (res: SecSerializeResult)
-    ensures prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_sec_msg2(s, v))
+
+pub exec fn sec_serialize_sec_msg2(s: SecStream, v: (SecBytes, SecBytes)) -> (res:
+    SecSerializeResult)
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_sec_msg2(s, v)),
 {
-    proof { reveal(prop_sec_serialize_exec_spec_equiv); }
+    proof {
+        reveal(prop_sec_serialize_exec_spec_equiv);
+    }
     let ghost spec_serialize_64_bytes = |s, v| spec_serialize_64_bytes(s, v);
     let ghost spec_serialize_256_bytes = |s, v| spec_serialize_256_bytes(s, v);
 
-    sec_serialize_pair(sec_serialize_64_bytes, sec_serialize_256_bytes, Ghost(spec_serialize_64_bytes), Ghost(spec_serialize_256_bytes), s, v)
+    sec_serialize_pair(
+        sec_serialize_64_bytes,
+        sec_serialize_256_bytes,
+        Ghost(spec_serialize_64_bytes),
+        Ghost(spec_serialize_256_bytes),
+        s,
+        v,
+    )
 }
 
-                    
-fn main() {}
+fn main() {
 }
+
+} // verus!

--- a/vest-dsl/test/src/test.rs
+++ b/vest-dsl/test/src/test.rs
@@ -1,0 +1,642 @@
+#![allow(unused_imports)]
+use vest::properties::*;
+use vest::regular::and_then::*;
+use vest::regular::bytes::*;
+use vest::regular::bytes_n::*;
+use vest::regular::choice::*;
+use vest::regular::cond::*;
+use vest::regular::depend::*;
+use vest::regular::map::*;
+use vest::regular::refined::*;
+use vest::regular::tail::*;
+use vest::regular::uints::*;
+use vest::utils::*;
+use vstd::prelude::*;
+verus! {
+
+pub enum SpecARegularChoose {
+    A(u8),
+    B(u16),
+    C(u32),
+}
+
+pub type SpecARegularChooseInner = Either<Either<u8, u16>, u32>;
+
+impl SpecFrom<SpecARegularChoose> for SpecARegularChooseInner {
+    open spec fn spec_from(m: SpecARegularChoose) -> SpecARegularChooseInner {
+        match m {
+            SpecARegularChoose::A(m) => Either::Left(Either::Left(m)),
+            SpecARegularChoose::B(m) => Either::Left(Either::Right(m)),
+            SpecARegularChoose::C(m) => Either::Right(m),
+        }
+    }
+}
+
+impl SpecFrom<SpecARegularChooseInner> for SpecARegularChoose {
+    open spec fn spec_from(m: SpecARegularChooseInner) -> SpecARegularChoose {
+        match m {
+            Either::Left(Either::Left(m)) => SpecARegularChoose::A(m),
+            Either::Left(Either::Right(m)) => SpecARegularChoose::B(m),
+            Either::Right(m) => SpecARegularChoose::C(m),
+        }
+    }
+}
+
+pub enum ARegularChoose {
+    A(u8),
+    B(u16),
+    C(u32),
+}
+
+pub type ARegularChooseInner = Either<Either<u8, u16>, u32>;
+
+impl View for ARegularChoose {
+    type V = SpecARegularChoose;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            ARegularChoose::A(m) => SpecARegularChoose::A(m@),
+            ARegularChoose::B(m) => SpecARegularChoose::B(m@),
+            ARegularChoose::C(m) => SpecARegularChoose::C(m@),
+        }
+    }
+}
+
+impl From<ARegularChoose> for ARegularChooseInner {
+    fn ex_from(m: ARegularChoose) -> ARegularChooseInner {
+        match m {
+            ARegularChoose::A(m) => Either::Left(Either::Left(m)),
+            ARegularChoose::B(m) => Either::Left(Either::Right(m)),
+            ARegularChoose::C(m) => Either::Right(m),
+        }
+    }
+}
+
+impl From<ARegularChooseInner> for ARegularChoose {
+    fn ex_from(m: ARegularChooseInner) -> ARegularChoose {
+        match m {
+            Either::Left(Either::Left(m)) => ARegularChoose::A(m),
+            Either::Left(Either::Right(m)) => ARegularChoose::B(m),
+            Either::Right(m) => ARegularChoose::C(m),
+        }
+    }
+}
+
+pub struct ARegularChooseMapper;
+
+impl View for ARegularChooseMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for ARegularChooseMapper {
+    type Src = SpecARegularChooseInner;
+
+    type Dst = SpecARegularChoose;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for ARegularChooseMapper {
+    type Src<'a> = ARegularChooseInner;
+
+    type Dst<'a> = ARegularChoose;
+
+    type SrcOwned = ARegularChooseOwnedInner;
+
+    type DstOwned = ARegularChooseOwned;
+}
+
+pub enum ARegularChooseOwned {
+    A(u8),
+    B(u16),
+    C(u32),
+}
+
+pub type ARegularChooseOwnedInner = Either<Either<u8, u16>, u32>;
+
+impl View for ARegularChooseOwned {
+    type V = SpecARegularChoose;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            ARegularChooseOwned::A(m) => SpecARegularChoose::A(m@),
+            ARegularChooseOwned::B(m) => SpecARegularChoose::B(m@),
+            ARegularChooseOwned::C(m) => SpecARegularChoose::C(m@),
+        }
+    }
+}
+
+impl From<ARegularChooseOwned> for ARegularChooseOwnedInner {
+    fn ex_from(m: ARegularChooseOwned) -> ARegularChooseOwnedInner {
+        match m {
+            ARegularChooseOwned::A(m) => Either::Left(Either::Left(m)),
+            ARegularChooseOwned::B(m) => Either::Left(Either::Right(m)),
+            ARegularChooseOwned::C(m) => Either::Right(m),
+        }
+    }
+}
+
+impl From<ARegularChooseOwnedInner> for ARegularChooseOwned {
+    fn ex_from(m: ARegularChooseOwnedInner) -> ARegularChooseOwned {
+        match m {
+            Either::Left(Either::Left(m)) => ARegularChooseOwned::A(m),
+            Either::Left(Either::Right(m)) => ARegularChooseOwned::B(m),
+            Either::Right(m) => ARegularChooseOwned::C(m),
+        }
+    }
+}
+
+#[derive(Structural, Copy, Clone, PartialEq, Eq)]
+pub enum AClosedEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+
+pub type SpecAClosedEnum = AClosedEnum;
+
+pub type AClosedEnumOwned = AClosedEnum;
+
+pub type AClosedEnumInner = u8;
+
+impl View for AClosedEnum {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecTryFrom<AClosedEnumInner> for AClosedEnum {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AClosedEnumInner) -> Result<AClosedEnum, ()> {
+        match v {
+            0u8 => Ok(AClosedEnum::A),
+            1u8 => Ok(AClosedEnum::B),
+            2u8 => Ok(AClosedEnum::C),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SpecTryFrom<AClosedEnum> for AClosedEnumInner {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AClosedEnum) -> Result<AClosedEnumInner, ()> {
+        match v {
+            AClosedEnum::A => Ok(0u8),
+            AClosedEnum::B => Ok(1u8),
+            AClosedEnum::C => Ok(2u8),
+        }
+    }
+}
+
+impl TryFrom<AClosedEnumInner> for AClosedEnum {
+    type Error = ();
+
+    fn ex_try_from(v: AClosedEnumInner) -> Result<AClosedEnum, ()> {
+        match v {
+            0u8 => Ok(AClosedEnum::A),
+            1u8 => Ok(AClosedEnum::B),
+            2u8 => Ok(AClosedEnum::C),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<AClosedEnum> for AClosedEnumInner {
+    type Error = ();
+
+    fn ex_try_from(v: AClosedEnum) -> Result<AClosedEnumInner, ()> {
+        match v {
+            AClosedEnum::A => Ok(0u8),
+            AClosedEnum::B => Ok(1u8),
+            AClosedEnum::C => Ok(2u8),
+        }
+    }
+}
+
+pub struct AClosedEnumMapper;
+
+impl View for AClosedEnumMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecTryFromInto for AClosedEnumMapper {
+    type Src = AClosedEnumInner;
+
+    type Dst = AClosedEnum;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl TryFromInto for AClosedEnumMapper {
+    type Src<'a> = AClosedEnumInner;
+
+    type Dst<'a> = AClosedEnum;
+
+    type SrcOwned = AClosedEnumInner;
+
+    type DstOwned = AClosedEnum;
+}
+
+pub type SpecAnOpenEnum = u8;
+
+pub type AnOpenEnum = u8;
+
+pub type AnOpenEnumOwned = u8;
+
+pub enum SpecAChooseWithDefault {
+    A(u8),
+    B(u16),
+    C(u32),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecAChooseWithDefaultInner = Either<Either<Either<u8, u16>, u32>, Seq<u8>>;
+
+impl SpecFrom<SpecAChooseWithDefault> for SpecAChooseWithDefaultInner {
+    open spec fn spec_from(m: SpecAChooseWithDefault) -> SpecAChooseWithDefaultInner {
+        match m {
+            SpecAChooseWithDefault::A(m) => Either::Left(Either::Left(Either::Left(m))),
+            SpecAChooseWithDefault::B(m) => Either::Left(Either::Left(Either::Right(m))),
+            SpecAChooseWithDefault::C(m) => Either::Left(Either::Right(m)),
+            SpecAChooseWithDefault::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl SpecFrom<SpecAChooseWithDefaultInner> for SpecAChooseWithDefault {
+    open spec fn spec_from(m: SpecAChooseWithDefaultInner) -> SpecAChooseWithDefault {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => SpecAChooseWithDefault::A(m),
+            Either::Left(Either::Left(Either::Right(m))) => SpecAChooseWithDefault::B(m),
+            Either::Left(Either::Right(m)) => SpecAChooseWithDefault::C(m),
+            Either::Right(m) => SpecAChooseWithDefault::Unrecognized(m),
+        }
+    }
+}
+
+pub enum AChooseWithDefault<'a> {
+    A(u8),
+    B(u16),
+    C(u32),
+    Unrecognized(&'a [u8]),
+}
+
+pub type AChooseWithDefaultInner<'a> = Either<Either<Either<u8, u16>, u32>, &'a [u8]>;
+
+impl View for AChooseWithDefault<'_> {
+    type V = SpecAChooseWithDefault;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            AChooseWithDefault::A(m) => SpecAChooseWithDefault::A(m@),
+            AChooseWithDefault::B(m) => SpecAChooseWithDefault::B(m@),
+            AChooseWithDefault::C(m) => SpecAChooseWithDefault::C(m@),
+            AChooseWithDefault::Unrecognized(m) => SpecAChooseWithDefault::Unrecognized(m@),
+        }
+    }
+}
+
+impl<'a> From<AChooseWithDefault<'a>> for AChooseWithDefaultInner<'a> {
+    fn ex_from(m: AChooseWithDefault<'a>) -> AChooseWithDefaultInner<'a> {
+        match m {
+            AChooseWithDefault::A(m) => Either::Left(Either::Left(Either::Left(m))),
+            AChooseWithDefault::B(m) => Either::Left(Either::Left(Either::Right(m))),
+            AChooseWithDefault::C(m) => Either::Left(Either::Right(m)),
+            AChooseWithDefault::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl<'a> From<AChooseWithDefaultInner<'a>> for AChooseWithDefault<'a> {
+    fn ex_from(m: AChooseWithDefaultInner<'a>) -> AChooseWithDefault<'a> {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => AChooseWithDefault::A(m),
+            Either::Left(Either::Left(Either::Right(m))) => AChooseWithDefault::B(m),
+            Either::Left(Either::Right(m)) => AChooseWithDefault::C(m),
+            Either::Right(m) => AChooseWithDefault::Unrecognized(m),
+        }
+    }
+}
+
+pub struct AChooseWithDefaultMapper;
+
+impl View for AChooseWithDefaultMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for AChooseWithDefaultMapper {
+    type Src = SpecAChooseWithDefaultInner;
+
+    type Dst = SpecAChooseWithDefault;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for AChooseWithDefaultMapper {
+    type Src<'a> = AChooseWithDefaultInner<'a>;
+
+    type Dst<'a> = AChooseWithDefault<'a>;
+
+    type SrcOwned = AChooseWithDefaultOwnedInner;
+
+    type DstOwned = AChooseWithDefaultOwned;
+}
+
+pub enum AChooseWithDefaultOwned {
+    A(u8),
+    B(u16),
+    C(u32),
+    Unrecognized(Vec<u8>),
+}
+
+pub type AChooseWithDefaultOwnedInner = Either<Either<Either<u8, u16>, u32>, Vec<u8>>;
+
+impl View for AChooseWithDefaultOwned {
+    type V = SpecAChooseWithDefault;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            AChooseWithDefaultOwned::A(m) => SpecAChooseWithDefault::A(m@),
+            AChooseWithDefaultOwned::B(m) => SpecAChooseWithDefault::B(m@),
+            AChooseWithDefaultOwned::C(m) => SpecAChooseWithDefault::C(m@),
+            AChooseWithDefaultOwned::Unrecognized(m) => SpecAChooseWithDefault::Unrecognized(m@),
+        }
+    }
+}
+
+impl From<AChooseWithDefaultOwned> for AChooseWithDefaultOwnedInner {
+    fn ex_from(m: AChooseWithDefaultOwned) -> AChooseWithDefaultOwnedInner {
+        match m {
+            AChooseWithDefaultOwned::A(m) => Either::Left(Either::Left(Either::Left(m))),
+            AChooseWithDefaultOwned::B(m) => Either::Left(Either::Left(Either::Right(m))),
+            AChooseWithDefaultOwned::C(m) => Either::Left(Either::Right(m)),
+            AChooseWithDefaultOwned::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl From<AChooseWithDefaultOwnedInner> for AChooseWithDefaultOwned {
+    fn ex_from(m: AChooseWithDefaultOwnedInner) -> AChooseWithDefaultOwned {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => AChooseWithDefaultOwned::A(m),
+            Either::Left(Either::Left(Either::Right(m))) => AChooseWithDefaultOwned::B(m),
+            Either::Left(Either::Right(m)) => AChooseWithDefaultOwned::C(m),
+            Either::Right(m) => AChooseWithDefaultOwned::Unrecognized(m),
+        }
+    }
+}
+
+pub type ARegularChooseCombinator = Mapped<
+    OrdChoice<OrdChoice<Cond<U8>, Cond<U16>>, Cond<U32>>,
+    ARegularChooseMapper,
+>;
+
+pub type AClosedEnumCombinator = TryMap<U8, AClosedEnumMapper>;
+
+pub type AnOpenEnumCombinator = U8;
+
+pub type AChooseWithDefaultCombinator = Mapped<
+    OrdChoice<OrdChoice<OrdChoice<Cond<U8>, Cond<U16>>, Cond<U32>>, Cond<Tail>>,
+    AChooseWithDefaultMapper,
+>;
+
+pub open spec fn spec_a_regular_choose(e: SpecAClosedEnum) -> ARegularChooseCombinator {
+    Mapped {
+        inner: OrdChoice(
+            OrdChoice(
+                Cond { cond: e == AClosedEnum::A, inner: U8 },
+                Cond { cond: e == AClosedEnum::B, inner: U16 },
+            ),
+            Cond { cond: e == AClosedEnum::C, inner: U32 },
+        ),
+        mapper: ARegularChooseMapper,
+    }
+}
+
+pub fn a_regular_choose(e: AClosedEnum) -> (o: ARegularChooseCombinator)
+    ensures
+        o@ == spec_a_regular_choose(e@),
+{
+    Mapped {
+        inner: OrdChoice(
+            OrdChoice(
+                Cond { cond: e == AClosedEnum::A, inner: U8 },
+                Cond { cond: e == AClosedEnum::B, inner: U16 },
+            ),
+            Cond { cond: e == AClosedEnum::C, inner: U32 },
+        ),
+        mapper: ARegularChooseMapper,
+    }
+}
+
+pub open spec fn spec_a_closed_enum() -> AClosedEnumCombinator {
+    TryMap { inner: U8, mapper: AClosedEnumMapper }
+}
+
+pub fn a_closed_enum() -> (o: AClosedEnumCombinator)
+    ensures
+        o@ == spec_a_closed_enum(),
+{
+    TryMap { inner: U8, mapper: AClosedEnumMapper }
+}
+
+pub open spec fn spec_an_open_enum() -> AnOpenEnumCombinator {
+    U8
+}
+
+pub fn an_open_enum() -> (o: AnOpenEnumCombinator)
+    ensures
+        o@ == spec_an_open_enum(),
+{
+    U8
+}
+
+pub open spec fn spec_a_choose_with_default(e: SpecAnOpenEnum) -> AChooseWithDefaultCombinator {
+    Mapped {
+        inner: OrdChoice(
+            OrdChoice(
+                OrdChoice(Cond { cond: e == 0, inner: U8 }, Cond { cond: e == 1, inner: U16 }),
+                Cond { cond: e == 2, inner: U32 },
+            ),
+            Cond { cond: !(e == 0 || e == 1 || e == 2), inner: Tail },
+        ),
+        mapper: AChooseWithDefaultMapper,
+    }
+}
+
+pub fn a_choose_with_default<'a>(e: AnOpenEnum) -> (o: AChooseWithDefaultCombinator)
+    ensures
+        o@ == spec_a_choose_with_default(e@),
+{
+    Mapped {
+        inner: OrdChoice(
+            OrdChoice(
+                OrdChoice(Cond { cond: e == 0, inner: U8 }, Cond { cond: e == 1, inner: U16 }),
+                Cond { cond: e == 2, inner: U32 },
+            ),
+            Cond { cond: !(e == 0 || e == 1 || e == 2), inner: Tail },
+        ),
+        mapper: AChooseWithDefaultMapper,
+    }
+}
+
+pub open spec fn parse_spec_a_regular_choose(i: Seq<u8>, e: SpecAClosedEnum) -> Result<
+    (usize, SpecARegularChoose),
+    (),
+> {
+    spec_a_regular_choose(e).spec_parse(i)
+}
+
+pub open spec fn serialize_spec_a_regular_choose(
+    msg: SpecARegularChoose,
+    e: SpecAClosedEnum,
+) -> Result<Seq<u8>, ()> {
+    spec_a_regular_choose(e).spec_serialize(msg)
+}
+
+pub fn parse_a_regular_choose(i: &[u8], e: AClosedEnum) -> (o: Result<(usize, ARegularChoose), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_a_regular_choose(i@, e@) matches Ok(r_) && r@ == r_,
+{
+    a_regular_choose(e).parse(i)
+}
+
+pub fn serialize_a_regular_choose(
+    msg: ARegularChoose,
+    data: &mut Vec<u8>,
+    pos: usize,
+    e: AClosedEnum,
+) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_a_regular_choose(msg@, e@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    a_regular_choose(e).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_a_closed_enum(i: Seq<u8>) -> Result<(usize, SpecAClosedEnum), ()> {
+    spec_a_closed_enum().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_a_closed_enum(msg: SpecAClosedEnum) -> Result<Seq<u8>, ()> {
+    spec_a_closed_enum().spec_serialize(msg)
+}
+
+pub fn parse_a_closed_enum(i: &[u8]) -> (o: Result<(usize, AClosedEnum), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_a_closed_enum(i@) matches Ok(r_) && r@ == r_,
+{
+    a_closed_enum().parse(i)
+}
+
+pub fn serialize_a_closed_enum(msg: AClosedEnum, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    (),
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_a_closed_enum(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    a_closed_enum().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_an_open_enum(i: Seq<u8>) -> Result<(usize, SpecAnOpenEnum), ()> {
+    spec_an_open_enum().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_an_open_enum(msg: SpecAnOpenEnum) -> Result<Seq<u8>, ()> {
+    spec_an_open_enum().spec_serialize(msg)
+}
+
+pub fn parse_an_open_enum(i: &[u8]) -> (o: Result<(usize, AnOpenEnum), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_an_open_enum(i@) matches Ok(r_) && r@ == r_,
+{
+    an_open_enum().parse(i)
+}
+
+pub fn serialize_an_open_enum(msg: AnOpenEnum, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    (),
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_an_open_enum(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    an_open_enum().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_a_choose_with_default(i: Seq<u8>, e: SpecAnOpenEnum) -> Result<
+    (usize, SpecAChooseWithDefault),
+    (),
+> {
+    spec_a_choose_with_default(e).spec_parse(i)
+}
+
+pub open spec fn serialize_spec_a_choose_with_default(
+    msg: SpecAChooseWithDefault,
+    e: SpecAnOpenEnum,
+) -> Result<Seq<u8>, ()> {
+    spec_a_choose_with_default(e).spec_serialize(msg)
+}
+
+pub fn parse_a_choose_with_default(i: &[u8], e: AnOpenEnum) -> (o: Result<
+    (usize, AChooseWithDefault<'_>),
+    (),
+>)
+    ensures
+        o matches Ok(r) ==> parse_spec_a_choose_with_default(i@, e@) matches Ok(r_) && r@ == r_,
+{
+    a_choose_with_default(e).parse(i)
+}
+
+pub fn serialize_a_choose_with_default(
+    msg: AChooseWithDefault<'_>,
+    data: &mut Vec<u8>,
+    pos: usize,
+    e: AnOpenEnum,
+) -> (o: Result<usize, ()>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_a_choose_with_default(msg@, e@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    a_choose_with_default(e).serialize(msg, data, pos)
+}
+
+} // verus!

--- a/vest-dsl/test/src/test.vest
+++ b/vest-dsl/test/src/test.vest
@@ -1,0 +1,27 @@
+a_closed_enum = enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+
+a_regular_choose(@e: a_closed_enum) = choose(@e) {
+  A => u8,
+  B => u16,
+  C => u32,
+}
+
+
+an_open_enum = enum {
+  A = 0,
+  B = 1,
+  C = 2,
+  ...
+}
+
+a_choose_with_default(@e: an_open_enum) = choose(@e) {
+  A => u8,
+  B => u16,
+  C => u32,
+  _ => Tail,
+}
+

--- a/vest-dsl/test/src/wireguard.rs
+++ b/vest-dsl/test/src/wireguard.rs
@@ -6,284 +6,275 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 verus! {
-    /// won't work for serializers
-    pub struct Stream<'a> {
-        pub data: &'a [u8], // the input data
-        pub start: usize, // the index, in range [0, data.len())
-    }
 
-    pub struct SerializeStream {
-        pub data: Vec<u8>,
-        pub start: usize,
-    }
-
-    pub struct SpecStream {
-        pub data: Seq<u8>,
-        pub start: int, // the index, in range [0, data.len())
-    }
-
-    impl<'a> DView for Stream<'a> {
-        type V = SpecStream;
-        open spec fn dview(&self) -> SpecStream {
-            SpecStream {
-                data: self.data.dview(),
-                start: self.start as int,
-            }
-        }
-    }
-
-    impl DView for SerializeStream {
-        type V = SpecStream;
-        open spec fn dview(&self) -> SpecStream {
-            SpecStream {
-                data: self.data.dview(),
-                start: self.start as int,
-            }
-        }
-    }
-
-    #[derive(PartialEq, Eq)]
-    pub enum ParseError {
-        Eof,
-        NotEnoughData,
-        NegativeIndex,
-        IntegerOverflow,
-        ConstMismatch,
-    }
-
-    #[derive(PartialEq, Eq)]
-    pub enum SerializeError {
-        NotEnoughSpace,
-        NegativeIndex,
-        IntegerOverflow,
-        RepeatNMismatch, // for spec_serialize_repeat_n
-        TailLengthMismatch, // for spec_serialize_tail
-        ConstMismatch, // for const serializers
-        BytesLengthMismatch, // for spec_serialize_bytes
-    }
-
-    pub type ParseResult<'a, Output> = Result<(Stream<'a>, usize, Output), ParseError>;
-    pub type SpecParseResult<Output> = Result<(SpecStream, nat, Output), ParseError>;
-
-    pub type SerializeResult = Result<(usize, usize), SerializeError>; // (new start position, number of bytes written)
-    pub type SpecSerializeResult = Result<(SpecStream, nat), SerializeError>;
-
-    /// opaque type abstraction over raw bytes
-    pub struct SecBytes(Vec<u8>);
-
-    impl DView for SecBytes {
-        type V = Seq<u8>;
-        closed spec fn dview(&self) -> Self::V
-        {
-            self.0.dview()
-        }
-    }
-
-    impl SecBytes {
-
-        pub fn length(&self) -> (res: usize)
-            ensures
-                res == self.dview().len()
-        {
-            self.0.length()
-        }
-
-        /// memcpy the secret bytes from `self.0[i..j]` to a new secret bytes
-        pub fn subrange(&self, i: usize, j: usize) -> (res: Self)
-            requires
-                0 <= i <= j <= self.dview().len()
-            ensures
-                res.dview() == self.dview().subrange(i as int, j as int)
-        {
-            Self(slice_to_vec(slice_subrange(vec_as_slice(&self.0), i, j))) // (&self.0[i..j]).to_vec()
-        }
-
-        pub fn append(&mut self, other: &mut Self)
-            ensures
-                self.dview() == old(self).dview() + old(other).dview()
-        {
-            vec_append(&mut self.0, &mut other.0);
-        }
-    }
-
-    pub struct SecStream {
-        pub data : SecBytes,
-        pub start : usize
-    }
-
-    impl DView for SecStream {
-        type V = SpecStream;
-        open spec fn dview(&self) -> SpecStream {
-            SpecStream {
-                data: self.data.dview(),
-                start: self.start as int,
-            }
-        }
-    }
-
-    pub type SecParseResult<Sec> = Result<(SecStream, usize, Sec), ParseError>;
-    pub type SecSerializeResult = Result<(SecStream, usize), SerializeError>;
-
-    #[verifier(external)]
-    impl<'a> std::fmt::Debug for Stream<'a> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "Stream {{ data: {:?}, start: {} }}", self.data, self.start)
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SerializeStream {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SerializeStream {{ data: {:?}, start: {} }}", self.data, self.start)
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SecStream {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SecStream {{ data: {:?}, start: {} }}", self.data, self.start)
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SecBytes {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SecBytes {{ {:?} }}", self.0)
-        }
-    }
-
-    #[verifier(external_body)]
-    impl<'a> std::clone::Clone for Stream<'a> {
-        fn clone(&self) -> (res: Self)
-            ensures
-                self.data == res.data,
-                self.start == res.start
-        {
-            Self {
-                data: self.data.clone(),
-                start: self.start,
-            }
-        }
-    }
-
-    impl<'a> std::clone::Clone for SerializeStream {
-        #[verifier(external_body)]
-        fn clone(&self) -> (res: Self)
-            ensures
-                self.data == res.data,
-                self.start == res.start
-        {
-            Self {
-                data: self.data.clone(),
-                start: self.start,
-            }
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for ParseError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::Eof => write!(f, "Eof"),
-                Self::NotEnoughData => write!(f, "NotEnoughData"),
-                Self::NegativeIndex => write!(f, "Other"),
-                Self::IntegerOverflow => write!(f, "IntegerOverflow"),
-                Self::ConstMismatch => write!(f, "ConstMismatch"),
-            }
-        }
-    }
-
-    #[verifier(external)]
-    impl std::fmt::Debug for SerializeError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::NotEnoughSpace => write!(f, "NotEnoughSpace"),
-                Self::NegativeIndex => write!(f, "NegativeIndex"),
-                Self::RepeatNMismatch => write!(f, "RepeatNMismatch"),
-                Self::IntegerOverflow => write!(f, "IntegerOverflow"),
-                Self::TailLengthMismatch => write!(f, "TailLengthMismatch"),
-                Self::ConstMismatch => write!(f, "ConstMismatch"),
-                Self::BytesLengthMismatch => write!(f, "BytesLengthMismatch"),
-            }
-        }
-    }
-
-    pub enum Either<A, B> {
-        Left(A),
-        Right(B),
-    }
-
-    impl<A, B> DView for Either<A, B>
-        where
-            A: DView,
-            B: DView,
-    {
-        type V = Either<A::V, B::V>;
-        open spec fn dview(&self) -> Either<A::V, B::V> {
-            match self {
-                Self::Left(a) => Either::Left(a.dview()),
-                Self::Right(b) => Either::Right(b.dview()),
-            }
-        }
-    }
-
-    #[verifier(external)]
-    impl<A,B> std::fmt::Debug for Either<A, B>
-        where
-            A: std::fmt::Debug,
-            B: std::fmt::Debug,
-    {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                Self::Left(a) => write!(f, "Left({:?})", a),
-                Self::Right(b) => write!(f, "Right({:?})", b),
-            }
-        }
-    }
-
+/// won't work for serializers
+pub struct Stream<'a> {
+    pub data: &'a [u8],  // the input data
+    pub start: usize,  // the index, in range [0, data.len())
 }
 
+pub struct SerializeStream {
+    pub data: Vec<u8>,
+    pub start: usize,
+}
+
+pub struct SpecStream {
+    pub data: Seq<u8>,
+    pub start: int,  // the index, in range [0, data.len())
+}
+
+impl<'a> DView for Stream<'a> {
+    type V = SpecStream;
+
+    open spec fn dview(&self) -> SpecStream {
+        SpecStream { data: self.data.dview(), start: self.start as int }
+    }
+}
+
+impl DView for SerializeStream {
+    type V = SpecStream;
+
+    open spec fn dview(&self) -> SpecStream {
+        SpecStream { data: self.data.dview(), start: self.start as int }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum ParseError {
+    Eof,
+    NotEnoughData,
+    NegativeIndex,
+    IntegerOverflow,
+    ConstMismatch,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum SerializeError {
+    NotEnoughSpace,
+    NegativeIndex,
+    IntegerOverflow,
+    RepeatNMismatch,  // for spec_serialize_repeat_n
+    TailLengthMismatch,  // for spec_serialize_tail
+    ConstMismatch,  // for const serializers
+    BytesLengthMismatch,  // for spec_serialize_bytes
+}
+
+pub type ParseResult<'a, Output> = Result<(Stream<'a>, usize, Output), ParseError>;
+
+pub type SpecParseResult<Output> = Result<(SpecStream, nat, Output), ParseError>;
+
+pub type SerializeResult = Result<(usize, usize), SerializeError>;
+  // (new start position, number of bytes written)
+pub type SpecSerializeResult = Result<(SpecStream, nat), SerializeError>;
+
+/// opaque type abstraction over raw bytes
+pub struct SecBytes(Vec<u8>);
+
+impl DView for SecBytes {
+    type V = Seq<u8>;
+
+    closed spec fn dview(&self) -> Self::V {
+        self.0.dview()
+    }
+}
+
+impl SecBytes {
+    pub fn length(&self) -> (res: usize)
+        ensures
+            res == self.dview().len(),
+    {
+        self.0.length()
+    }
+
+    /// memcpy the secret bytes from `self.0[i..j]` to a new secret bytes
+    pub fn subrange(&self, i: usize, j: usize) -> (res: Self)
+        requires
+            0 <= i <= j <= self.dview().len(),
+        ensures
+            res.dview() == self.dview().subrange(i as int, j as int),
+    {
+        Self(
+            slice_to_vec(slice_subrange(vec_as_slice(&self.0), i, j)),
+        )  // (&self.0[i..j]).to_vec()
+
+    }
+
+    pub fn append(&mut self, other: &mut Self)
+        ensures
+            self.dview() == old(self).dview() + old(other).dview(),
+    {
+        vec_append(&mut self.0, &mut other.0);
+    }
+}
+
+pub struct SecStream {
+    pub data: SecBytes,
+    pub start: usize,
+}
+
+impl DView for SecStream {
+    type V = SpecStream;
+
+    open spec fn dview(&self) -> SpecStream {
+        SpecStream { data: self.data.dview(), start: self.start as int }
+    }
+}
+
+pub type SecParseResult<Sec> = Result<(SecStream, usize, Sec), ParseError>;
+
+pub type SecSerializeResult = Result<(SecStream, usize), SerializeError>;
+
+#[verifier(external)]
+impl<'a> std::fmt::Debug for Stream<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Stream {{ data: {:?}, start: {} }}", self.data, self.start)
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SerializeStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SerializeStream {{ data: {:?}, start: {} }}", self.data, self.start)
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SecStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecStream {{ data: {:?}, start: {} }}", self.data, self.start)
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SecBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SecBytes {{ {:?} }}", self.0)
+    }
+}
+
+#[verifier(external_body)]
+impl<'a> std::clone::Clone for Stream<'a> {
+    fn clone(&self) -> (res: Self)
+        ensures
+            self.data == res.data,
+            self.start == res.start,
+    {
+        Self { data: self.data.clone(), start: self.start }
+    }
+}
+
+impl<'a> std::clone::Clone for SerializeStream {
+    #[verifier(external_body)]
+    fn clone(&self) -> (res: Self)
+        ensures
+            self.data == res.data,
+            self.start == res.start,
+    {
+        Self { data: self.data.clone(), start: self.start }
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Eof => write!(f, "Eof"),
+            Self::NotEnoughData => write!(f, "NotEnoughData"),
+            Self::NegativeIndex => write!(f, "Other"),
+            Self::IntegerOverflow => write!(f, "IntegerOverflow"),
+            Self::ConstMismatch => write!(f, "ConstMismatch"),
+        }
+    }
+}
+
+#[verifier(external)]
+impl std::fmt::Debug for SerializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotEnoughSpace => write!(f, "NotEnoughSpace"),
+            Self::NegativeIndex => write!(f, "NegativeIndex"),
+            Self::RepeatNMismatch => write!(f, "RepeatNMismatch"),
+            Self::IntegerOverflow => write!(f, "IntegerOverflow"),
+            Self::TailLengthMismatch => write!(f, "TailLengthMismatch"),
+            Self::ConstMismatch => write!(f, "ConstMismatch"),
+            Self::BytesLengthMismatch => write!(f, "BytesLengthMismatch"),
+        }
+    }
+}
+
+pub enum Either<A, B> {
+    Left(A),
+    Right(B),
+}
+
+impl<A, B> DView for Either<A, B> where A: DView, B: DView {
+    type V = Either<A::V, B::V>;
+
+    open spec fn dview(&self) -> Either<A::V, B::V> {
+        match self {
+            Self::Left(a) => Either::Left(a.dview()),
+            Self::Right(b) => Either::Right(b.dview()),
+        }
+    }
+}
+
+#[verifier(external)]
+impl<A, B> std::fmt::Debug for Either<A, B> where A: std::fmt::Debug, B: std::fmt::Debug {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Left(a) => write!(f, "Left({:?})", a),
+            Self::Right(b) => write!(f, "Right({:?})", b),
+        }
+    }
+}
+
+} // verus!
 verus! {
 
-    /// deep view of an exec type
-    pub trait DView {
-        type V;
-        spec fn dview(&self) -> Self::V;
-    }
+/// deep view of an exec type
+pub trait DView {
+    type V;
 
-    impl<A: DView> DView for &A {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
-    }
+    spec fn dview(&self) -> Self::V;
+}
 
-    impl<A: DView> DView for alloc::boxed::Box<A> {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
-    }
+impl<A: DView> DView for &A {
+    type V = A::V;
 
-    impl<A: DView> DView for alloc::rc::Rc<A> {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
     }
+}
 
-    impl<A: DView> DView for alloc::sync::Arc<A> {
-        type V = A::V;
-        #[verifier::inline]
-        open spec fn dview(&self) -> A::V {
-            (**self).dview()
-        }
+impl<A: DView> DView for alloc::boxed::Box<A> {
+    type V = A::V;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
     }
+}
 
-    macro_rules! declare_identity_view {
+impl<A: DView> DView for alloc::rc::Rc<A> {
+    type V = A::V;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
+    }
+}
+
+impl<A: DView> DView for alloc::sync::Arc<A> {
+    type V = A::V;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> A::V {
+        (**self).dview()
+    }
+}
+
+macro_rules! declare_identity_view {
         ($t:ty) => {
             #[cfg_attr(verus_keep_ghost, verifier::verify)]
             impl DView for $t {
@@ -299,22 +290,35 @@ verus! {
         }
     }
 
-    declare_identity_view!(());
-    declare_identity_view!(bool);
-    declare_identity_view!(u8);
-    declare_identity_view!(u16);
-    declare_identity_view!(u32);
-    declare_identity_view!(u64);
-    declare_identity_view!(u128);
-    declare_identity_view!(usize);
-    declare_identity_view!(i8);
-    declare_identity_view!(i16);
-    declare_identity_view!(i32);
-    declare_identity_view!(i64);
-    declare_identity_view!(i128);
-    declare_identity_view!(isize);
+declare_identity_view!(());
 
-    macro_rules! declare_tuple_view {
+declare_identity_view!(bool);
+
+declare_identity_view!(u8);
+
+declare_identity_view!(u16);
+
+declare_identity_view!(u32);
+
+declare_identity_view!(u64);
+
+declare_identity_view!(u128);
+
+declare_identity_view!(usize);
+
+declare_identity_view!(i8);
+
+declare_identity_view!(i16);
+
+declare_identity_view!(i32);
+
+declare_identity_view!(i64);
+
+declare_identity_view!(i128);
+
+declare_identity_view!(isize);
+
+macro_rules! declare_tuple_view {
         ([$($n:tt)*], [$($a:ident)*]) => {
             #[cfg_attr(verus_keep_ghost, verifier::verify)]
             impl<$($a: DView, )*> DView for ($($a, )*) {
@@ -329,1840 +333,1939 @@ verus! {
         }
     }
 
-    declare_tuple_view!([0], [A0]);
-    declare_tuple_view!([0 1], [A0 A1]);
-    declare_tuple_view!([0 1 2], [A0 A1 A2]);
-    declare_tuple_view!([0 1 2 3], [A0 A1 A2 A3]);
+declare_tuple_view!([0], [A0]);
 
-    /// deep view of a Vec
-    impl<T: DView> DView for Vec<T> {
-        type V = Seq<T::V>;
-        open spec fn dview(&self) -> Self::V;
-    }
+declare_tuple_view!([0 1], [A0 A1]);
 
-    #[verifier::external]
-    pub trait VecAdditionalExecFns<T> {
-        fn set(&mut self, i: usize, value: T);
-        fn set_and_swap(&mut self, i: usize, value: &mut T);
-        fn length(&self) -> usize;
-    }
+declare_tuple_view!([0 1 2], [A0 A1 A2]);
 
-    impl<T: DView> VecAdditionalExecFns<T> for Vec<T> {
-        /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
+declare_tuple_view!([0 1 2 3], [A0 A1 A2 A3]);
 
-        #[verifier::external_body]
-        fn set(&mut self, i: usize, value: T)
-            requires
-                i < old(self).dview().len(),
-            ensures
-                self.dview() == old(self).dview().update(i as int, value.dview()),
-        {
-            self[i] = value;
-        }
+/// deep view of a Vec
+impl<T: DView> DView for Vec<T> {
+    type V = Seq<T::V>;
 
-        /// Replacement for `swap(&mut self[i], &mut value)` (which Verus does not support for technical reasons)
-
-        #[verifier::external_body]
-        fn set_and_swap(&mut self, i: usize, value: &mut T)
-            requires
-                i < old(self).dview().len(),
-            ensures
-                value.dview() == old(self).dview().index(i as int)
-        {
-            core::mem::swap(&mut self[i], value);
-        }
-
-        #[verifier::external_body]
-        fn length(&self) -> (res: usize)
-            ensures
-                res == spec_vec_len(self)
-        {
-            self.len()
-        }
-    }
-
-    #[verifier::external_body]
-    pub fn vec_index<T: DView>(vec: &Vec<T>, i: usize) -> (element: &T)
-        requires i < vec.dview().len(),
-        ensures element.dview() == vec.dview().index(i as int)
-    {
-        &vec[i]
-    }
-
-    #[verifier::external_body]
-    pub fn vec_as_slice<T: DView>(vec: &Vec<T>) -> (slice: &[T])
-        ensures slice.dview() == vec.dview()
-    {
-        vec.as_slice()
-    }
-
-    #[verifier::external_body]
-    pub fn vec_push<T: DView>(vec: &mut Vec<T>, value: T)
-        ensures vec.dview() == old(vec).dview().push(value.dview())
-    {
-        vec.push(value);
-    }
-
-    #[verifier::external_body]
-    pub fn vec_new<T: DView>() -> (v: Vec<T>)
-        ensures
-            v.dview() == Seq::<T::V>::empty(),
-    {
-        Vec::<T>::new()
-    }
-
-    #[verifier::external_body]
-    pub fn vec_append<T: DView>(vec: &mut Vec<T>, other: &mut Vec<T>)
-        ensures
-            vec.dview() == old(vec).dview() + old(other).dview(),
-    {
-        vec.append(other)
-    }
-
-    pub open spec fn spec_vec_len<T: DView>(v: &Vec<T>) -> usize;
-
-    #[verifier(external_body)]
-    #[verifier(broadcast_forall)]
-    pub proof fn axiom_spec_len<T: DView>(v: &Vec<T>)
-        ensures
-            #[trigger] spec_vec_len(v) == v.dview().len()
-    {}
-
-
-    impl<T: DView> DView for [T] {
-        type V = Seq<T::V>;
-        open spec fn dview(&self) -> Self::V;
-    }
-
-    impl<T: DView> DView for &[T] {
-        type V = Seq<T::V>;
-        #[verifier::inline]
-        open spec fn dview(&self) -> Self::V {
-            (*self).dview()
-        }
-    }
-
-    #[verifier::external]
-    pub trait SliceAdditionalExecFns<T> {
-        fn set(&mut self, i: usize, value: T);
-        fn length(&self) -> usize;
-    }
-
-    impl<T: DView> SliceAdditionalExecFns<T> for [T] {
-
-        /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
-        #[verifier::external_body]
-        fn set(&mut self, i: usize, value: T)
-            requires
-                i < old(self).dview().len(),
-            ensures
-                self.dview() == old(self).dview().update(i as int, value.dview()),
-        {
-            self[i] = value;
-        }
-
-        #[verifier::external_body]
-        fn length(&self) -> (length: usize)
-            ensures
-                length >= 0,
-                length == self.dview().len()
-        {
-            self.len()
-        }
-
-    }
-
-
-    #[verifier(external_body)]
-    pub exec fn slice_index_get<T: DView>(slice: &[T], i: usize) -> (out: &T)
-        requires 0 <= i < slice.dview().len(),
-        ensures out.dview() == slice.dview().index(i as int),
-    {
-        &slice[i]
-    }
-
-    #[verifier(external_body)]
-    pub exec fn slice_to_vec<T: Copy + DView>(slice: &[T]) -> (out: Vec<T>)
-        ensures out.dview() == slice.dview()
-    {
-        slice.to_vec()
-    }
-
-    #[verifier(external_body)]
-    pub exec fn slice_subrange<T: DView, 'a>(slice: &'a [T], i: usize, j: usize) -> (out: &'a [T])
-        requires 0 <= i <= j <= slice.dview().len()
-        ensures out.dview() == slice.dview().subrange(i as int, j as int)
-    {
-        &slice[i .. j]
-    }
-
-    #[verifier(external_body)]
-    pub exec fn swap_with_slice<T: DView>(left: &mut [T], right: &mut [T])
-        requires
-            old(left).dview().len() == old(right).dview().len(),
-        ensures
-            left.dview() == old(right).dview(),
-            right.dview() == old(left).dview(),
-    {
-        left.swap_with_slice(right)
-    }
-
+    open spec fn dview(&self) -> Self::V;
 }
 
-verus! {
-    /// A *well-behaved parser* should
-    /// 1. keep the input data unchanged
-    /// 2. the new start position should be the addition of the old start position and the number of consumed bytes
-    /// 3. the old and new start positions should be in range
-    pub open spec fn prop_parse_well_behaved_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        s: SpecStream) -> bool
+#[verifier::external]
+pub trait VecAdditionalExecFns<T> {
+    fn set(&mut self, i: usize, value: T);
+
+    fn set_and_swap(&mut self, i: usize, value: &mut T);
+
+    fn length(&self) -> usize;
+}
+
+impl<T: DView> VecAdditionalExecFns<T> for Vec<T> {
+    /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
+    #[verifier::external_body]
+    fn set(&mut self, i: usize, value: T)
+        requires
+            i < old(self).dview().len(),
+        ensures
+            self.dview() == old(self).dview().update(i as int, value.dview()),
     {
-        match parser(s) {
-            Ok((sout, n, _)) => {
-                &&& sout.data == s.data
-                &&& s.start + n == sout.start
-                &&& 0 <= s.start <= sout.start <= s.data.len()
-            }
-            Err(_) => true, // vacuously true
-        }
+        self[i] = value;
     }
 
-    /// A *well-behaved serializer* should
-    /// 1. keep the length of the input data unchanged
-    /// 2. keep the input data prior to the start position unchanged
-    /// 3. keep the input data following serialized data unchanged
-    /// 4. the new start position should be the addition of the old start position and the number of serialized bytes
-    /// 5. the old and new start positions should be in range
-    pub open spec fn prop_serialize_well_behaved_on<R>(
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-s: SpecStream, v: R) -> bool
+    /// Replacement for `swap(&mut self[i], &mut value)` (which Verus does not support for technical reasons)
+    #[verifier::external_body]
+    fn set_and_swap(&mut self, i: usize, value: &mut T)
+        requires
+            i < old(self).dview().len(),
+        ensures
+            value.dview() == old(self).dview().index(i as int),
     {
-        if let Ok((sout, n)) = serializer(s, v) {
-            &&& sout.data.len() == s.data.len()
-            &&& sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)
-            &&& sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(s.start + n, s.data.len() as int)
+        core::mem::swap(&mut self[i], value);
+    }
+
+    #[verifier::external_body]
+    fn length(&self) -> (res: usize)
+        ensures
+            res == spec_vec_len(self),
+    {
+        self.len()
+    }
+}
+
+#[verifier::external_body]
+pub fn vec_index<T: DView>(vec: &Vec<T>, i: usize) -> (element: &T)
+    requires
+        i < vec.dview().len(),
+    ensures
+        element.dview() == vec.dview().index(i as int),
+{
+    &vec[i]
+}
+
+#[verifier::external_body]
+pub fn vec_as_slice<T: DView>(vec: &Vec<T>) -> (slice: &[T])
+    ensures
+        slice.dview() == vec.dview(),
+{
+    vec.as_slice()
+}
+
+#[verifier::external_body]
+pub fn vec_push<T: DView>(vec: &mut Vec<T>, value: T)
+    ensures
+        vec.dview() == old(vec).dview().push(value.dview()),
+{
+    vec.push(value);
+}
+
+#[verifier::external_body]
+pub fn vec_new<T: DView>() -> (v: Vec<T>)
+    ensures
+        v.dview() == Seq::<T::V>::empty(),
+{
+    Vec::<T>::new()
+}
+
+#[verifier::external_body]
+pub fn vec_append<T: DView>(vec: &mut Vec<T>, other: &mut Vec<T>)
+    ensures
+        vec.dview() == old(vec).dview() + old(other).dview(),
+{
+    vec.append(other)
+}
+
+pub open spec fn spec_vec_len<T: DView>(v: &Vec<T>) -> usize;
+
+#[verifier(external_body)]
+#[verifier(broadcast_forall)]
+pub proof fn axiom_spec_len<T: DView>(v: &Vec<T>)
+    ensures
+        #[trigger] spec_vec_len(v) == v.dview().len(),
+{
+}
+
+impl<T: DView> DView for [T] {
+    type V = Seq<T::V>;
+
+    open spec fn dview(&self) -> Self::V;
+}
+
+impl<T: DView> DView for &[T] {
+    type V = Seq<T::V>;
+
+    #[verifier::inline]
+    open spec fn dview(&self) -> Self::V {
+        (*self).dview()
+    }
+}
+
+#[verifier::external]
+pub trait SliceAdditionalExecFns<T> {
+    fn set(&mut self, i: usize, value: T);
+
+    fn length(&self) -> usize;
+}
+
+impl<T: DView> SliceAdditionalExecFns<T> for [T] {
+    /// Replacement for `self[i] = value;` (which Verus does not support for technical reasons)
+    #[verifier::external_body]
+    fn set(&mut self, i: usize, value: T)
+        requires
+            i < old(self).dview().len(),
+        ensures
+            self.dview() == old(self).dview().update(i as int, value.dview()),
+    {
+        self[i] = value;
+    }
+
+    #[verifier::external_body]
+    fn length(&self) -> (length: usize)
+        ensures
+            length >= 0,
+            length == self.dview().len(),
+    {
+        self.len()
+    }
+}
+
+#[verifier(external_body)]
+pub exec fn slice_index_get<T: DView>(slice: &[T], i: usize) -> (out: &T)
+    requires
+        0 <= i < slice.dview().len(),
+    ensures
+        out.dview() == slice.dview().index(i as int),
+{
+    &slice[i]
+}
+
+#[verifier(external_body)]
+pub exec fn slice_to_vec<T: Copy + DView>(slice: &[T]) -> (out: Vec<T>)
+    ensures
+        out.dview() == slice.dview(),
+{
+    slice.to_vec()
+}
+
+#[verifier(external_body)]
+pub exec fn slice_subrange<T: DView, 'a>(slice: &'a [T], i: usize, j: usize) -> (out: &'a [T])
+    requires
+        0 <= i <= j <= slice.dview().len(),
+    ensures
+        out.dview() == slice.dview().subrange(i as int, j as int),
+{
+    &slice[i..j]
+}
+
+#[verifier(external_body)]
+pub exec fn swap_with_slice<T: DView>(left: &mut [T], right: &mut [T])
+    requires
+        old(left).dview().len() == old(right).dview().len(),
+    ensures
+        left.dview() == old(right).dview(),
+        right.dview() == old(left).dview(),
+{
+    left.swap_with_slice(right)
+}
+
+} // verus!
+verus! {
+
+/// A *well-behaved parser* should
+/// 1. keep the input data unchanged
+/// 2. the new start position should be the addition of the old start position and the number of consumed bytes
+/// 3. the old and new start positions should be in range
+pub open spec fn prop_parse_well_behaved_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    s: SpecStream,
+) -> bool {
+    match parser(s) {
+        Ok((sout, n, _)) => {
+            &&& sout.data == s.data
             &&& s.start + n == sout.start
             &&& 0 <= s.start <= sout.start <= s.data.len()
-        } else {
-            true // vacuously true
-        }
+        },
+        Err(_) => true,  // vacuously true
     }
-
-    pub open spec fn prop_serialize_deterministic_on<R>(
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-        s1: SpecStream, s2: SpecStream, v: R) -> bool
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer(s1, v), serializer(s2, v)) {
-            n1 == n2 && sout1.data.subrange(s1.start, s1.start + n1) == sout2.data.subrange(s2.start, s2.start + n2)
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_strong_prefix_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        s1: SpecStream,
-        s2: SpecStream) -> bool
-    {
-        if let Ok((sout1, n, x1)) = parser(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + n <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = parser(s2) {
-                    n == m && x1 == x2
-                } else {
-                    false
-                }
-            } else {
-                true // vacuously true
-            }
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_correct_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-        s: SpecStream, v: R) -> bool
-    {
-        if let Ok((sout, n)) = serializer(s, v) {
-            if let Ok((_, m, res)) = parser(SpecStream {start: s.start, ..sout}) {
-                n == m && v == res
-            } else {
-                false
-            }
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_serialize_inverse_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
-        s: SpecStream) -> bool
-    {
-        if let Ok((ss, m, res)) = parser(s) {
-            if let Ok((sout, n)) = serializer(s, res) {
-                m == n && sout.data == s.data
-            } else {
-                false
-            }
-        } else {
-            true // vacuously true
-        }
-    }
-
-    pub open spec fn prop_parse_nonmalleable_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        s1: SpecStream,
-        s2: SpecStream) -> bool
-    {
-        if let (Ok((sout1, n, x1)), Ok((sout2, m, x2))) = (parser(s1), parser(s2)) {
-            x1 == x2 ==> n == m && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + m)
-        } else {
-            true // vacuously true
-        }
-    }
-
-    /// An `exec` parser is equivalent to a `spec` parser if
-    ///
-    /// 1. on the same input stream, they both success and produce the same result,
-    /// including the output stream, the number of consumed bytes and the result value
-    /// 2. or they both fail and throw the same error.
-    pub open spec fn prop_parse_exec_spec_equiv_on<T: DView>(
-        s: Stream,
-        res: ParseResult<T>,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-    {
-        match spec_parser(s.dview()) {
-            Ok((sout, sn, sx)) => {
-                if let Ok((s, n, x)) = res {
-                    &&& s.dview() == sout
-                    &&& n == sn
-                    &&& x.dview() == sx
-                } else {
-                    false
-                }
-            }
-            Err(e) => {
-                if let Err(e2) = res {
-                    e == e2
-                } else {
-                    false
-                }
-            }
-        }
-    }
-
-    /// An `exec` serializer is equivalent to a `spec` serializer if
-    ///
-    /// 1. on the same input stream and value, they both success and produce the same result
-    /// 2. or they both fail and throw the same error.
-    pub open spec fn prop_serialize_exec_spec_equiv_on<T>(
-        old_data: Seq<u8>, start: usize, new_data: Seq<u8>,
-        v: T,
-        res: SerializeResult,
-        spec_serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        match spec_serializer(SpecStream {
-            data: old_data,
-            start: start as int,
-        }, v) {
-            Ok((sout, sn)) => {
-                &&& res.is_ok()
-                &&& res.unwrap().1 == sn
-                &&& res.unwrap().0 as int == sout.start
-                &&& new_data == sout.data
-            }
-            Err(e) => res.is_err() && res.unwrap_err() == e
-        }
-    }
-
-    // prevent the body from seen
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_well_behaved<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>) -> bool
-    {
-        forall |s: SpecStream| prop_parse_well_behaved_on(parser, s)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_serialize_well_behaved<T>(serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        forall |s: SpecStream, v: T| prop_serialize_well_behaved_on(serializer, s, v)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_serialize_deterministic<R>(serializer: spec_fn(SpecStream, R) -> SpecSerializeResult) -> bool
-    {
-        forall |s1: SpecStream, s2: SpecStream, v: R| prop_serialize_deterministic_on(serializer, s1, s2, v)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_strong_prefix<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>) -> bool
-    {
-        forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(parser, s1, s2)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_correct<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        forall |s: SpecStream, v: T| s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v)
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_serialize_inverse<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult) -> bool
-    {
-        forall |s: SpecStream| prop_parse_serialize_inverse_on(parser, serializer, s)
-    }
-
-    #[verifier(opaque)]
-    /// this property can actually be derived from the parse_serialize_inverse property (with deterministic serializers)
-    /// ∀ s. serialize(parse(s)) == s
-    /// ==>
-    /// ∀ s1 s2.
-    /// &&& serialize(parse(s1)) == s1 && serialize(parse(s2)) == s2
-    /// &&& (parse(s1) == parse(s2) <==> serialize(parse(s1)) == serialize(parse(s2)) ==> s1 == s2)
-    pub open spec fn prop_parse_nonmalleable<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>) -> bool
-    {
-        forall |s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2)
-    }
-
-    pub proof fn lemma_parse_serialize_inverse_implies_nonmalleable<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult)
-        requires
-            prop_parse_serialize_inverse(parser, serializer),
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_parse_nonmalleable(parser)
-    {
-        reveal(prop_parse_serialize_inverse);
-        reveal(prop_parse_nonmalleable);
-        reveal(prop_serialize_deterministic);
-        assert forall |s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2) by {
-            lemma_parse_serialize_inverse_on(parser, serializer, s1);
-            lemma_parse_serialize_inverse_on(parser, serializer, s2);
-            if let (Ok((sout1, n1, x1)), Ok((sout2, n2, x2))) = (parser(s1), parser(s2)) {
-                if x1 == x2 {
-                    lemma_serialize_deterministic_on(serializer, s1, s2, x1);
-                    assert(n1 == n2);
-                    assert(s1.data.subrange(s1.start, s1.start + n1) =~= s2.data.subrange(s2.start, s2.start + n2));
-                }
-            }
-        }
-    }
-
-    #[verifier(opaque)]
-    pub open spec fn prop_parse_exec_spec_equiv<'a, T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-        where
-            P: FnOnce(Stream<'a>) -> ParseResult<T>,
-            T: DView,
-    {
-        &&& forall |s| #[trigger] exec_parser.requires((s,))
-        &&& forall |s, res| #[trigger] exec_parser.ensures((s,), res) ==> prop_parse_exec_spec_equiv_on(s, res, spec_parser)
-    }
-
-    // #[verifier(opaque)]
-    // pub open spec fn prop_serialize_exec_spec_equiv<T, P>(
-    //     exec_serializer: P,
-    //     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
-    //     where
-    //         P: FnOnce(SerializeStream, T) -> SerializeResult,
-    //         T: std::fmt::Debug + DView,
-    // {
-    //     &&& forall |s, v| #[trigger] exec_serializer.requires((s, v))
-    //     &&& forall |s, v, res| #[trigger] exec_serializer.ensures((s, v), res) ==> prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
-    // }
-
-    // for performance boost
-    pub proof fn lemma_parse_well_behaved_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser)
-        ensures
-            prop_parse_well_behaved_on(parser, s)
-    {
-        reveal(prop_parse_well_behaved);
-    }
-
-    pub proof fn lemma_serialize_well_behaved_on<T>(serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s: SpecStream, v: T)
-        requires
-            prop_serialize_well_behaved(serializer)
-        ensures
-            prop_serialize_well_behaved_on(serializer, s, v)
-    {
-        reveal(prop_serialize_well_behaved);
-    }
-
-    pub proof fn lemma_serialize_deterministic_on<T>(serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s1: SpecStream, s2: SpecStream, v: T)
-        requires
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_serialize_deterministic_on(serializer, s1, s2, v)
-    {
-        reveal(prop_serialize_deterministic);
-    }
-
-    pub proof fn lemma_parse_strong_prefix_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, s1: SpecStream, s2: SpecStream)
-        requires
-            prop_parse_strong_prefix(parser)
-        ensures
-            prop_parse_strong_prefix_on(parser, s1, s2)
-    {
-        reveal(prop_parse_strong_prefix);
-    }
-
-    pub proof fn lemma_parse_correct_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s: SpecStream, v: T)
-        requires
-            prop_parse_correct(parser, serializer)
-        ensures
-            s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v)
-    {
-        reveal(prop_parse_correct);
-    }
-
-    pub proof fn lemma_parse_serialize_inverse_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s: SpecStream)
-        requires
-            prop_parse_serialize_inverse(parser, serializer)
-        ensures
-            prop_parse_serialize_inverse_on(parser, serializer, s)
-    {
-        reveal(prop_parse_serialize_inverse);
-    }
-
-    pub proof fn lemma_parse_nonmalleable_on<T>(parser: spec_fn(SpecStream) -> SpecParseResult<T>, serializer: spec_fn(SpecStream, T) -> SpecSerializeResult, s1: SpecStream, s2: SpecStream)
-        requires
-            prop_parse_nonmalleable(parser)
-        ensures
-            prop_parse_nonmalleable_on(parser, s1, s2)
-    {
-        reveal(prop_parse_nonmalleable);
-    }
-
-    pub proof fn lemma_parse_exec_spec_equiv_on<'a, T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
-        s: Stream, res: ParseResult<T>)
-        where
-            P: FnOnce(Stream<'a>) -> ParseResult<T>,
-            T: DView,
-        requires
-            prop_parse_exec_spec_equiv(exec_parser, spec_parser),
-            exec_parser.ensures((s,), res)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, spec_parser)
-    {
-        reveal(prop_parse_exec_spec_equiv);
-    }
-
-    // pub proof fn lemma_serialize_exec_spec_equiv_on<T, P>(
-    //     exec_serializer: P,
-    //     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
-    //     s: SerializeStream, v: T, res: SerializeResult)
-    //     where
-    //         P: FnOnce(SerializeStream, T) -> SerializeResult,
-    //         T: std::fmt::Debug + DView,
-    //     requires
-    //         prop_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
-    //         exec_serializer.ensures((s, v), res)
-    //     ensures
-    //         prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
-    // {
-    //     reveal(prop_serialize_exec_spec_equiv);
-    // }
 }
 
+/// A *well-behaved serializer* should
+/// 1. keep the length of the input data unchanged
+/// 2. keep the input data prior to the start position unchanged
+/// 3. keep the input data following serialized data unchanged
+/// 4. the new start position should be the addition of the old start position and the number of serialized bytes
+/// 5. the old and new start positions should be in range
+pub open spec fn prop_serialize_well_behaved_on<R>(
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s: SpecStream,
+    v: R,
+) -> bool {
+    if let Ok((sout, n)) = serializer(s, v) {
+        &&& sout.data.len() == s.data.len()
+        &&& sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)
+        &&& sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(
+            s.start + n,
+            s.data.len() as int,
+        )
+        &&& s.start + n == sout.start
+        &&& 0 <= s.start <= sout.start <= s.data.len()
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_serialize_deterministic_on<R>(
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+    v: R,
+) -> bool {
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer(s1, v), serializer(s2, v)) {
+        n1 == n2 && sout1.data.subrange(s1.start, s1.start + n1) == sout2.data.subrange(
+            s2.start,
+            s2.start + n2,
+        )
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_strong_prefix_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    s1: SpecStream,
+    s2: SpecStream,
+) -> bool {
+    if let Ok((sout1, n, x1)) = parser(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX && 0 <= s2.start <= s2.start
+            + n <= s2.data.len() <= usize::MAX && s1.data.subrange(s1.start, s1.start + n)
+            == s2.data.subrange(s2.start, s2.start + n) {
+            if let Ok((sout2, m, x2)) = parser(s2) {
+                n == m && x1 == x2
+            } else {
+                false
+            }
+        } else {
+            true  // vacuously true
+
+        }
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_correct_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s: SpecStream,
+    v: R,
+) -> bool {
+    if let Ok((sout, n)) = serializer(s, v) {
+        if let Ok((_, m, res)) = parser(SpecStream { start: s.start, ..sout }) {
+            n == m && v == res
+        } else {
+            false
+        }
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_serialize_inverse_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+    s: SpecStream,
+) -> bool {
+    if let Ok((ss, m, res)) = parser(s) {
+        if let Ok((sout, n)) = serializer(s, res) {
+            m == n && sout.data == s.data
+        } else {
+            false
+        }
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+pub open spec fn prop_parse_nonmalleable_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    s1: SpecStream,
+    s2: SpecStream,
+) -> bool {
+    if let (Ok((sout1, n, x1)), Ok((sout2, m, x2))) = (parser(s1), parser(s2)) {
+        x1 == x2 ==> n == m && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + m,
+        )
+    } else {
+        true  // vacuously true
+
+    }
+}
+
+/// An `exec` parser is equivalent to a `spec` parser if
+///
+/// 1. on the same input stream, they both success and produce the same result,
+/// including the output stream, the number of consumed bytes and the result value
+/// 2. or they both fail and throw the same error.
+pub open spec fn prop_parse_exec_spec_equiv_on<T: DView>(
+    s: Stream,
+    res: ParseResult<T>,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool {
+    match spec_parser(s.dview()) {
+        Ok((sout, sn, sx)) => {
+            if let Ok((s, n, x)) = res {
+                &&& s.dview() == sout
+                &&& n == sn
+                &&& x.dview() == sx
+            } else {
+                false
+            }
+        },
+        Err(e) => {
+            if let Err(e2) = res {
+                e == e2
+            } else {
+                false
+            }
+        },
+    }
+}
+
+/// An `exec` serializer is equivalent to a `spec` serializer if
+///
+/// 1. on the same input stream and value, they both success and produce the same result
+/// 2. or they both fail and throw the same error.
+pub open spec fn prop_serialize_exec_spec_equiv_on<T>(
+    old_data: Seq<u8>,
+    start: usize,
+    new_data: Seq<u8>,
+    v: T,
+    res: SerializeResult,
+    spec_serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    match spec_serializer(SpecStream { data: old_data, start: start as int }, v) {
+        Ok((sout, sn)) => {
+            &&& res.is_ok()
+            &&& res.unwrap().1 == sn
+            &&& res.unwrap().0 as int == sout.start
+            &&& new_data == sout.data
+        },
+        Err(e) => res.is_err() && res.unwrap_err() == e,
+    }
+}
+
+// prevent the body from seen
+#[verifier(opaque)]
+pub open spec fn prop_parse_well_behaved<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+) -> bool {
+    forall|s: SpecStream| prop_parse_well_behaved_on(parser, s)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_serialize_well_behaved<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    forall|s: SpecStream, v: T| prop_serialize_well_behaved_on(serializer, s, v)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_serialize_deterministic<R>(
+    serializer: spec_fn(SpecStream, R) -> SpecSerializeResult,
+) -> bool {
+    forall|s1: SpecStream, s2: SpecStream, v: R|
+        prop_serialize_deterministic_on(serializer, s1, s2, v)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_strong_prefix<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+) -> bool {
+    forall|s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(parser, s1, s2)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_correct<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    forall|s: SpecStream, v: T|
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_serialize_inverse<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+) -> bool {
+    forall|s: SpecStream| prop_parse_serialize_inverse_on(parser, serializer, s)
+}
+
+#[verifier(opaque)]
+/// this property can actually be derived from the parse_serialize_inverse property (with deterministic serializers)
+/// ∀ s. serialize(parse(s)) == s
+/// ==>
+/// ∀ s1 s2.
+/// &&& serialize(parse(s1)) == s1 && serialize(parse(s2)) == s2
+/// &&& (parse(s1) == parse(s2) <==> serialize(parse(s1)) == serialize(parse(s2)) ==> s1 == s2)
+pub open spec fn prop_parse_nonmalleable<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+) -> bool {
+    forall|s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2)
+}
+
+pub proof fn lemma_parse_serialize_inverse_implies_nonmalleable<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+)
+    requires
+        prop_parse_serialize_inverse(parser, serializer),
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_parse_nonmalleable(parser),
+{
+    reveal(prop_parse_serialize_inverse);
+    reveal(prop_parse_nonmalleable);
+    reveal(prop_serialize_deterministic);
+    assert forall|s1: SpecStream, s2: SpecStream| prop_parse_nonmalleable_on(parser, s1, s2) by {
+        lemma_parse_serialize_inverse_on(parser, serializer, s1);
+        lemma_parse_serialize_inverse_on(parser, serializer, s2);
+        if let (Ok((sout1, n1, x1)), Ok((sout2, n2, x2))) = (parser(s1), parser(s2)) {
+            if x1 == x2 {
+                lemma_serialize_deterministic_on(serializer, s1, s2, x1);
+                assert(n1 == n2);
+                assert(s1.data.subrange(s1.start, s1.start + n1) =~= s2.data.subrange(
+                    s2.start,
+                    s2.start + n2,
+                ));
+            }
+        }
+    }
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_parse_exec_spec_equiv<'a, T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool where P: FnOnce(Stream<'a>) -> ParseResult<T>, T: DView {
+    &&& forall|s| #[trigger] exec_parser.requires((s,))
+    &&& forall|s, res| #[trigger]
+        exec_parser.ensures((s,), res) ==> prop_parse_exec_spec_equiv_on(s, res, spec_parser)
+}
+
+// #[verifier(opaque)]
+// pub open spec fn prop_serialize_exec_spec_equiv<T, P>(
+//     exec_serializer: P,
+//     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
+//     where
+//         P: FnOnce(SerializeStream, T) -> SerializeResult,
+//         T: std::fmt::Debug + DView,
+// {
+//     &&& forall |s, v| #[trigger] exec_serializer.requires((s, v))
+//     &&& forall |s, v, res| #[trigger] exec_serializer.ensures((s, v), res) ==> prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
+// }
+// for performance boost
+pub proof fn lemma_parse_well_behaved_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser),
+    ensures
+        prop_parse_well_behaved_on(parser, s),
+{
+    reveal(prop_parse_well_behaved);
+}
+
+pub proof fn lemma_serialize_well_behaved_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s: SpecStream,
+    v: T,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+    ensures
+        prop_serialize_well_behaved_on(serializer, s, v),
+{
+    reveal(prop_serialize_well_behaved);
+}
+
+pub proof fn lemma_serialize_deterministic_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+    v: T,
+)
+    requires
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_serialize_deterministic_on(serializer, s1, s2, v),
+{
+    reveal(prop_serialize_deterministic);
+}
+
+pub proof fn lemma_parse_strong_prefix_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    s1: SpecStream,
+    s2: SpecStream,
+)
+    requires
+        prop_parse_strong_prefix(parser),
+    ensures
+        prop_parse_strong_prefix_on(parser, s1, s2),
+{
+    reveal(prop_parse_strong_prefix);
+}
+
+pub proof fn lemma_parse_correct_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s: SpecStream,
+    v: T,
+)
+    requires
+        prop_parse_correct(parser, serializer),
+    ensures
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(parser, serializer, s, v),
+{
+    reveal(prop_parse_correct);
+}
+
+pub proof fn lemma_parse_serialize_inverse_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s: SpecStream,
+)
+    requires
+        prop_parse_serialize_inverse(parser, serializer),
+    ensures
+        prop_parse_serialize_inverse_on(parser, serializer, s),
+{
+    reveal(prop_parse_serialize_inverse);
+}
+
+pub proof fn lemma_parse_nonmalleable_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+)
+    requires
+        prop_parse_nonmalleable(parser),
+    ensures
+        prop_parse_nonmalleable_on(parser, s1, s2),
+{
+    reveal(prop_parse_nonmalleable);
+}
+
+pub proof fn lemma_parse_exec_spec_equiv_on<'a, T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+    s: Stream,
+    res: ParseResult<T>,
+) where P: FnOnce(Stream<'a>) -> ParseResult<T>, T: DView
+    requires
+        prop_parse_exec_spec_equiv(exec_parser, spec_parser),
+        exec_parser.ensures((s,), res),
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, spec_parser),
+{
+    reveal(prop_parse_exec_spec_equiv);
+}
+
+// pub proof fn lemma_serialize_exec_spec_equiv_on<T, P>(
+//     exec_serializer: P,
+//     spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+//     s: SerializeStream, v: T, res: SerializeResult)
+//     where
+//         P: FnOnce(SerializeStream, T) -> SerializeResult,
+//         T: std::fmt::Debug + DView,
+//     requires
+//         prop_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
+//         exec_serializer.ensures((s, v), res)
+//     ensures
+//         prop_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
+// {
+//     reveal(prop_serialize_exec_spec_equiv);
+// }
+} // verus!
 verus! {
 
-    pub open spec fn spec_parse_u8_le(s: SpecStream) -> (res: SpecParseResult<u8>)
-        recommends
-            0 <= s.start < s.data.len(),
-            s.data.len() >= 1
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
-                SpecStream {
-                    start: s.start + 1,
-                    ..s
-                },
-                1,
-                s.data[s.start],
-            ))
-        }
+pub open spec fn spec_parse_u8_le(s: SpecStream) -> (res: SpecParseResult<u8>)
+    recommends
+        0 <= s.start < s.data.len(),
+        s.data.len() >= 1,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok((SpecStream { start: s.start + 1, ..s }, 1, s.data[s.start]))
     }
+}
 
-    pub open spec fn spec_parse_u16_le(s: SpecStream) -> (res: SpecParseResult<u16>)
-        recommends
-            0 <= s.start < s.data.len() - 1,
-            s.data.len() >= 2
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
+pub open spec fn spec_parse_u16_le(s: SpecStream) -> (res: SpecParseResult<u16>)
+    recommends
+        0 <= s.start < s.data.len() - 1,
+        s.data.len() >= 2,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + 2, ..s },
+                2,
+                spec_u16_from_le_bytes(s.data.subrange(s.start, s.start + 2)),
+            ),
+        )
+    }
+}
+
+pub open spec fn spec_parse_u32_le(s: SpecStream) -> (res: SpecParseResult<u32>)
+    recommends
+        0 <= s.start < s.data.len() - 3,
+        s.data.len() >= 4,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + 4, ..s },
+                4,
+                spec_u32_from_le_bytes(s.data.subrange(s.start, s.start + 4)),
+            ),
+        )
+    }
+}
+
+pub open spec fn spec_parse_u64_le(s: SpecStream) -> (res: SpecParseResult<u64>)
+    recommends
+        0 <= s.start < s.data.len() - 7,
+        s.data.len() >= 8,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.len() {
+        Err(ParseError::Eof)
+    } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + 8, ..s },
+                8,
+                spec_u64_from_le_bytes(s.data.subrange(s.start, s.start + 8)),
+            ),
+        )
+    }
+}
+
+pub open spec fn spec_serialize_u8_le(s: SpecStream, v: u8) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len(),
+        s.data.len() >= 1,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 1 || s.start >= s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        Ok((SpecStream { data: s.data.update(s.start, v), start: s.start + 1 }, 1))
+    }
+}
+
+pub open spec fn spec_serialize_u16_le(s: SpecStream, v: u16) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len() - 1,
+        s.data.len() >= 2,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let data = spec_u16_to_le_bytes(v);
+        Ok(
+            (
                 SpecStream {
+                    data: s.data.update(s.start, data[0]).update(s.start + 1, data[1]),
                     start: s.start + 2,
-                    ..s
                 },
                 2,
-                spec_u16_from_le_bytes(
-                    s.data.subrange(s.start, s.start + 2)
-                )
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_parse_u32_le(s: SpecStream) -> (res: SpecParseResult<u32>)
-        recommends
-            0 <= s.start < s.data.len() - 3,
-            s.data.len() >= 4
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
+pub open spec fn spec_serialize_u32_le(s: SpecStream, v: u32) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len() - 3,
+        s.data.len() >= 4,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let data = spec_u32_to_le_bytes(v);
+        Ok(
+            (
                 SpecStream {
+                    data: s.data.update(s.start, data[0]).update(s.start + 1, data[1]).update(
+                        s.start + 2,
+                        data[2],
+                    ).update(s.start + 3, data[3]),
                     start: s.start + 4,
-                    ..s
                 },
                 4,
-                spec_u32_from_le_bytes(
-                    s.data.subrange(s.start, s.start + 4)
-                )
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_parse_u64_le(s: SpecStream) -> (res: SpecParseResult<u64>)
-        recommends
-            0 <= s.start < s.data.len() - 7,
-            s.data.len() >= 8
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.len() {
-            Err(ParseError::Eof)
-        } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
+pub open spec fn spec_serialize_u64_le(s: SpecStream, v: u64) -> SpecSerializeResult
+    recommends
+        0 <= s.start < s.data.len() - 7,
+        s.data.len() >= 8,
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let data = spec_u64_to_le_bytes(v);
+        Ok(
+            (
                 SpecStream {
+                    data: s.data.update(s.start, data[0]).update(s.start + 1, data[1]).update(
+                        s.start + 2,
+                        data[2],
+                    ).update(s.start + 3, data[3]).update(s.start + 4, data[4]).update(
+                        s.start + 5,
+                        data[5],
+                    ).update(s.start + 6, data[6]).update(s.start + 7, data[7]),
                     start: s.start + 8,
-                    ..s
                 },
                 8,
-                spec_u64_from_le_bytes(
-                    s.data.subrange(s.start, s.start + 8)
-                )
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_serialize_u8_le(s: SpecStream, v: u8) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len(),
-            s.data.len() >= 1
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 1 || s.start >= s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, v),
-                    start: s.start + 1,
-                },
-                1
-            ))
-        }
+pub exec fn parse_u8_le(s: Stream) -> (res: ParseResult<u8>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let v = *slice_index_get(s.data, s.start);  // &s.data[s.start];
+        Ok((Stream { start: s.start + 1, ..s }, 1, v))
     }
+}
 
-    pub open spec fn spec_serialize_u16_le(s: SpecStream, v: u16) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len() - 1,
-            s.data.len() >= 2
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 2 || s.start >= s.data.len() - 1 {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let data = spec_u16_to_le_bytes(v);
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, data[0])
-                                .update(s.start + 1, data[1]),
-                    start: s.start + 2,
-                },
-                2
-            ))
-        }
+pub exec fn parse_u16_le(s: Stream) -> (res: ParseResult<u16>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u16_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 2 || s.start >= s.data.length() - 1 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(s.data, s.start, s.start + 2);  // &s.data[s.start..s.start + 2];
+        let v = u16_from_le_bytes(data);
+        Ok((Stream { start: s.start + 2, ..s }, 2, v))
     }
+}
 
-    pub open spec fn spec_serialize_u32_le(s: SpecStream, v: u32) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len() - 3,
-            s.data.len() >= 4
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 4 || s.start >= s.data.len() - 3 {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let data = spec_u32_to_le_bytes(v);
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, data[0])
-                                .update(s.start + 1, data[1])
-                                .update(s.start + 2, data[2])
-                                .update(s.start + 3, data[3]),
-                    start: s.start + 4,
-                },
-                4
-            ))
-        }
+pub exec fn parse_u32_le(s: Stream) -> (res: ParseResult<u32>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u32_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 4 || s.start >= s.data.length() - 3 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(s.data, s.start, s.start + 4);  // &s.data[s.start..s.start + 4];
+        let v = u32_from_le_bytes(data);
+        Ok((Stream { start: s.start + 4, ..s }, 4, v))
     }
+}
 
-    pub open spec fn spec_serialize_u64_le(s: SpecStream, v: u64) -> SpecSerializeResult
-        recommends
-            0 <= s.start < s.data.len() - 7,
-            s.data.len() >= 8
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.data.len() < 8 || s.start >= s.data.len() - 7 {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let data = spec_u64_to_le_bytes(v);
-            Ok((
-                SpecStream {
-                    data: s.data.update(s.start, data[0])
-                                .update(s.start + 1, data[1])
-                                .update(s.start + 2, data[2])
-                                .update(s.start + 3, data[3])
-                                .update(s.start + 4, data[4])
-                                .update(s.start + 5, data[5])
-                                .update(s.start + 6, data[6])
-                                .update(s.start + 7, data[7]),
-                    start: s.start + 8,
-                },
-                8
-            ))
-        }
+pub exec fn parse_u64_le(s: Stream) -> (res: ParseResult<u64>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u64_le(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start >= s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.data.length() < 8 || s.start >= s.data.length() - 7 {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(&s.data, s.start, s.start + 8);  // &s.data[s.start..s.start + 8];
+        let v = u64_from_le_bytes(data);
+        Ok((Stream { start: s.start + 8, ..s }, 8, v))
     }
+}
 
-
-    pub exec fn parse_u8_le(s: Stream) -> (res: ParseResult<u8>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let v = *slice_index_get(s.data, s.start); // &s.data[s.start];
-            Ok((
-                Stream {
-                    start: s.start + 1,
-                    ..s
-                },
-                1,
-                v
-            ))
-        }
+pub exec fn serialize_u8_le(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u8_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 1 || start >= data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        data.set(start, v);
+        Ok((start + 1, 1))
     }
+}
 
-    pub exec fn parse_u16_le(s: Stream) -> (res: ParseResult<u16>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u16_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 2 || s.start >= s.data.length() - 1 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(s.data, s.start, s.start + 2); // &s.data[s.start..s.start + 2];
-            let v = u16_from_le_bytes(data);
-            Ok((
-                Stream {
-                    start: s.start + 2,
-                    ..s
-                },
-                2,
-                v
-            ))
-        }
+pub exec fn serialize_u16_le(data: &mut [u8], start: usize, v: u16) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u16_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 2 || start >= data.length() - 1 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let bytes = u16_to_le_bytes(v);
+        data.set(start, *vec_index(&bytes, 0));  // data[start] = bytes[0];
+        data.set(start + 1, *vec_index(&bytes, 1));  // data[start + 1] = bytes[1];
+        Ok((start + 2, 2))
     }
+}
 
-    pub exec fn parse_u32_le(s: Stream) -> (res: ParseResult<u32>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u32_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 4 || s.start >= s.data.length() - 3 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(s.data, s.start, s.start + 4); // &s.data[s.start..s.start + 4];
-            let v = u32_from_le_bytes(data);
-            Ok((
-                Stream {
-                    start: s.start + 4,
-                    ..s
-                },
-                4,
-                v
-            ))
-        }
+pub exec fn serialize_u32_le(data: &mut [u8], start: usize, v: u32) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u32_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 4 || start >= data.length() - 3 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let bytes = u32_to_le_bytes(v);
+        data.set(start, *vec_index(&bytes, 0));  // data[start] = bytes[0];
+        data.set(start + 1, *vec_index(&bytes, 1));  // data[start + 1] = bytes[1];
+        data.set(start + 2, *vec_index(&bytes, 2));  // data[start + 2] = bytes[2];
+        data.set(start + 3, *vec_index(&bytes, 3));  // data[start + 3] = bytes[3];
+        Ok((start + 4, 4))
     }
+}
 
-    pub exec fn parse_u64_le(s: Stream) -> (res: ParseResult<u64>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u64_le(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start >= s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.data.length() < 8 || s.start >= s.data.length() - 7 {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(&s.data, s.start, s.start + 8); // &s.data[s.start..s.start + 8];
-            let v = u64_from_le_bytes(data);
-            Ok((
-                Stream {
-                    start: s.start + 8,
-                    ..s
-                },
-                8,
-                v
-            ))
-        }
+pub exec fn serialize_u64_le(data: &mut [u8], start: usize, v: u64) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u64_le(s, v),
+        ),
+{
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if data.length() < 8 || start >= data.length() - 7 {
+        Err(SerializeError::NotEnoughSpace)
+    } else {
+        let bytes = u64_to_le_bytes(v);
+        data.set(start, *vec_index(&bytes, 0));
+        data.set(start + 1, *vec_index(&bytes, 1));
+        data.set(start + 2, *vec_index(&bytes, 2));
+        data.set(start + 3, *vec_index(&bytes, 3));
+        data.set(start + 4, *vec_index(&bytes, 4));
+        data.set(start + 5, *vec_index(&bytes, 5));
+        data.set(start + 6, *vec_index(&bytes, 6));
+        data.set(start + 7, *vec_index(&bytes, 7));
+        Ok((start + 8, 8))
     }
+}
 
-    pub exec fn serialize_u8_le(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u8_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 1 || start >= data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            data.set(start, v);
-            Ok((
-                start + 1,
-                1
-            ))
-        }
+pub proof fn lemma_parse_u8_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u8_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le, s) by {
+        lemma_parse_u8_le_well_behaved_on(s)
     }
+}
 
-    pub exec fn serialize_u16_le(data: &mut [u8], start: usize, v: u16) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u16_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 2 || start >= data.length() - 1  {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let bytes = u16_to_le_bytes(v);
-            data.set(start, *vec_index(&bytes, 0)); // data[start] = bytes[0];
-            data.set(start + 1, *vec_index(&bytes, 1)); // data[start + 1] = bytes[1];
-            Ok((
-                start + 2,
-                2
-            ))
-        }
+pub proof fn lemma_parse_u16_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u16_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u16_le, s) by {
+        lemma_parse_u16_le_well_behaved_on(s)
     }
+}
 
-    pub exec fn serialize_u32_le(data: &mut [u8], start: usize, v: u32) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u32_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 4 || start >= data.length() - 3  {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let bytes = u32_to_le_bytes(v);
-            data.set(start, *vec_index(&bytes, 0)); // data[start] = bytes[0];
-            data.set(start + 1, *vec_index(&bytes, 1)); // data[start + 1] = bytes[1];
-            data.set(start + 2, *vec_index(&bytes, 2)); // data[start + 2] = bytes[2];
-            data.set(start + 3, *vec_index(&bytes, 3)); // data[start + 3] = bytes[3];
-            Ok((
-                start + 4,
-                4
-            ))
-        }
+pub proof fn lemma_parse_u32_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u32_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u32_le, s) by {
+        lemma_parse_u32_le_well_behaved_on(s)
     }
+}
 
-    pub exec fn serialize_u64_le(data: &mut [u8], start: usize, v: u64) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u64_le(s, v))
-    {
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if data.length() < 8 || start >= data.length() - 7  {
-            Err(SerializeError::NotEnoughSpace)
-        } else {
-            let bytes = u64_to_le_bytes(v);
-            data.set(start, *vec_index(&bytes, 0));
-            data.set(start + 1, *vec_index(&bytes, 1));
-            data.set(start + 2, *vec_index(&bytes, 2));
-            data.set(start + 3, *vec_index(&bytes, 3));
-            data.set(start + 4, *vec_index(&bytes, 4));
-            data.set(start + 5, *vec_index(&bytes, 5));
-            data.set(start + 6, *vec_index(&bytes, 6));
-            data.set(start + 7, *vec_index(&bytes, 7));
-            Ok((
-                start + 8,
-                8
-            ))
-        }
+pub proof fn lemma_parse_u64_le_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_u64_le(s)),
+{
+    reveal(prop_parse_well_behaved::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u64_le, s) by {
+        lemma_parse_u64_le_well_behaved_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u8_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le, s) by {
-            lemma_parse_u8_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u8_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u8>);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le, s, v) by {
+        lemma_serialize_u8_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u16_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u16_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u16_le, s) by {
-            lemma_parse_u16_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u16_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u16>);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u16_le, s, v) by {
+        lemma_serialize_u16_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u32_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u32_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u32_le, s) by {
-            lemma_parse_u32_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u32_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u32>);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u32_le, s, v) by {
+        lemma_serialize_u32_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u64_le_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_u64_le(s))
-    {
-        reveal(prop_parse_well_behaved::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u64_le, s) by {
-            lemma_parse_u64_le_well_behaved_on(s)
-        }
+pub proof fn lemma_serialize_u64_le_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<u64>);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u64_le, s, v) by {
+        lemma_serialize_u64_le_well_behaved_on(s, v)
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u8>);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le, s, v) by {
-            lemma_serialize_u8_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u8_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u8>);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u8_le, s1, s2, v) by {
+        lemma_serialize_u8_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u16>);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u16_le, s, v) by {
-            lemma_serialize_u16_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u16_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u16>);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u16_le, s1, s2, v) by {
+        lemma_serialize_u16_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u32_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u32>);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u32_le, s, v) by {
-            lemma_serialize_u32_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u32_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u32>);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u32_le, s1, s2, v) by {
+        lemma_serialize_u32_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u64_le_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<u64>);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u64_le, s, v) by {
-            lemma_serialize_u64_le_well_behaved_on(s, v)
-        }
+pub proof fn lemma_serialize_u64_le_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_serialize_deterministic::<u64>);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u64_le, s1, s2, v) by {
+        lemma_serialize_u64_le_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u8>);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u8_le, s1, s2, v) by {
-            lemma_serialize_u8_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u8_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u8_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le, s1, s2) by {
+        lemma_parse_u8_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u16>);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u16_le, s1, s2, v) by {
-            lemma_serialize_u16_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u16_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u16_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u16_le, s1, s2) by {
+        lemma_parse_u16_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_serialize_u32_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u32>);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u32_le, s1, s2, v) by {
-            lemma_serialize_u32_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u32_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u32_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u32_le, s1, s2) by {
+        lemma_parse_u32_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_serialize_u64_le_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_serialize_deterministic::<u64>);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u64_le, s1, s2, v) by {
-            lemma_serialize_u64_le_deterministic_on(s1, s2, v)
-        }
+pub proof fn lemma_parse_u64_le_strong_prefix()
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_u64_le(s)),
+{
+    reveal(prop_parse_strong_prefix::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u64_le, s1, s2) by {
+        lemma_parse_u64_le_strong_prefix_on(s1, s2)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u8_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le, s1, s2) by {
-            lemma_parse_u8_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u8_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_parse_correct::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u8_le, spec_serialize_u8_le, s, v) by {
+        lemma_parse_u8_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u16_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u16_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u16_le, s1, s2) by {
-            lemma_parse_u16_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u16_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_parse_correct::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u16_le, spec_serialize_u16_le, s, v) by {
+        lemma_parse_u16_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u32_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u32_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u32_le, s1, s2) by {
-            lemma_parse_u32_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u32_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_parse_correct::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u32_le, spec_serialize_u32_le, s, v) by {
+        lemma_parse_u32_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u64_le_strong_prefix()
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_u64_le(s))
-    {
-        reveal(prop_parse_strong_prefix::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u64_le, s1, s2) by {
-            lemma_parse_u64_le_strong_prefix_on(s1, s2)
-        }
+pub proof fn lemma_parse_u64_le_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_parse_correct::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u64_le, spec_serialize_u64_le, s, v) by {
+        lemma_parse_u64_le_correct_on(s, v)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_parse_correct::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u8_le, spec_serialize_u8_le, s, v) by {
-            lemma_parse_u8_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u8_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u8>);
+    let spec_parse_u8_le = |s| spec_parse_u8_le(s);
+    let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u8_le, spec_serialize_u8_le, s) by {
+        lemma_parse_u8_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u16_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_parse_correct::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u16_le, spec_serialize_u16_le, s, v) by {
-            lemma_parse_u16_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u16_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u16>);
+    let spec_parse_u16_le = |s| spec_parse_u16_le(s);
+    let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u16_le, spec_serialize_u16_le, s) by {
+        lemma_parse_u16_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u32_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_parse_correct::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u32_le, spec_serialize_u32_le, s, v) by {
-            lemma_parse_u32_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u32_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u32>);
+    let spec_parse_u32_le = |s| spec_parse_u32_le(s);
+    let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u32_le, spec_serialize_u32_le, s) by {
+        lemma_parse_u32_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u64_le_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_parse_correct::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u64_le, spec_serialize_u64_le, s, v) by {
-            lemma_parse_u64_le_correct_on(s, v)
-        }
+pub proof fn lemma_parse_u64_le_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<u64>);
+    let spec_parse_u64_le = |s| spec_parse_u64_le(s);
+    let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u64_le, spec_serialize_u64_le, s) by {
+        lemma_parse_u64_le_serialize_inverse_on(s)
     }
+}
 
-    pub proof fn lemma_parse_u8_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u8>);
-        let spec_parse_u8_le = |s| spec_parse_u8_le(s);
-        let spec_serialize_u8_le = |s, v| spec_serialize_u8_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u8_le, spec_serialize_u8_le, s) by {
-            lemma_parse_u8_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u8_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u8_le(s)),
+{
+    lemma_parse_u8_le_serialize_inverse();
+    lemma_serialize_u8_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u8_le(s),
+        |s, v| spec_serialize_u8_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u16_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u16>);
-        let spec_parse_u16_le = |s| spec_parse_u16_le(s);
-        let spec_serialize_u16_le = |s, v| spec_serialize_u16_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u16_le, spec_serialize_u16_le, s) by {
-            lemma_parse_u16_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u16_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u16_le(s)),
+{
+    lemma_parse_u16_le_serialize_inverse();
+    lemma_serialize_u16_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u16_le(s),
+        |s, v| spec_serialize_u16_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u32_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u32>);
-        let spec_parse_u32_le = |s| spec_parse_u32_le(s);
-        let spec_serialize_u32_le = |s, v| spec_serialize_u32_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u32_le, spec_serialize_u32_le, s) by {
-            lemma_parse_u32_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u32_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u32_le(s)),
+{
+    lemma_parse_u32_le_serialize_inverse();
+    lemma_serialize_u32_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u32_le(s),
+        |s, v| spec_serialize_u32_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u64_le_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<u64>);
-        let spec_parse_u64_le = |s| spec_parse_u64_le(s);
-        let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u64_le, spec_serialize_u64_le, s) by {
-            lemma_parse_u64_le_serialize_inverse_on(s)
-        }
-    }
+pub proof fn lemma_parse_u64_le_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_u64_le(s)),
+{
+    lemma_parse_u64_le_serialize_inverse();
+    lemma_serialize_u64_le_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u64_le(s),
+        |s, v| spec_serialize_u64_le(s, v),
+    );
+}
 
-    pub proof fn lemma_parse_u8_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u8_le(s))
-    {
-        lemma_parse_u8_le_serialize_inverse();
-        lemma_serialize_u8_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v));
-    }
+pub proof fn lemma_parse_u8_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u8_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u16_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u16_le(s))
-    {
-        lemma_parse_u16_le_serialize_inverse();
-        lemma_serialize_u16_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v));
-    }
+pub proof fn lemma_parse_u16_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u16_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u32_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u32_le(s))
-    {
-        lemma_parse_u32_le_serialize_inverse();
-        lemma_serialize_u32_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v));
-    }
+pub proof fn lemma_parse_u32_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u32_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u64_le_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_u64_le(s))
-    {
-        lemma_parse_u64_le_serialize_inverse();
-        lemma_serialize_u64_le_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v));
-    }
+pub proof fn lemma_parse_u64_le_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_u64_le(s), s),
+{
+}
 
-    pub proof fn lemma_parse_u8_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u8_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u16_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u16_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u32_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u32_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u64_le_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_u64_le(s), s)
-    {}
-
-    pub proof fn lemma_parse_u8_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u8_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u8_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u8_le(s2) {
-                    assert(n == 1);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            s1.data[s1.start]; {}
-                            s1.data.subrange(s1.start, s1.start + 1)[0]; {}
-                            s2.data.subrange(s2.start, s2.start + 1)[0]; {}
-                            s2.data[s2.start]; {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u8_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u8_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u8_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u8_le(s2) {
+                assert(n == 1);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        s1.data[s1.start]; {}
+                        s1.data.subrange(s1.start, s1.start + 1)[0]; {}
+                        s2.data.subrange(s2.start, s2.start + 1)[0]; {}
+                        s2.data[s2.start]; {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u16_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u16_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u16_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u16_le(s2) {
-                    assert(n == 2);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            spec_u16_from_le_bytes(s1.data.subrange(s1.start, s1.start + 2)); {}
-                            spec_u16_from_le_bytes(s2.data.subrange(s2.start, s2.start + 2)); {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u16_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u16_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u16_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u16_le(s2) {
+                assert(n == 2);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        spec_u16_from_le_bytes(s1.data.subrange(s1.start, s1.start + 2)); {}
+                        spec_u16_from_le_bytes(s2.data.subrange(s2.start, s2.start + 2)); {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u32_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u32_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u32_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u32_le(s2) {
-                    assert(n == 4);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            spec_u32_from_le_bytes(s1.data.subrange(s1.start, s1.start + 4)); {}
-                            spec_u32_from_le_bytes(s2.data.subrange(s2.start, s2.start + 4)); {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u32_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u32_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u32_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u32_le(s2) {
+                assert(n == 4);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        spec_u32_from_le_bytes(s1.data.subrange(s1.start, s1.start + 4)); {}
+                        spec_u32_from_le_bytes(s2.data.subrange(s2.start, s2.start + 4)); {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u64_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_u64_le(s), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_u64_le(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len()
-            && 0 <= s2.start <= s2.start + n <= s2.data.len()
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                if let Ok((sout2, m, x2)) = spec_parse_u64_le(s2) {
-                    assert(n == 8);
-                    assert(n == m);
-                    assert(x1 == x2) by {
-                        calc!{ (==)
-                            x1; {}
-                            spec_u64_from_le_bytes(s1.data.subrange(s1.start, s1.start + 8)); {}
-                            spec_u64_from_le_bytes(s2.data.subrange(s2.start, s2.start + 8)); {}
-                            x2;
-                        }
+pub proof fn lemma_parse_u64_le_strong_prefix_on(s1: SpecStream, s2: SpecStream)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_u64_le(s), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_u64_le(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() && 0 <= s2.start <= s2.start + n
+            <= s2.data.len() && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ) {
+            if let Ok((sout2, m, x2)) = spec_parse_u64_le(s2) {
+                assert(n == 8);
+                assert(n == m);
+                assert(x1 == x2) by {
+                    calc! {
+                        (==)
+                        x1; {}
+                        spec_u64_from_le_bytes(s1.data.subrange(s1.start, s1.start + 8)); {}
+                        spec_u64_from_le_bytes(s2.data.subrange(s2.start, s2.start + 8)); {}
+                        x2;
                     }
                 }
             }
         }
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_well_behaved_on(s: SpecStream, v: u8)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u8_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u8_le(s, v) {
-            assert(n == 1 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 1, s.data.len() as int) =~= s.data.subrange(s.start + 1, s.data.len() as int));
-        }
+pub proof fn lemma_serialize_u8_le_well_behaved_on(s: SpecStream, v: u8)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u8_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u8_le(s, v) {
+        assert(n == 1 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 1, s.data.len() as int) =~= s.data.subrange(
+            s.start + 1,
+            s.data.len() as int,
+        ));
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_well_behaved_on(s: SpecStream, v: u16)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u16_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
+pub proof fn lemma_serialize_u16_le_well_behaved_on(s: SpecStream, v: u16)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u16_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
+        lemma_auto_spec_u16_to_from_le_bytes();
+        assert(n == 2 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 2, s.data.len() as int) =~= s.data.subrange(
+            s.start + 2,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u32_le_well_behaved_on(s: SpecStream, v: u32)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u32_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
+        lemma_auto_spec_u32_to_from_le_bytes();
+        assert(n == 4 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 4, s.data.len() as int) =~= s.data.subrange(
+            s.start + 4,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u64_le_well_behaved_on(s: SpecStream, v: u64)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_u64_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
+        lemma_auto_spec_u64_to_from_le_bytes();
+        assert(n == 8 && sout.data.len() == s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + 8, s.data.len() as int) =~= s.data.subrange(
+            s.start + 8,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u8_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u8)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u8_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u8_le(s1, v),
+        spec_serialize_u8_le(s2, v),
+    ) {
+        assert(n1 == 1 && n2 == 1);
+        assert(sout1.data.subrange(s1.start, s1.start + 1) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 1,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u16_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u16)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u16_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u16_le(s1, v),
+        spec_serialize_u16_le(s2, v),
+    ) {
+        lemma_auto_spec_u16_to_from_le_bytes();
+        assert(n1 == 2 && n2 == 2);
+        assert(sout1.data.subrange(s1.start, s1.start + 2) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 2,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u32_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u32)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u32_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u32_le(s1, v),
+        spec_serialize_u32_le(s2, v),
+    ) {
+        lemma_auto_spec_u32_to_from_le_bytes();
+        assert(n1 == 4 && n2 == 4);
+        assert(sout1.data.subrange(s1.start, s1.start + 4) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 4,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_u64_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u64)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_u64_le(s, v), s1, s2, v),
+{
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_u64_le(s1, v),
+        spec_serialize_u64_le(s2, v),
+    ) {
+        lemma_auto_spec_u64_to_from_le_bytes();
+        assert(n1 == 8 && n2 == 8);
+        assert(sout1.data.subrange(s1.start, s1.start + 8) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + 8,
+        ));
+    }
+}
+
+pub proof fn lemma_parse_u8_le_correct_on(s: SpecStream, v: u8)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v), s, v),
+{
+}
+
+pub proof fn lemma_parse_u16_le_correct_on(s: SpecStream, v: u16)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
+        assert(sout.data.len() == s.data.len()) by { lemma_serialize_u16_le_well_behaved_on(s, v) }
+        if let Ok((_, m, res)) = spec_parse_u16_le(SpecStream { start: s.start, ..sout }) {
             lemma_auto_spec_u16_to_from_le_bytes();
-            assert(n == 2 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 2, s.data.len() as int) =~= s.data.subrange(s.start + 2, s.data.len() as int));
+            assert(n == m);
+            assert(res == spec_u16_from_le_bytes(sout.data.subrange(s.start, s.start + 2)));
+            assert(sout.data.subrange(s.start, s.start + 2) =~= spec_u16_to_le_bytes(v));
+            assert(v =~= res);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u32_le_well_behaved_on(s: SpecStream, v: u32)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u32_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
+pub proof fn lemma_parse_u32_le_correct_on(s: SpecStream, v: u32)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
+        assert(sout.data.len() == s.data.len()) by { lemma_serialize_u32_le_well_behaved_on(s, v) }
+        if let Ok((_, m, res)) = spec_parse_u32_le(SpecStream { start: s.start, ..sout }) {
             lemma_auto_spec_u32_to_from_le_bytes();
-            assert(n == 4 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 4, s.data.len() as int) =~= s.data.subrange(s.start + 4, s.data.len() as int));
+            assert(n == m);
+            assert(res == spec_u32_from_le_bytes(sout.data.subrange(s.start, s.start + 4)));
+            assert(sout.data.subrange(s.start, s.start + 4) =~= spec_u32_to_le_bytes(v));
+            assert(v =~= res);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u64_le_well_behaved_on(s: SpecStream, v: u64)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_u64_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
+pub proof fn lemma_parse_u64_le_correct_on(s: SpecStream, v: u64)
+    ensures
+        prop_parse_correct_on(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
+        assert(sout.data.len() == s.data.len()) by { lemma_serialize_u64_le_well_behaved_on(s, v) }
+        if let Ok((_, m, res)) = spec_parse_u64_le(SpecStream { start: s.start, ..sout }) {
             lemma_auto_spec_u64_to_from_le_bytes();
-            assert(n == 8 && sout.data.len() == s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + 8, s.data.len() as int) =~= s.data.subrange(s.start + 8, s.data.len() as int));
+            assert(n == m);
+            assert(res == spec_u64_from_le_bytes(sout.data.subrange(s.start, s.start + 8)));
+            assert(sout.data.subrange(s.start, s.start + 8) =~= spec_u64_to_le_bytes(v));
+            assert(v =~= res);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u8_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u8)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u8_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u8_le(s1, v), spec_serialize_u8_le(s2, v)) {
-            assert(n1 == 1 && n2 == 1);
-            assert(sout1.data.subrange(s1.start, s1.start + 1) =~= sout2.data.subrange(s2.start, s2.start + 1));
+pub proof fn lemma_parse_u8_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u8_le(s),
+            |s, v| spec_serialize_u8_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u8_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u8_le(s, res) {
+            assert(n == m && sout.data =~= s.data);
         }
     }
+}
 
-    pub proof fn lemma_serialize_u16_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u16)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u16_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u16_le(s1, v), spec_serialize_u16_le(s2, v)) {
-            lemma_auto_spec_u16_to_from_le_bytes();
-            assert(n1 == 2 && n2 == 2);
-            assert(sout1.data.subrange(s1.start, s1.start + 2) =~= sout2.data.subrange(s2.start, s2.start + 2));
-        }
-    }
-
-    pub proof fn lemma_serialize_u32_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u32)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u32_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u32_le(s1, v), spec_serialize_u32_le(s2, v)) {
-            lemma_auto_spec_u32_to_from_le_bytes();
-            assert(n1 == 4 && n2 == 4);
-            assert(sout1.data.subrange(s1.start, s1.start + 4) =~= sout2.data.subrange(s2.start, s2.start + 4));
-        }
-    }
-
-    pub proof fn lemma_serialize_u64_le_deterministic_on(s1: SpecStream, s2: SpecStream, v: u64)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_u64_le(s, v), s1, s2, v)
-    {
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_u64_le(s1, v), spec_serialize_u64_le(s2, v)) {
-            lemma_auto_spec_u64_to_from_le_bytes();
-            assert(n1 == 8 && n2 == 8);
-            assert(sout1.data.subrange(s1.start, s1.start + 8) =~= sout2.data.subrange(s2.start, s2.start + 8));
-        }
-    }
-
-    pub proof fn lemma_parse_u8_le_correct_on(s: SpecStream, v: u8)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v), s, v)
-    {}
-
-    pub proof fn lemma_parse_u16_le_correct_on(s: SpecStream, v: u16)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u16_le(s, v) {
-            assert(sout.data.len() == s.data.len()) by { lemma_serialize_u16_le_well_behaved_on(s, v)}
-            if let Ok((_, m, res)) = spec_parse_u16_le(SpecStream {start: s.start, ..sout}) {
+pub proof fn lemma_parse_u16_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u16_le(s),
+            |s, v| spec_serialize_u16_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u16_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u16_le(s, res) {
+            assert(n == m && sout.data =~= s.data) by {
                 lemma_auto_spec_u16_to_from_le_bytes();
-                assert(n == m);
-                assert(res == spec_u16_from_le_bytes(sout.data.subrange(s.start, s.start + 2)));
-                assert(sout.data.subrange(s.start, s.start + 2) =~= spec_u16_to_le_bytes(v));
-                assert(v =~= res);
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u32_le_correct_on(s: SpecStream, v: u32)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u32_le(s, v) {
-            assert(sout.data.len() == s.data.len()) by { lemma_serialize_u32_le_well_behaved_on(s, v)}
-            if let Ok((_, m, res)) = spec_parse_u32_le(SpecStream {start: s.start, ..sout}) {
+pub proof fn lemma_parse_u32_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u32_le(s),
+            |s, v| spec_serialize_u32_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u32_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u32_le(s, res) {
+            assert(n == m && sout.data =~= s.data) by {
                 lemma_auto_spec_u32_to_from_le_bytes();
-                assert(n == m);
-                assert(res == spec_u32_from_le_bytes(sout.data.subrange(s.start, s.start + 4)));
-                assert(sout.data.subrange(s.start, s.start + 4) =~= spec_u32_to_le_bytes(v));
-                assert(v =~= res);
             }
         }
     }
+}
 
-    pub proof fn lemma_parse_u64_le_correct_on(s: SpecStream, v: u64)
-        ensures
-            prop_parse_correct_on(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_u64_le(s, v) {
-            assert(sout.data.len() == s.data.len()) by { lemma_serialize_u64_le_well_behaved_on(s, v)}
-            if let Ok((_, m, res)) = spec_parse_u64_le(SpecStream {start: s.start, ..sout}) {
+pub proof fn lemma_parse_u64_le_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_u64_le(s),
+            |s, v| spec_serialize_u64_le(s, v),
+            s,
+        ),
+{
+    if let Ok((ss, m, res)) = spec_parse_u64_le(s) {
+        if let Ok((sout, n)) = spec_serialize_u64_le(s, res) {
+            assert(n == m && sout.data =~= s.data) by {
                 lemma_auto_spec_u64_to_from_le_bytes();
-                assert(n == m);
-                assert(res == spec_u64_from_le_bytes(sout.data.subrange(s.start, s.start + 8)));
-                assert(sout.data.subrange(s.start, s.start + 8) =~= spec_u64_to_le_bytes(v));
-                assert(v =~= res);
             }
         }
     }
-
-    pub proof fn lemma_parse_u8_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u8_le(s), |s, v| spec_serialize_u8_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u8_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u8_le(s, res) {
-                assert(n == m && sout.data =~= s.data);
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_u16_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u16_le(s), |s, v| spec_serialize_u16_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u16_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u16_le(s, res) {
-                assert(n == m && sout.data =~= s.data) by {
-                    lemma_auto_spec_u16_to_from_le_bytes();
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_u32_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u32_le(s), |s, v| spec_serialize_u32_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u32_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u32_le(s, res) {
-                assert(n == m && sout.data =~= s.data) by {
-                    lemma_auto_spec_u32_to_from_le_bytes();
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_u64_le_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_u64_le(s), |s, v| spec_serialize_u64_le(s, v), s)
-    {
-        if let Ok((ss, m, res)) = spec_parse_u64_le(s) {
-            if let Ok((sout, n)) = spec_serialize_u64_le(s, res) {
-                assert(n == m && sout.data =~= s.data) by {
-                    lemma_auto_spec_u64_to_from_le_bytes();
-                }
-            }
-        }
-    }
+}
 
 // Conversion between u16 and little-endian byte sequences
-
-pub closed spec fn spec_u16_to_le_bytes(x: u16) -> Seq<u8>
-{
-  seq![
-    (x & 0xff) as u8,
-    ((x >> 8) & 0xff) as u8
-  ]
+pub closed spec fn spec_u16_to_le_bytes(x: u16) -> Seq<u8> {
+    seq![(x & 0xff) as u8, ((x >> 8) & 0xff) as u8]
 }
 
 pub closed spec fn spec_u16_from_le_bytes(s: Seq<u8>) -> u16
-  recommends s.len() == 2
+    recommends
+        s.len() == 2,
 {
-  (s[0] as u16) |
-  (s[1] as u16) << 8
+    (s[0] as u16) | (s[1] as u16) << 8
 }
 
 pub proof fn lemma_auto_spec_u16_to_from_le_bytes()
-  ensures
-    forall |x: u16|
-    {
-      &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
-      &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
-    },
-    forall |s: Seq<u8>|
-      s.len() == 2 ==> #[trigger] spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s,
+    ensures
+        forall|x: u16|
+            {
+                &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
+                &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
+            },
+        forall|s: Seq<u8>|
+            s.len() == 2 ==> #[trigger] spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s,
 {
-  assert forall |x: u16|  {
-    &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
-    &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
-  } by {
-    let s = spec_u16_to_le_bytes(x);
-    assert({
-      &&& x & 0xff < 256
-      &&& (x >> 8) & 0xff < 256
-    }) by (bit_vector);
+    assert forall|x: u16|
+        {
+            &&& #[trigger] spec_u16_to_le_bytes(x).len() == 2
+            &&& spec_u16_from_le_bytes(spec_u16_to_le_bytes(x)) == x
+        } by {
+        let s = spec_u16_to_le_bytes(x);
+        assert({
+            &&& x & 0xff < 256
+            &&& (x >> 8) & 0xff < 256
+        }) by (bit_vector);
 
-    assert(x == (
-      (x & 0xff) |
-      ((x >> 8) & 0xff) << 8)) by (bit_vector);
-  };
+        assert(x == ((x & 0xff) | ((x >> 8) & 0xff) << 8)) by (bit_vector);
+    };
 
-  assert forall |s: Seq<u8>| s.len() == 2 implies #[trigger] spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s by {
-    let x = spec_u16_from_le_bytes(s);
-    let s0 = s[0] as u16;
-    let s1 = s[1] as u16;
+    assert forall|s: Seq<u8>| s.len() == 2 implies #[trigger] spec_u16_to_le_bytes(
+        spec_u16_from_le_bytes(s),
+    ) == s by {
+        let x = spec_u16_from_le_bytes(s);
+        let s0 = s[0] as u16;
+        let s1 = s[1] as u16;
 
-    assert(
-      (
-        (x == s0 | s1 << 8) &&
-        (s0 < 256) &&
-        (s1 < 256)
-      ) ==>
-      s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff)
-    ) by (bit_vector);
+        assert(((x == s0 | s1 << 8) && (s0 < 256) && (s1 < 256)) ==> s0 == (x & 0xff) && s1 == ((x
+            >> 8) & 0xff)) by (bit_vector);
 
-    assert_seqs_equal!(spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s);
-  }
+        assert_seqs_equal!(spec_u16_to_le_bytes(spec_u16_from_le_bytes(s)) == s);
+    }
 }
 
 #[verifier(external_body)]
-pub exec fn u16_from_le_bytes(s: &[u8]) -> (x:u16)
-  requires s.dview().len() == 2,
-  ensures x == spec_u16_from_le_bytes(s.dview()),
+pub exec fn u16_from_le_bytes(s: &[u8]) -> (x: u16)
+    requires
+        s.dview().len() == 2,
+    ensures
+        x == spec_u16_from_le_bytes(s.dview()),
 {
-  use core::convert::TryInto;
-  u16::from_le_bytes(s.try_into().unwrap())
+    use core::convert::TryInto;
+    u16::from_le_bytes(s.try_into().unwrap())
 }
-
 
 #[verifier(external_body)]
 pub exec fn u16_to_le_bytes(x: u16) -> (s: alloc::vec::Vec<u8>)
-  ensures
-    s.dview() == spec_u16_to_le_bytes(x),
-    s.dview().len() == 2,
+    ensures
+        s.dview() == spec_u16_to_le_bytes(x),
+        s.dview().len() == 2,
 {
-  x.to_le_bytes().to_vec()
+    x.to_le_bytes().to_vec()
 }
 
 // Conversion between u32 and little-endian byte sequences
-
-pub closed spec fn spec_u32_to_le_bytes(x: u32) -> Seq<u8>
-{
-  seq![
-    (x & 0xff) as u8,
-    ((x >> 8) & 0xff) as u8,
-    ((x >> 16) & 0xff) as u8,
-    ((x >> 24) & 0xff) as u8,
-  ]
+pub closed spec fn spec_u32_to_le_bytes(x: u32) -> Seq<u8> {
+    seq![
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+    ]
 }
 
 pub closed spec fn spec_u32_from_le_bytes(s: Seq<u8>) -> u32
-  recommends s.len() == 4
+    recommends
+        s.len() == 4,
 {
-  (s[0] as u32) |
-  (s[1] as u32) << 8 |
-  (s[2] as u32) << 16 |
-  (s[3] as u32) << 24
+    (s[0] as u32) | (s[1] as u32) << 8 | (s[2] as u32) << 16 | (s[3] as u32) << 24
 }
 
 #[verifier::spinoff_prover]
 pub proof fn lemma_auto_spec_u32_to_from_le_bytes()
-  ensures
-    forall |x: u32|
-    {
-      &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
-      &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
-    },
-    forall |s: Seq<u8>|
-      s.len() == 4 ==> #[trigger] spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s,
+    ensures
+        forall|x: u32|
+            {
+                &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
+                &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
+            },
+        forall|s: Seq<u8>|
+            s.len() == 4 ==> #[trigger] spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s,
 {
-  assert forall |x: u32|  {
-    &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
-    &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
-  } by {
-    let s = spec_u32_to_le_bytes(x);
-    assert({
-      &&& x & 0xff < 256
-      &&& (x >> 8) & 0xff < 256
-      &&& (x >> 16) & 0xff < 256
-      &&& (x >> 24) & 0xff < 256
-    }) by (bit_vector);
+    assert forall|x: u32|
+        {
+            &&& #[trigger] spec_u32_to_le_bytes(x).len() == 4
+            &&& spec_u32_from_le_bytes(spec_u32_to_le_bytes(x)) == x
+        } by {
+        let s = spec_u32_to_le_bytes(x);
+        assert({
+            &&& x & 0xff < 256
+            &&& (x >> 8) & 0xff < 256
+            &&& (x >> 16) & 0xff < 256
+            &&& (x >> 24) & 0xff < 256
+        }) by (bit_vector);
 
-    assert(x == (
-      (x & 0xff) |
-      ((x >> 8) & 0xff) << 8 |
-      ((x >> 16) & 0xff) << 16 |
-      ((x >> 24) & 0xff) << 24)) by (bit_vector);
-  };
+        assert(x == ((x & 0xff) | ((x >> 8) & 0xff) << 8 | ((x >> 16) & 0xff) << 16 | ((x >> 24)
+            & 0xff) << 24)) by (bit_vector);
+    };
 
-  assert forall |s: Seq<u8>| s.len() == 4 implies #[trigger] spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s by {
-    let x = spec_u32_from_le_bytes(s);
-    let s0 = s[0] as u32;
-    let s1 = s[1] as u32;
-    let s2 = s[2] as u32;
-    let s3 = s[3] as u32;
+    assert forall|s: Seq<u8>| s.len() == 4 implies #[trigger] spec_u32_to_le_bytes(
+        spec_u32_from_le_bytes(s),
+    ) == s by {
+        let x = spec_u32_from_le_bytes(s);
+        let s0 = s[0] as u32;
+        let s1 = s[1] as u32;
+        let s2 = s[2] as u32;
+        let s3 = s[3] as u32;
 
-    assert(
-      (
-        (x == s0 | s1 << 8 | s2 << 16 | s3 << 24) &&
-        (s0 < 256) &&
-        (s1 < 256) &&
-        (s2 < 256) &&
-        (s3 < 256)
-      ) ==>
-      s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff) && s2 == ((x >> 16) & 0xff) && s3 == ((x >> 24) & 0xff)
-    ) by (bit_vector);
+        assert(((x == s0 | s1 << 8 | s2 << 16 | s3 << 24) && (s0 < 256) && (s1 < 256) && (s2 < 256)
+            && (s3 < 256)) ==> s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff) && s2 == ((x >> 16)
+            & 0xff) && s3 == ((x >> 24) & 0xff)) by (bit_vector);
 
-    assert_seqs_equal!(spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s);
-  }
+        assert_seqs_equal!(spec_u32_to_le_bytes(spec_u32_from_le_bytes(s)) == s);
+    }
 }
 
 #[verifier(external_body)]
-pub exec fn u32_from_le_bytes(s: &[u8]) -> (x:u32)
-  requires s.dview().len() == 4,
-  ensures x == spec_u32_from_le_bytes(s.dview()),
+pub exec fn u32_from_le_bytes(s: &[u8]) -> (x: u32)
+    requires
+        s.dview().len() == 4,
+    ensures
+        x == spec_u32_from_le_bytes(s.dview()),
 {
-  use core::convert::TryInto;
-  u32::from_le_bytes(s.try_into().unwrap())
+    use core::convert::TryInto;
+    u32::from_le_bytes(s.try_into().unwrap())
 }
-
 
 #[verifier(external_body)]
 pub exec fn u32_to_le_bytes(x: u32) -> (s: alloc::vec::Vec<u8>)
-  ensures
-    s.dview() == spec_u32_to_le_bytes(x),
-    s.dview().len() == 4,
+    ensures
+        s.dview() == spec_u32_to_le_bytes(x),
+        s.dview().len() == 4,
 {
-  x.to_le_bytes().to_vec()
+    x.to_le_bytes().to_vec()
 }
 
 // Conversion between u64 and little-endian byte sequences
-
-pub closed spec fn spec_u64_to_le_bytes(x: u64) -> Seq<u8>
-{
-  seq![
-    (x & 0xff) as u8,
-    ((x >> 8) & 0xff) as u8,
-    ((x >> 16) & 0xff) as u8,
-    ((x >> 24) & 0xff) as u8,
-    ((x >> 32) & 0xff) as u8,
-    ((x >> 40) & 0xff) as u8,
-    ((x >> 48) & 0xff) as u8,
-    ((x >> 56) & 0xff) as u8,
-  ]
+pub closed spec fn spec_u64_to_le_bytes(x: u64) -> Seq<u8> {
+    seq![
+        (x & 0xff) as u8,
+        ((x >> 8) & 0xff) as u8,
+        ((x >> 16) & 0xff) as u8,
+        ((x >> 24) & 0xff) as u8,
+        ((x >> 32) & 0xff) as u8,
+        ((x >> 40) & 0xff) as u8,
+        ((x >> 48) & 0xff) as u8,
+        ((x >> 56) & 0xff) as u8,
+    ]
 }
 
 pub closed spec fn spec_u64_from_le_bytes(s: Seq<u8>) -> u64
-  recommends s.len() == 8
+    recommends
+        s.len() == 8,
 {
-  (s[0] as u64) |
-  (s[1] as u64) << 8 |
-  (s[2] as u64) << 16 |
-  (s[3] as u64) << 24 |
-  (s[4] as u64) << 32 |
-  (s[5] as u64) << 40 |
-  (s[6] as u64) << 48 |
-  (s[7] as u64) << 56
+    (s[0] as u64) | (s[1] as u64) << 8 | (s[2] as u64) << 16 | (s[3] as u64) << 24 | (s[4] as u64)
+        << 32 | (s[5] as u64) << 40 | (s[6] as u64) << 48 | (s[7] as u64) << 56
 }
 
 pub proof fn lemma_auto_spec_u64_to_from_le_bytes()
-  ensures
-    forall |x: u64|
-      #![trigger spec_u64_to_le_bytes(x)]
-    {
-      &&& spec_u64_to_le_bytes(x).len() == 8
-      &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
-    },
-    forall |s: Seq<u8>|
-      #![trigger spec_u64_to_le_bytes(spec_u64_from_le_bytes(s))]
-      s.len() == 8 ==> spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s,
+    ensures
+        forall|x: u64|
+            #![trigger spec_u64_to_le_bytes(x)]
+            {
+                &&& spec_u64_to_le_bytes(x).len() == 8
+                &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
+            },
+        forall|s: Seq<u8>|
+            #![trigger spec_u64_to_le_bytes(spec_u64_from_le_bytes(s))]
+            s.len() == 8 ==> spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s,
 {
-  assert forall |x: u64|  {
-    &&& #[trigger] spec_u64_to_le_bytes(x).len() == 8
-    &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
-  } by {
-    let s = spec_u64_to_le_bytes(x);
-    assert({
-      &&& x & 0xff < 256
-      &&& (x >> 8) & 0xff < 256
-      &&& (x >> 16) & 0xff < 256
-      &&& (x >> 24) & 0xff < 256
-      &&& (x >> 32) & 0xff < 256
-      &&& (x >> 40) & 0xff < 256
-      &&& (x >> 48) & 0xff < 256
-      &&& (x >> 56) & 0xff < 256
-    }) by (bit_vector);
+    assert forall|x: u64|
+        {
+            &&& #[trigger] spec_u64_to_le_bytes(x).len() == 8
+            &&& spec_u64_from_le_bytes(spec_u64_to_le_bytes(x)) == x
+        } by {
+        let s = spec_u64_to_le_bytes(x);
+        assert({
+            &&& x & 0xff < 256
+            &&& (x >> 8) & 0xff < 256
+            &&& (x >> 16) & 0xff < 256
+            &&& (x >> 24) & 0xff < 256
+            &&& (x >> 32) & 0xff < 256
+            &&& (x >> 40) & 0xff < 256
+            &&& (x >> 48) & 0xff < 256
+            &&& (x >> 56) & 0xff < 256
+        }) by (bit_vector);
 
-    assert(x == (
-      (x & 0xff) |
-      ((x >> 8) & 0xff) << 8 |
-      ((x >> 16) & 0xff) << 16 |
-      ((x >> 24) & 0xff) << 24 |
-      ((x >> 32) & 0xff) << 32 |
-      ((x >> 40) & 0xff) << 40 |
-      ((x >> 48) & 0xff) << 48 |
-      ((x >> 56) & 0xff) << 56)) by (bit_vector);
-  };
+        assert(x == ((x & 0xff) | ((x >> 8) & 0xff) << 8 | ((x >> 16) & 0xff) << 16 | ((x >> 24)
+            & 0xff) << 24 | ((x >> 32) & 0xff) << 32 | ((x >> 40) & 0xff) << 40 | ((x >> 48) & 0xff)
+            << 48 | ((x >> 56) & 0xff) << 56)) by (bit_vector);
+    };
 
-  assert forall |s: Seq<u8>| s.len() == 8 implies #[trigger] spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s by {
-    let x = spec_u64_from_le_bytes(s);
-    let s0 = s[0] as u64;
-    let s1 = s[1] as u64;
-    let s2 = s[2] as u64;
-    let s3 = s[3] as u64;
-    let s4 = s[4] as u64;
-    let s5 = s[5] as u64;
-    let s6 = s[6] as u64;
-    let s7 = s[7] as u64;
+    assert forall|s: Seq<u8>| s.len() == 8 implies #[trigger] spec_u64_to_le_bytes(
+        spec_u64_from_le_bytes(s),
+    ) == s by {
+        let x = spec_u64_from_le_bytes(s);
+        let s0 = s[0] as u64;
+        let s1 = s[1] as u64;
+        let s2 = s[2] as u64;
+        let s3 = s[3] as u64;
+        let s4 = s[4] as u64;
+        let s5 = s[5] as u64;
+        let s6 = s[6] as u64;
+        let s7 = s[7] as u64;
 
-    assert(
-      (
-        (x == s0 | s1 << 8 | s2 << 16 | s3 << 24 | s4 << 32 | s5 << 40 | s6 << 48 | s7 << 56) &&
-        (s0 < 256) &&
-        (s1 < 256) &&
-        (s2 < 256) &&
-        (s3 < 256) &&
-        (s4 < 256) &&
-        (s5 < 256) &&
-        (s6 < 256) &&
-        (s7 < 256)
-      ) ==>
-      s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff) && s2 == ((x >> 16) & 0xff) && s3 == ((x >> 24) & 0xff) && s4 == ((x >> 32) & 0xff) && s5 == ((x >> 40) & 0xff) && s6 == ((x >> 48) & 0xff) && s7 == ((x >> 56) & 0xff)
-    ) by (bit_vector);
+        assert(((x == s0 | s1 << 8 | s2 << 16 | s3 << 24 | s4 << 32 | s5 << 40 | s6 << 48 | s7
+            << 56) && (s0 < 256) && (s1 < 256) && (s2 < 256) && (s3 < 256) && (s4 < 256) && (s5
+            < 256) && (s6 < 256) && (s7 < 256)) ==> s0 == (x & 0xff) && s1 == ((x >> 8) & 0xff)
+            && s2 == ((x >> 16) & 0xff) && s3 == ((x >> 24) & 0xff) && s4 == ((x >> 32) & 0xff)
+            && s5 == ((x >> 40) & 0xff) && s6 == ((x >> 48) & 0xff) && s7 == ((x >> 56) & 0xff))
+            by (bit_vector);
 
-    assert_seqs_equal!(spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s);
-  }
+        assert_seqs_equal!(spec_u64_to_le_bytes(spec_u64_from_le_bytes(s)) == s);
+    }
 }
 
 #[verifier(external_body)]
-pub exec fn u64_from_le_bytes(s: &[u8]) -> (x:u64)
-  requires s.dview().len() == 8,
-  ensures x == spec_u64_from_le_bytes(s.dview()),
+pub exec fn u64_from_le_bytes(s: &[u8]) -> (x: u64)
+    requires
+        s.dview().len() == 8,
+    ensures
+        x == spec_u64_from_le_bytes(s.dview()),
 {
-  use core::convert::TryInto;
-  u64::from_le_bytes(s.try_into().unwrap())
+    use core::convert::TryInto;
+    u64::from_le_bytes(s.try_into().unwrap())
 }
-
 
 #[verifier(external_body)]
 pub exec fn u64_to_le_bytes(x: u64) -> (s: alloc::vec::Vec<u8>)
-  ensures
-    s.dview() == spec_u64_to_le_bytes(x),
-    s.dview().len() == 8,
+    ensures
+        s.dview() == spec_u64_to_le_bytes(x),
+        s.dview().len() == 8,
 {
-  x.to_le_bytes().to_vec()
+    x.to_le_bytes().to_vec()
 }
 
-
-} // verus
-
+} // verus!
+// verus
 verus! {
 
-    pub open spec fn spec_parse_pair<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>) ->
-        spec_fn(SpecStream) -> SpecParseResult<(R1,R2)>
-    {
-        move |s| match parser1(s) {
+pub open spec fn spec_parse_pair<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+) -> spec_fn(SpecStream) -> SpecParseResult<(R1, R2)> {
+    move |s|
+        match parser1(s) {
             Ok((s, n, r1)) => match parser2(s) {
                 Ok((s, m, r2)) => {
                     if n + m > usize::MAX {
@@ -2170,19 +2273,19 @@ verus! {
                     } else {
                         Ok((s, n + m, (r1, r2)))
                     }
-                }
+                },
                 Err(e) => Err(e),
             },
             Err(e) => Err(e),
         }
-    }
+}
 
-    pub open spec fn spec_serialize_pair<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult) ->
-        spec_fn(SpecStream, (T1, T2)) -> SpecSerializeResult
-    {
-        move |s, v: (T1, T2)| match serializer1(s, v.0) {
+pub open spec fn spec_serialize_pair<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, (T1, T2)) -> SpecSerializeResult {
+    move |s, v: (T1, T2)|
+        match serializer1(s, v.0) {
             Ok((s, n)) => match serializer2(s, v.1) {
                 Ok((s, m)) => {
                     if n + m > usize::MAX {
@@ -2190,406 +2293,411 @@ verus! {
                     } else {
                         Ok((s, n + m))
                     }
-                }
+                },
                 Err(e) => Err(e),
             },
             Err(e) => Err(e),
         }
-    }
+}
 
-    pub exec fn parse_pair<'a, P1, P2, R1, R2>(
-        exec_parser1: P1,
-        exec_parser2: P2,
-        Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
-        Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
-        s: Stream<'a>) -> (res: ParseResult<'a, (R1,R2)>)
-        where
-            R1: DView,
-            R2: DView,
-            P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
-            P2: FnOnce(Stream<'a>) -> ParseResult<R2>,
-        requires
-            prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
-            prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2))
-    {
-        proof { reveal(prop_parse_exec_spec_equiv); }
-        let res1 = exec_parser1(s);
-        proof { lemma_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1); }
-        match res1 {
-            Ok((s1, n1, r1)) => {
-                let res2 = exec_parser2(s1);
-                proof { lemma_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2); }
-                match res2 {
-                    Ok((s2, n2, r2)) => {
-                        if n1 > usize::MAX - n2 {
-                            Err(ParseError::IntegerOverflow)
-                        } else {
-                            Ok((s2, n1 + n2, (r1, r2)))
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
+pub exec fn parse_pair<'a, P1, P2, R1, R2>(
+    exec_parser1: P1,
+    exec_parser2: P2,
+    Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
+    Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
+    s: Stream<'a>,
+) -> (res: ParseResult<'a, (R1, R2)>) where
+    R1: DView,
+    R2: DView,
+    P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
+    P2: FnOnce(Stream<'a>) -> ParseResult<R2>,
+
+    requires
+        prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
+        prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+{
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let res1 = exec_parser1(s);
+    proof {
+        lemma_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1);
+    }
+    match res1 {
+        Ok((s1, n1, r1)) => {
+            let res2 = exec_parser2(s1);
+            proof {
+                lemma_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2);
             }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub proof fn lemma_parse_pair_correct<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2),
-            prop_parse_well_behaved(parser1),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_correct(parser1, serializer1),
-            prop_parse_correct(parser2, serializer2)
-        ensures
-            prop_parse_correct(spec_parse_pair(parser1, parser2),
-                                spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_parse_correct);
-        assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> prop_parse_correct_on(spec_parse_pair(parser1, parser2), spec_serialize_pair(serializer1, serializer2), s, v) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_pair_correct_on(parser1, parser2, serializer1, serializer2, s, v);
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_pair_serialize_inverse<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_serialize_well_behaved(serializer1),
-            prop_parse_serialize_inverse(parser1, serializer1),
-            prop_parse_serialize_inverse(parser2, serializer2)
-        ensures
-            prop_parse_serialize_inverse(spec_parse_pair(parser1, parser2),
-                                    spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_parse_serialize_inverse);
-        assert forall |s: SpecStream| prop_parse_serialize_inverse_on(spec_parse_pair(parser1, parser2),
-        spec_serialize_pair(serializer1, serializer2), s) by {
-            lemma_parse_pair_serialize_inverse_on(parser1, parser2, serializer1, serializer2, s);
-        }
-    }
-
-    pub proof fn lemma_parse_pair_well_behaved<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2)
-        ensures
-            prop_parse_well_behaved(spec_parse_pair(parser1, parser2))
-    {
-        reveal(prop_parse_well_behaved);
-        assert forall |s: SpecStream| prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s) by {
-            lemma_parse_pair_well_behaved_on(parser1, parser2, s);
-        }
-    }
-
-    pub proof fn lemma_serialize_pair_well_behaved<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_well_behaved(spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_serialize_well_behaved);
-        assert forall |s: SpecStream, v: (T1, T2)| prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v) by {
-            lemma_serialize_pair_well_behaved_on(serializer1, serializer2, s, v);
-        }
-    }
-
-    pub proof fn lemma_serialize_pair_deterministic<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult)
-        requires
-            prop_serialize_deterministic(serializer1),
-            prop_serialize_deterministic(serializer2),
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_deterministic(spec_serialize_pair(serializer1, serializer2))
-    {
-        reveal(prop_serialize_deterministic);
-        assert forall |s1, s2, v| prop_serialize_deterministic_on(spec_serialize_pair(serializer1, serializer2), s1, s2, v) by {
-            lemma_serialize_pair_deterministic_on(serializer1, serializer2, s1, s2, v);
-        }
-    }
-
-    pub proof fn lemma_parse_pair_strong_prefix<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_strong_prefix(parser2),
-        ensures
-            prop_parse_strong_prefix(spec_parse_pair(parser1, parser2))
-    {
-        reveal(prop_parse_strong_prefix);
-        assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2) by {
-            lemma_parse_pair_strong_prefix_on(parser1, parser2, s1, s2);
-        }
-    }
-
-    pub proof fn lemma_parse_pair_well_behaved_on<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2)
-        ensures
-            prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s)
-    {
-        if let Ok((s1, n1, _)) = parser1(s) {
-            assert(
-                s1.data == s.data &&
-                s1.start == s.start + n1 &&
-                0 <= s.start <= s1.start <= s.data.len()) by {
-                    lemma_parse_well_behaved_on(parser1, s);
-                }
-            if let Ok((s2, n2, _)) = parser2(s1) {
-                assert(
-                    s2.data == s1.data &&
-                    s2.start == s1.start + n2 &&
-                    0 <= s1.start <= s2.start <= s1.data.len()) by {
-                        lemma_parse_well_behaved_on(parser2, s1);
+            match res2 {
+                Ok((s2, n2, r2)) => {
+                    if n1 > usize::MAX - n2 {
+                        Err(ParseError::IntegerOverflow)
+                    } else {
+                        Ok((s2, n1 + n2, (r1, r2)))
                     }
-                if let Ok((sout, n, _)) = spec_parse_pair(parser1, parser2)(s) {
-                    assert(n == n1 + n2);
-                }
+                },
+                Err(e) => Err(e),
             }
+        },
+        Err(e) => Err(e),
+    }
+}
+
+pub proof fn lemma_parse_pair_correct<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+        prop_parse_well_behaved(parser1),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_correct(parser1, serializer1),
+        prop_parse_correct(parser2, serializer2),
+    ensures
+        prop_parse_correct(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+        ),
+{
+    reveal(prop_parse_correct);
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+            v,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_pair_correct_on(parser1, parser2, serializer1, serializer2, s, v);
         }
     }
+}
 
-    pub proof fn lemma_serialize_pair_well_behaved_on<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s: SpecStream, v: (T1, T2))
-        requires
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v)
-    {
-        lemma_serialize_well_behaved_on(serializer1, s, v.0);
-        if let Ok((s1, n1)) = serializer1(s, v.0) {
-            assert(
-                s1.data.len() == s.data.len()
-                && 0 <= s.start <= s1.start <= s.data.len()
-                && s1.start == s.start + n1
-                && s1.data.subrange(0, s.start) == s.data.subrange(0, s.start)
-                && s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(s.start + n1, s.data.len() as int));
-            lemma_serialize_well_behaved_on(serializer2, s1, v.1);
-            if let Ok((s2, n2)) = serializer2(s1, v.1) {
-                assert(
-                    s2.data.len() == s1.data.len()
-                    && 0 <= s1.start <= s2.start <= s1.data.len()
-                    && s2.start == s1.start + n2
-                    && s2.data.subrange(0, s1.start) == s1.data.subrange(0, s1.start)
-                    && s2.data.subrange(s1.start + n2, s1.data.len() as int) == s1.data.subrange(s1.start + n2, s1.data.len() as int));
-                if let Ok((sout, n)) = spec_serialize_pair(serializer1, serializer2)(s, v) {
-                    // assert(n == n1 + n2);
-                    // assert(s2 == sout);
-                    assert(sout.data.len() == s.data.len());
-                    assert(0 <= s.start <= sout.start <= s.data.len());
-                    assert(sout.start == s.start + n);
-                    assert(sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
-                        assert(s2.data.subrange(0, s1.start).subrange(0, s.start) =~= s2.data.subrange(0, s.start));
-                        assert(s1.data.subrange(0, s1.start).subrange(0, s.start) =~= s1.data.subrange(0, s.start));
-                    }
-                    assert(sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(s.start + n, s.data.len() as int)) by {
-                        assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s1.data.subrange(s.start + n, s.data.len() as int));
-                        assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s.data.subrange(s.start + n, s.data.len() as int));
-                    }
-                }
-            }
-        }
+pub proof fn lemma_parse_pair_serialize_inverse<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_serialize_well_behaved(serializer1),
+        prop_parse_serialize_inverse(parser1, serializer1),
+        prop_parse_serialize_inverse(parser2, serializer2),
+    ensures
+        prop_parse_serialize_inverse(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+        ),
+{
+    reveal(prop_parse_serialize_inverse);
+    assert forall|s: SpecStream|
+        prop_parse_serialize_inverse_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+        ) by {
+        lemma_parse_pair_serialize_inverse_on(parser1, parser2, serializer1, serializer2, s);
     }
+}
 
-    pub proof fn lemma_serialize_pair_deterministic_on<T1, T2>(
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s1: SpecStream, s2: SpecStream, v: (T1, T2))
-        requires
-            prop_serialize_deterministic(serializer1),
-            prop_serialize_deterministic(serializer2),
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2)
-        ensures
-            prop_serialize_deterministic_on(spec_serialize_pair(serializer1, serializer2), s1, s2, v)
-    {
-        lemma_serialize_deterministic_on(serializer1, s1, s2, v.0);
-        lemma_serialize_well_behaved_on(serializer1, s1, v.0);
-        lemma_serialize_well_behaved_on(serializer1, s2, v.0);
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer1(s1, v.0), serializer1(s2, v.0)) {
-            lemma_serialize_deterministic_on(serializer2, sout1, sout2, v.1);
-            lemma_serialize_well_behaved_on(serializer2, sout1, v.1);
-            lemma_serialize_well_behaved_on(serializer2, sout2, v.1);
-            if let (Ok((sout3, n3)), Ok((sout4, n4))) = (serializer2(sout1, v.1), serializer2(sout2, v.1)) {
-                assert(n1 + n3 == n2 + n4);
-                assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout4.data.subrange(s2.start, s2.start + n2 + n4)) by {
-                    assert(sout1.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1) =~= sout1.data.subrange(s1.start, s1.start + n1));
-                    assert(sout2.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2) =~= sout2.data.subrange(s2.start, s2.start + n2));
-                    assert(sout3.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1) =~= sout3.data.subrange(s1.start, s1.start + n1));
-                    assert(sout4.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2) =~= sout4.data.subrange(s2.start, s2.start + n2));
-
-                    assert(sout3.data.subrange(s1.start, s1.start + n1) =~= sout4.data.subrange(s2.start, s2.start + n2));
-                    assert(sout3.data.subrange(s1.start + n1, s1.start + n1 + n3) == sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
-
-                    assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout3.data.subrange(s1.start, s1.start + n1) + sout3.data.subrange(s1.start + n1, s1.start + n1 + n3));
-                    assert(sout4.data.subrange(s2.start, s2.start + n2 + n4) =~= sout4.data.subrange(s2.start, s2.start + n2) + sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
-                }
-            }
-        }
+pub proof fn lemma_parse_pair_well_behaved<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+    ensures
+        prop_parse_well_behaved(spec_parse_pair(parser1, parser2)),
+{
+    reveal(prop_parse_well_behaved);
+    assert forall|s: SpecStream|
+        prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s) by {
+        lemma_parse_pair_well_behaved_on(parser1, parser2, s);
     }
+}
 
-    pub proof fn lemma_parse_pair_strong_prefix_on<R1, R2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
-        s1: SpecStream, s2: SpecStream)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_strong_prefix(parser2),
-        ensures
-            prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2)
-    {
-        if let Ok((sout1, n, x1)) = spec_parse_pair(parser1, parser2)(s1) {
-            if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + n <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + n) == s2.data.subrange(s2.start, s2.start + n) {
-                // assert(parser1(s1).is_ok());
-                if let Ok((p1s1, n1, p1x1)) = parser1(s1) {
-                    // assert(parser2(p1s1).is_ok());
-                    if let Ok((p2s1, n2, p2x1)) = parser2(p1s1) {
-                        assert(s1.data.subrange(s1.start, s1.start + n1) == s2.data.subrange(s2.start, s2.start + n1)) by {
-                            assert(s1.data.subrange(s1.start, s1.start + n).subrange(0, n1 as int) =~= s1.data.subrange(s1.start, s1.start + n1));
-                            assert(s2.data.subrange(s2.start, s2.start + n).subrange(0, n1 as int) =~= s2.data.subrange(s2.start, s2.start + n1));
-                        }
-                        lemma_parse_strong_prefix_on(parser1, s1, s2);
-                        // assert(parser1(s2).is_ok());
-                        if let Ok((p1s2, m1, p1x2)) = parser1(s2) {
-                            lemma_parse_well_behaved_on(parser1, s1);
-                            lemma_parse_well_behaved_on(parser1, s2);
-                            // assert(p1s1.data == s1.data);
-                            // assert(p1s2.data == s2.data);
-                            // assert(p1s1.start == s1.start + n1);
-                            // assert(p1s2.start == s2.start + n1);
-                            // assert(n == n1 + n2);
-                            assert(s1.data.subrange(s1.start + n1, s1.start + n1 + n2) == s2.data.subrange(s2.start + n1, s2.start + n1 + n2)) by {
-                                assert(s1.data.subrange(s1.start, s1.start + n).subrange(n1 as int, n as int) =~= s1.data.subrange(s1.start + n1, s1.start + n1 + n2));
-                                assert(s2.data.subrange(s2.start, s2.start + n).subrange(n1 as int, n as int) =~= s2.data.subrange(s2.start + n1, s2.start + n1 + n2));
-                            }
-                            assert(p1s1.data.subrange(p1s1.start, p1s1.start + n2) == p1s2.data.subrange(p1s2.start, p1s2.start + n2));
-                            lemma_parse_strong_prefix_on(parser2, p1s1, p1s2);
-                            // assert(parser2(p1s2).is_ok());
-                            if let Ok((p2s2, m2, p2x2)) = parser2(p1s2) {
-                                if let Ok((sout2, m, x2)) = spec_parse_pair(parser1, parser2)(s2) {
-                                    assert(m == n && x2 == x1);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+pub proof fn lemma_serialize_pair_well_behaved<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_well_behaved(spec_serialize_pair(serializer1, serializer2)),
+{
+    reveal(prop_serialize_well_behaved);
+    assert forall|s: SpecStream, v: (T1, T2)|
+        prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v) by {
+        lemma_serialize_pair_well_behaved_on(serializer1, serializer2, s, v);
     }
+}
 
-    pub proof fn lemma_parse_pair_correct_on<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s: SpecStream, v: (T1, T2))
-        requires
-            s.data.len() <= usize::MAX,
-            prop_serialize_well_behaved(serializer1),
-            prop_serialize_well_behaved(serializer2),
-            prop_parse_well_behaved(parser1),
-            prop_parse_strong_prefix(parser1),
-            prop_parse_correct(parser1, serializer1),
-            prop_parse_correct(parser2, serializer2)
-        ensures
-            prop_parse_correct_on(spec_parse_pair(parser1, parser2),
-                                spec_serialize_pair(serializer1, serializer2), s, v)
-    {
-        if let Ok((s1, n1)) = serializer1(s, v.0) {
-            if let Ok((s2, n2)) = serializer2(s1, v.1) {
-                lemma_serialize_well_behaved_on(serializer1, s, v.0);
-                lemma_serialize_well_behaved_on(serializer2, s1, v.1);
-                lemma_parse_correct_on(parser1, serializer1, s, v.0);
-                if let Ok((s_c1, n_c1, r_c1)) = parser1(SpecStream {start: s.start, ..s1}) {
-                    assert(n1 == n_c1 && r_c1 == v.0);
-                    assert(s1.data.subrange(s.start, s.start + n_c1) == s2.data.subrange(s.start, s.start + n_c1)) by {
-                        assert(s1.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1) =~= s1.data.subrange(s.start, s.start + n1));
-                        assert(s2.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1) =~= s2.data.subrange(s.start, s.start + n1));
-                    }
-                    lemma_parse_strong_prefix_on(parser1, SpecStream {start: s.start, ..s1}, SpecStream {start: s.start, ..s2});
-                    if let Ok((s3, m1, res1)) = parser1(SpecStream {start: s.start, ..s2}) {
-                        assert(m1 == n_c1 && res1 == r_c1);
-                        assert(m1 == n1 && res1 == v.0); // crucial fact 1
-                        lemma_parse_well_behaved_on(parser1, SpecStream {start: s.start, ..s2});
-                        assert(s3.data == s2.data && s3.start == s.start + m1); // crucial fact 2 (s3 == SpecStream {start: s1.start, ..s2})
-                        lemma_parse_correct_on(parser2, serializer2, s1, v.1);
-                        // if let Ok((s_c2, n_c2, r_c2)) = parser2(SpecStream {start: s1.start, ..s2}) {
-                            // assert(n2 == n_c2 && r_c2 == v.1);
-                            if let Ok((s4, m2, res2)) = parser2(s3) {
-                                // assert(m2 == n_c2 && res2 == r_c2);
-                                assert(m1 + m2 == n1 + n2);
-                                assert(res1 == v.0 && res2 == v.1);
-                            }
-                        // }
-                    }
-                }
-            }
-        }
+pub proof fn lemma_serialize_pair_deterministic<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+)
+    requires
+        prop_serialize_deterministic(serializer1),
+        prop_serialize_deterministic(serializer2),
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_deterministic(spec_serialize_pair(serializer1, serializer2)),
+{
+    reveal(prop_serialize_deterministic);
+    assert forall|s1, s2, v|
+        prop_serialize_deterministic_on(
+            spec_serialize_pair(serializer1, serializer2),
+            s1,
+            s2,
+            v,
+        ) by {
+        lemma_serialize_pair_deterministic_on(serializer1, serializer2, s1, s2, v);
     }
+}
 
-    pub proof fn lemma_parse_pair_serialize_inverse_on<T1, T2>(
-        parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
-        parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
-        serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
-        serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser1),
-            prop_parse_well_behaved(parser2),
-            prop_serialize_well_behaved(serializer1),
-            prop_parse_serialize_inverse(parser1, serializer1),
-            prop_parse_serialize_inverse(parser2, serializer2)
-        ensures
-            prop_parse_serialize_inverse_on(spec_parse_pair(parser1, parser2),
-                                    spec_serialize_pair(serializer1, serializer2), s)
-    {
-        if let Ok((s1, n1, x1)) = parser1(s) {
-            if let Ok((s2, n2, x2)) = parser2(s1) {
-                lemma_parse_well_behaved_on(parser1, s);
+pub proof fn lemma_parse_pair_strong_prefix<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_strong_prefix(parser2),
+    ensures
+        prop_parse_strong_prefix(spec_parse_pair(parser1, parser2)),
+{
+    reveal(prop_parse_strong_prefix);
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2) by {
+        lemma_parse_pair_strong_prefix_on(parser1, parser2, s1, s2);
+    }
+}
+
+pub proof fn lemma_parse_pair_well_behaved_on<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+    ensures
+        prop_parse_well_behaved_on(spec_parse_pair(parser1, parser2), s),
+{
+    if let Ok((s1, n1, _)) = parser1(s) {
+        assert(s1.data == s.data && s1.start == s.start + n1 && 0 <= s.start <= s1.start
+            <= s.data.len()) by {
+            lemma_parse_well_behaved_on(parser1, s);
+        }
+        if let Ok((s2, n2, _)) = parser2(s1) {
+            assert(s2.data == s1.data && s2.start == s1.start + n2 && 0 <= s1.start <= s2.start
+                <= s1.data.len()) by {
                 lemma_parse_well_behaved_on(parser2, s1);
-                lemma_parse_serialize_inverse_on(parser1, serializer1, s);
-                lemma_serialize_well_behaved_on(serializer1, s, x1);
-                if let Ok((s3, m1)) = serializer1(s, x1) {
-                    assert(m1 == n1 && s3.data == s.data);
-                    lemma_parse_serialize_inverse_on(parser2, serializer2, s1);
-                    if let Ok((s4, m2)) = serializer2(s3, x2) {
-                        assert(m1 + m2 == n1 + n2);
-                        assert(s4.data == s.data);
+            }
+            if let Ok((sout, n, _)) = spec_parse_pair(parser1, parser2)(s) {
+                assert(n == n1 + n2);
+            }
+        }
+    }
+}
+
+pub proof fn lemma_serialize_pair_well_behaved_on<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s: SpecStream,
+    v: (T1, T2),
+)
+    requires
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_well_behaved_on(spec_serialize_pair(serializer1, serializer2), s, v),
+{
+    lemma_serialize_well_behaved_on(serializer1, s, v.0);
+    if let Ok((s1, n1)) = serializer1(s, v.0) {
+        assert(s1.data.len() == s.data.len() && 0 <= s.start <= s1.start <= s.data.len() && s1.start
+            == s.start + n1 && s1.data.subrange(0, s.start) == s.data.subrange(0, s.start)
+            && s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(
+            s.start + n1,
+            s.data.len() as int,
+        ));
+        lemma_serialize_well_behaved_on(serializer2, s1, v.1);
+        if let Ok((s2, n2)) = serializer2(s1, v.1) {
+            assert(s2.data.len() == s1.data.len() && 0 <= s1.start <= s2.start <= s1.data.len()
+                && s2.start == s1.start + n2 && s2.data.subrange(0, s1.start) == s1.data.subrange(
+                0,
+                s1.start,
+            ) && s2.data.subrange(s1.start + n2, s1.data.len() as int) == s1.data.subrange(
+                s1.start + n2,
+                s1.data.len() as int,
+            ));
+            if let Ok((sout, n)) = spec_serialize_pair(serializer1, serializer2)(s, v) {
+                // assert(n == n1 + n2);
+                // assert(s2 == sout);
+                assert(sout.data.len() == s.data.len());
+                assert(0 <= s.start <= sout.start <= s.data.len());
+                assert(sout.start == s.start + n);
+                assert(sout.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
+                    assert(s2.data.subrange(0, s1.start).subrange(0, s.start) =~= s2.data.subrange(
+                        0,
+                        s.start,
+                    ));
+                    assert(s1.data.subrange(0, s1.start).subrange(0, s.start) =~= s1.data.subrange(
+                        0,
+                        s.start,
+                    ));
+                }
+                assert(sout.data.subrange(s.start + n, s.data.len() as int) == s.data.subrange(
+                    s.start + n,
+                    s.data.len() as int,
+                )) by {
+                    assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                        n2 as int,
+                        s.data.len() - s.start - n1,
+                    ) =~= s1.data.subrange(s.start + n, s.data.len() as int));
+                    assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                        n2 as int,
+                        s.data.len() - s.start - n1,
+                    ) =~= s.data.subrange(s.start + n, s.data.len() as int));
+                }
+            }
+        }
+    }
+}
+
+pub proof fn lemma_serialize_pair_deterministic_on<T1, T2>(
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (T1, T2),
+)
+    requires
+        prop_serialize_deterministic(serializer1),
+        prop_serialize_deterministic(serializer2),
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+    ensures
+        prop_serialize_deterministic_on(spec_serialize_pair(serializer1, serializer2), s1, s2, v),
+{
+    lemma_serialize_deterministic_on(serializer1, s1, s2, v.0);
+    lemma_serialize_well_behaved_on(serializer1, s1, v.0);
+    lemma_serialize_well_behaved_on(serializer1, s2, v.0);
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (serializer1(s1, v.0), serializer1(s2, v.0)) {
+        lemma_serialize_deterministic_on(serializer2, sout1, sout2, v.1);
+        lemma_serialize_well_behaved_on(serializer2, sout1, v.1);
+        lemma_serialize_well_behaved_on(serializer2, sout2, v.1);
+        if let (Ok((sout3, n3)), Ok((sout4, n4))) = (
+            serializer2(sout1, v.1),
+            serializer2(sout2, v.1),
+        ) {
+            assert(n1 + n3 == n2 + n4);
+            assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout4.data.subrange(
+                s2.start,
+                s2.start + n2 + n4,
+            )) by {
+                assert(sout1.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1)
+                    =~= sout1.data.subrange(s1.start, s1.start + n1));
+                assert(sout2.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2)
+                    =~= sout2.data.subrange(s2.start, s2.start + n2));
+                assert(sout3.data.subrange(0, s1.start + n1).subrange(s1.start, s1.start + n1)
+                    =~= sout3.data.subrange(s1.start, s1.start + n1));
+                assert(sout4.data.subrange(0, s2.start + n2).subrange(s2.start, s2.start + n2)
+                    =~= sout4.data.subrange(s2.start, s2.start + n2));
+
+                assert(sout3.data.subrange(s1.start, s1.start + n1) =~= sout4.data.subrange(
+                    s2.start,
+                    s2.start + n2,
+                ));
+                assert(sout3.data.subrange(s1.start + n1, s1.start + n1 + n3)
+                    == sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
+
+                assert(sout3.data.subrange(s1.start, s1.start + n1 + n3) =~= sout3.data.subrange(
+                    s1.start,
+                    s1.start + n1,
+                ) + sout3.data.subrange(s1.start + n1, s1.start + n1 + n3));
+                assert(sout4.data.subrange(s2.start, s2.start + n2 + n4) =~= sout4.data.subrange(
+                    s2.start,
+                    s2.start + n2,
+                ) + sout4.data.subrange(s2.start + n2, s2.start + n2 + n4));
+            }
+        }
+    }
+}
+
+pub proof fn lemma_parse_pair_strong_prefix_on<R1, R2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<R1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
+    s1: SpecStream,
+    s2: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_strong_prefix(parser2),
+    ensures
+        prop_parse_strong_prefix_on(spec_parse_pair(parser1, parser2), s1, s2),
+{
+    if let Ok((sout1, n, x1)) = spec_parse_pair(parser1, parser2)(s1) {
+        if 0 <= s1.start <= s1.start + n <= s1.data.len() <= usize::MAX && 0 <= s2.start <= s2.start
+            + n <= s2.data.len() <= usize::MAX && s1.data.subrange(s1.start, s1.start + n)
+            == s2.data.subrange(s2.start, s2.start + n) {
+            // assert(parser1(s1).is_ok());
+            if let Ok((p1s1, n1, p1x1)) = parser1(s1) {
+                // assert(parser2(p1s1).is_ok());
+                if let Ok((p2s1, n2, p2x1)) = parser2(p1s1) {
+                    assert(s1.data.subrange(s1.start, s1.start + n1) == s2.data.subrange(
+                        s2.start,
+                        s2.start + n1,
+                    )) by {
+                        assert(s1.data.subrange(s1.start, s1.start + n).subrange(0, n1 as int)
+                            =~= s1.data.subrange(s1.start, s1.start + n1));
+                        assert(s2.data.subrange(s2.start, s2.start + n).subrange(0, n1 as int)
+                            =~= s2.data.subrange(s2.start, s2.start + n1));
+                    }
+                    lemma_parse_strong_prefix_on(parser1, s1, s2);
+                    // assert(parser1(s2).is_ok());
+                    if let Ok((p1s2, m1, p1x2)) = parser1(s2) {
+                        lemma_parse_well_behaved_on(parser1, s1);
+                        lemma_parse_well_behaved_on(parser1, s2);
+                        // assert(p1s1.data == s1.data);
+                        // assert(p1s2.data == s2.data);
+                        // assert(p1s1.start == s1.start + n1);
+                        // assert(p1s2.start == s2.start + n1);
+                        // assert(n == n1 + n2);
+                        assert(s1.data.subrange(s1.start + n1, s1.start + n1 + n2)
+                            == s2.data.subrange(s2.start + n1, s2.start + n1 + n2)) by {
+                            assert(s1.data.subrange(s1.start, s1.start + n).subrange(
+                                n1 as int,
+                                n as int,
+                            ) =~= s1.data.subrange(s1.start + n1, s1.start + n1 + n2));
+                            assert(s2.data.subrange(s2.start, s2.start + n).subrange(
+                                n1 as int,
+                                n as int,
+                            ) =~= s2.data.subrange(s2.start + n1, s2.start + n1 + n2));
+                        }
+                        assert(p1s1.data.subrange(p1s1.start, p1s1.start + n2)
+                            == p1s2.data.subrange(p1s2.start, p1s2.start + n2));
+                        lemma_parse_strong_prefix_on(parser2, p1s1, p1s2);
+                        // assert(parser2(p1s2).is_ok());
+                        if let Ok((p2s2, m2, p2x2)) = parser2(p1s2) {
+                            if let Ok((sout2, m, x2)) = spec_parse_pair(parser1, parser2)(s2) {
+                                assert(m == n && x2 == x1);
+                            }
+                        }
                     }
                 }
             }
@@ -2597,153 +2705,303 @@ verus! {
     }
 }
 
+pub proof fn lemma_parse_pair_correct_on<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s: SpecStream,
+    v: (T1, T2),
+)
+    requires
+        s.data.len() <= usize::MAX,
+        prop_serialize_well_behaved(serializer1),
+        prop_serialize_well_behaved(serializer2),
+        prop_parse_well_behaved(parser1),
+        prop_parse_strong_prefix(parser1),
+        prop_parse_correct(parser1, serializer1),
+        prop_parse_correct(parser2, serializer2),
+    ensures
+        prop_parse_correct_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+            v,
+        ),
+{
+    if let Ok((s1, n1)) = serializer1(s, v.0) {
+        if let Ok((s2, n2)) = serializer2(s1, v.1) {
+            lemma_serialize_well_behaved_on(serializer1, s, v.0);
+            lemma_serialize_well_behaved_on(serializer2, s1, v.1);
+            lemma_parse_correct_on(parser1, serializer1, s, v.0);
+            if let Ok((s_c1, n_c1, r_c1)) = parser1(SpecStream { start: s.start, ..s1 }) {
+                assert(n1 == n_c1 && r_c1 == v.0);
+                assert(s1.data.subrange(s.start, s.start + n_c1) == s2.data.subrange(
+                    s.start,
+                    s.start + n_c1,
+                )) by {
+                    assert(s1.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1)
+                        =~= s1.data.subrange(s.start, s.start + n1));
+                    assert(s2.data.subrange(0, s.start + n1).subrange(s.start, s.start + n1)
+                        =~= s2.data.subrange(s.start, s.start + n1));
+                }
+                lemma_parse_strong_prefix_on(
+                    parser1,
+                    SpecStream { start: s.start, ..s1 },
+                    SpecStream { start: s.start, ..s2 },
+                );
+                if let Ok((s3, m1, res1)) = parser1(SpecStream { start: s.start, ..s2 }) {
+                    assert(m1 == n_c1 && res1 == r_c1);
+                    assert(m1 == n1 && res1 == v.0);  // crucial fact 1
+                    lemma_parse_well_behaved_on(parser1, SpecStream { start: s.start, ..s2 });
+                    assert(s3.data == s2.data && s3.start == s.start + m1);  // crucial fact 2 (s3 == SpecStream {start: s1.start, ..s2})
+                    lemma_parse_correct_on(parser2, serializer2, s1, v.1);
+                    // if let Ok((s_c2, n_c2, r_c2)) = parser2(SpecStream {start: s1.start, ..s2}) {
+                    // assert(n2 == n_c2 && r_c2 == v.1);
+                    if let Ok((s4, m2, res2)) = parser2(s3) {
+                        // assert(m2 == n_c2 && res2 == r_c2);
+                        assert(m1 + m2 == n1 + n2);
+                        assert(res1 == v.0 && res2 == v.1);
+                    }
+                    // }
+
+                }
+            }
+        }
+    }
+}
+
+pub proof fn lemma_parse_pair_serialize_inverse_on<T1, T2>(
+    parser1: spec_fn(SpecStream) -> SpecParseResult<T1>,
+    parser2: spec_fn(SpecStream) -> SpecParseResult<T2>,
+    serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
+    serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser1),
+        prop_parse_well_behaved(parser2),
+        prop_serialize_well_behaved(serializer1),
+        prop_parse_serialize_inverse(parser1, serializer1),
+        prop_parse_serialize_inverse(parser2, serializer2),
+    ensures
+        prop_parse_serialize_inverse_on(
+            spec_parse_pair(parser1, parser2),
+            spec_serialize_pair(serializer1, serializer2),
+            s,
+        ),
+{
+    if let Ok((s1, n1, x1)) = parser1(s) {
+        if let Ok((s2, n2, x2)) = parser2(s1) {
+            lemma_parse_well_behaved_on(parser1, s);
+            lemma_parse_well_behaved_on(parser2, s1);
+            lemma_parse_serialize_inverse_on(parser1, serializer1, s);
+            lemma_serialize_well_behaved_on(serializer1, s, x1);
+            if let Ok((s3, m1)) = serializer1(s, x1) {
+                assert(m1 == n1 && s3.data == s.data);
+                lemma_parse_serialize_inverse_on(parser2, serializer2, s1);
+                if let Ok((s4, m2)) = serializer2(s3, x2) {
+                    assert(m1 + m2 == n1 + n2);
+                    assert(s4.data == s.data);
+                }
+            }
+        }
+    }
+}
+
+} // verus!
 verus! {
 
-    pub open spec fn spec_parse_repeat_n_rec<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat,
-        s: SpecStream) -> SpecParseResult<Seq<R>>
-        decreases n
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.len() {
-            Err(ParseError::Eof)
-        } else if n == 0 {
-            Ok((s, 0, seq![]))
-        } else {
-            match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
-                Ok((s, k, rs)) => match parser(s) {
-                    Ok((s, m, r)) => {
-                        if m + k > usize::MAX {
-                            Err(ParseError::IntegerOverflow)
-                        } else {
-                            Ok((s, m + k, rs.push(r))) // repeat_n(n) = repeat_n(n - 1).push(parse()) = repeat_n(n - 2).push(parse()).push(parse()) = ... = repeat_n(0).push(parse()).push(parse()).push(parse()) = seq![parse(), parse(), ..., parse()]
-                        }
-                    }
-                    Err(e) => Err(e),
-                },
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    pub open spec fn spec_parse_repeat_n<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat) ->
-        spec_fn(SpecStream) -> SpecParseResult<Seq<R>>
-    {
-        move |s| spec_parse_repeat_n_rec(parser, n, s)
-    }
-
-    pub open spec fn spec_serialize_repeat_n_rec<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream,
-        vs: Seq<T>) -> SpecSerializeResult
-        recommends
-            vs.len() == n // otherwise cannot prove correctness
-        decreases n
-    {
-        if vs.len() != n {
-            Err(SerializeError::RepeatNMismatch)
-        } else if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start > s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if n == 0 {
-            Ok((s, 0))
-        } else {
-            match spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1)) {
-                Ok((s, k)) => match serializer(s, vs[vs.len() as int - 1]) {
-                    Ok((s, m)) => {
-                        if m + k > usize::MAX {
-                            Err(SerializeError::IntegerOverflow)
-                        } else {
-                            Ok((s, m + k))
-                        }
-                    }
-                    Err(e) => Err(e),
-                },
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    pub open spec fn spec_serialize_repeat_n<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat) ->
-        spec_fn(SpecStream, Seq<T>) -> SpecSerializeResult
-    {
-        move |s, vs| spec_serialize_repeat_n_rec(serializer, n, s, vs)
-    }
-
-    pub exec fn parse_repeat_n<'a, P, R>(
-        exec_parser: P,
-        Ghost(spec_parser): Ghost<spec_fn(SpecStream) -> SpecParseResult<R::V>>,
-        n: usize, s: Stream<'a>) -> (res: ParseResult<'a, Vec<R>>)
-        where
-            P: Fn(Stream<'a>) -> ParseResult<'a, R>,
-            R: DView,
-        requires
-            prop_parse_exec_spec_equiv(exec_parser, spec_parser),
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat))
-    {
-        proof { reveal(prop_parse_exec_spec_equiv); }
-
-        if s.start < 0 {
-            return Err(ParseError::NegativeIndex);
-        } else if s.start > s.data.length() {
-            return Err(ParseError::Eof);
-        }
-
-        let (mut xs, mut mut_s, mut i, mut m): (Vec<R>, Stream, usize, usize) = (vec_new(), s, 0, 0);
-        let ghost res = Ok((mut_s, 0, xs));
-
-        while i < n
-            invariant
-                0 <= i <= n,
-                0 <= m <= usize::MAX,
-                forall |s| #![auto] exec_parser.requires((s,)),
-                res == Ok::<(Stream, usize, Vec<R>), ParseError>((mut_s, m, xs)),
-                prop_parse_exec_spec_equiv(exec_parser, spec_parser),
-                prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, i as nat)),
-        {
-            i = i + 1;
-            let res1 = exec_parser(mut_s);
-            proof { lemma_parse_exec_spec_equiv_on(exec_parser, spec_parser, mut_s, res1); }
-            match res1 {
-                Ok((s1, m1, r1)) => {
-                    if m > usize::MAX - m1 {
-                        proof { res = Err(ParseError::IntegerOverflow); }
-                        proof { lemma_parse_repeat_n_rec_error_unrecoverable_on(spec_parser, i as nat, n as nat, s.dview()); }
-                        assert(prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat)));
-                        return Err(ParseError::IntegerOverflow);
+pub open spec fn spec_parse_repeat_n_rec<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+    s: SpecStream,
+) -> SpecParseResult<Seq<R>>
+    decreases n,
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.len() {
+        Err(ParseError::Eof)
+    } else if n == 0 {
+        Ok((s, 0, seq![]))
+    } else {
+        match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
+            Ok((s, k, rs)) => match parser(s) {
+                Ok((s, m, r)) => {
+                    if m + k > usize::MAX {
+                        Err(ParseError::IntegerOverflow)
                     } else {
-                        vec_push(&mut xs, r1);
-                        mut_s = s1;
-                        m = m + m1;
-                        proof { res = Ok((mut_s, m, xs)); }
-                        assert(prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, i as nat)));
-                    }
-                }
-                Err(e) => {
-                    proof { res = Err(e); }
-                    proof { lemma_parse_repeat_n_rec_error_unrecoverable_on(spec_parser, i as nat, n as nat, s.dview()); }
-                    assert(prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat)));
-                    return Err(e);
-                }
-            }
-        }
+                        Ok(
+                            (s, m + k, rs.push(r)),
+                        )  // repeat_n(n) = repeat_n(n - 1).push(parse()) = repeat_n(n - 2).push(parse()).push(parse()) = ... = repeat_n(0).push(parse()).push(parse()).push(parse()) = seq![parse(), parse(), ..., parse()]
 
-        Ok((mut_s, m, xs))
+                    }
+                },
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub open spec fn spec_parse_repeat_n<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+) -> spec_fn(SpecStream) -> SpecParseResult<Seq<R>> {
+    move |s| spec_parse_repeat_n_rec(parser, n, s)
+}
+
+pub open spec fn spec_serialize_repeat_n_rec<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+    vs: Seq<T>,
+) -> SpecSerializeResult
+    recommends
+        vs.len() == n  // otherwise cannot prove correctness
+        ,
+    decreases n,
+{
+    if vs.len() != n {
+        Err(SerializeError::RepeatNMismatch)
+    } else if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start > s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if n == 0 {
+        Ok((s, 0))
+    } else {
+        match spec_serialize_repeat_n_rec(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        ) {
+            Ok((s, k)) => match serializer(s, vs[vs.len() as int - 1]) {
+                Ok((s, m)) => {
+                    if m + k > usize::MAX {
+                        Err(SerializeError::IntegerOverflow)
+                    } else {
+                        Ok((s, m + k))
+                    }
+                },
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+pub open spec fn spec_serialize_repeat_n<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+) -> spec_fn(SpecStream, Seq<T>) -> SpecSerializeResult {
+    move |s, vs| spec_serialize_repeat_n_rec(serializer, n, s, vs)
+}
+
+pub exec fn parse_repeat_n<'a, P, R>(
+    exec_parser: P,
+    Ghost(spec_parser): Ghost<spec_fn(SpecStream) -> SpecParseResult<R::V>>,
+    n: usize,
+    s: Stream<'a>,
+) -> (res: ParseResult<'a, Vec<R>>) where P: Fn(Stream<'a>) -> ParseResult<'a, R>, R: DView
+    requires
+        prop_parse_exec_spec_equiv(exec_parser, spec_parser),
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, n as nat)),
+{
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
     }
 
-    proof fn lemma_parse_repeat_n_rec_error_unrecoverable_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n1: nat, n2: nat, s: SpecStream)
-        ensures
+    if s.start < 0 {
+        return Err(ParseError::NegativeIndex);
+    } else if s.start > s.data.length() {
+        return Err(ParseError::Eof);
+    }
+    let (mut xs, mut mut_s, mut i, mut m): (Vec<R>, Stream, usize, usize) = (vec_new(), s, 0, 0);
+    let ghost res = Ok((mut_s, 0, xs));
+
+    while i < n
+        invariant
+            0 <= i <= n,
+            0 <= m <= usize::MAX,
+            forall|s| #![auto] exec_parser.requires((s,)),
+            res == Ok::<(Stream, usize, Vec<R>), ParseError>((mut_s, m, xs)),
+            prop_parse_exec_spec_equiv(exec_parser, spec_parser),
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_repeat_n(spec_parser, i as nat)),
+    {
+        i = i + 1;
+        let res1 = exec_parser(mut_s);
+        proof {
+            lemma_parse_exec_spec_equiv_on(exec_parser, spec_parser, mut_s, res1);
+        }
+        match res1 {
+            Ok((s1, m1, r1)) => {
+                if m > usize::MAX - m1 {
+                    proof {
+                        res = Err(ParseError::IntegerOverflow);
+                    }
+                    proof {
+                        lemma_parse_repeat_n_rec_error_unrecoverable_on(
+                            spec_parser,
+                            i as nat,
+                            n as nat,
+                            s.dview(),
+                        );
+                    }
+                    assert(prop_parse_exec_spec_equiv_on(
+                        s,
+                        res,
+                        spec_parse_repeat_n(spec_parser, n as nat),
+                    ));
+                    return Err(ParseError::IntegerOverflow);
+                } else {
+                    vec_push(&mut xs, r1);
+                    mut_s = s1;
+                    m = m + m1;
+                    proof {
+                        res = Ok((mut_s, m, xs));
+                    }
+                    assert(prop_parse_exec_spec_equiv_on(
+                        s,
+                        res,
+                        spec_parse_repeat_n(spec_parser, i as nat),
+                    ));
+                }
+            },
+            Err(e) => {
+                proof {
+                    res = Err(e);
+                }
+                proof {
+                    lemma_parse_repeat_n_rec_error_unrecoverable_on(
+                        spec_parser,
+                        i as nat,
+                        n as nat,
+                        s.dview(),
+                    );
+                }
+                assert(prop_parse_exec_spec_equiv_on(
+                    s,
+                    res,
+                    spec_parse_repeat_n(spec_parser, n as nat),
+                ));
+                return Err(e);
+            },
+        }
+    }
+    Ok((mut_s, m, xs))
+}
+
+proof fn lemma_parse_repeat_n_rec_error_unrecoverable_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n1: nat,
+    n2: nat,
+    s: SpecStream,
+)
+    ensures
         n2 >= n1 ==> {
             if let Err(e1) = spec_parse_repeat_n_rec(parser, n1, s) {
                 if let Err(e2) = spec_parse_repeat_n_rec(parser, n2, s) {
@@ -2754,484 +3012,687 @@ verus! {
             } else {
                 true
             }
-        }
-        decreases n2
-    {
-        if n2 == n1 {}
-        else if n2 > n1 {
-            lemma_parse_repeat_n_rec_error_unrecoverable_on(parser, n1, (n2 - 1) as nat, s);
-        }
+        },
+    decreases n2,
+{
+    if n2 == n1 {
+    } else if n2 > n1 {
+        lemma_parse_repeat_n_rec_error_unrecoverable_on(parser, n1, (n2 - 1) as nat, s);
     }
+}
 
-    proof fn lemma_serialize_repeat_n_rec_error_unrecoverable_on<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n1: nat, n2: nat, s: SpecStream, vs1: Seq<T>, vs2: Seq<T>)
-        requires
-            n2 >= n1,
-            vs1.len() == n1,
-            vs2.len() == n2,
-            vs1 == vs2.subrange(0, n1 as int),
-        ensures
-            if let Err(e1) = spec_serialize_repeat_n_rec(serializer, n1, s, vs1) {
-                if let Err(e2) = spec_serialize_repeat_n_rec(serializer, n2, s, vs2) {
-                    e1 == e2
-                } else {
-                    false
-                }
+proof fn lemma_serialize_repeat_n_rec_error_unrecoverable_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n1: nat,
+    n2: nat,
+    s: SpecStream,
+    vs1: Seq<T>,
+    vs2: Seq<T>,
+)
+    requires
+        n2 >= n1,
+        vs1.len() == n1,
+        vs2.len() == n2,
+        vs1 == vs2.subrange(0, n1 as int),
+    ensures
+        if let Err(e1) = spec_serialize_repeat_n_rec(serializer, n1, s, vs1) {
+            if let Err(e2) = spec_serialize_repeat_n_rec(serializer, n2, s, vs2) {
+                e1 == e2
             } else {
-                true
+                false
             }
-        decreases n2, vs2.len()
-    {
-        if n2 == n1 {
-            assert(vs1 =~= vs2);
-        }
-        else if n2 > n1 {
-            assert(vs1 =~= vs2.subrange(0, vs2.len() as int - 1).subrange(0, n1 as int));
-            lemma_serialize_repeat_n_rec_error_unrecoverable_on(serializer, n1, (n2 - 1) as nat, s, vs1, vs2.subrange(0, vs2.len() as int - 1));
-        }
+        } else {
+            true
+        },
+    decreases n2, vs2.len(),
+{
+    if n2 == n1 {
+        assert(vs1 =~= vs2);
+    } else if n2 > n1 {
+        assert(vs1 =~= vs2.subrange(0, vs2.len() as int - 1).subrange(0, n1 as int));
+        lemma_serialize_repeat_n_rec_error_unrecoverable_on(
+            serializer,
+            n1,
+            (n2 - 1) as nat,
+            s,
+            vs1,
+            vs2.subrange(0, vs2.len() as int - 1),
+        );
     }
+}
 
-    pub proof fn spec_parse_repeat_n_rec_step<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat, s: SpecStream)
-        ensures
-            s.start < 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(ParseError::NegativeIndex),
-            s.start > s.data.len() ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(ParseError::Eof),
-            0 <= s.start <= s.data.len() ==> {
-                &&& n == 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Ok::<(SpecStream, nat, Seq<R>), ParseError>((s, 0, seq![]))
-                &&& n > 0 ==> match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
-                    Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(e),
-                    Ok((s0, m, rs)) => match parser(s0) {
-                        Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(e),
-                        Ok((s1, k, r)) => {
-                            if m + k > usize::MAX {
-                                spec_parse_repeat_n_rec(parser, n, s) == Err::<(SpecStream, nat, Seq<R>), ParseError>(ParseError::IntegerOverflow)
-                            } else {
-                                spec_parse_repeat_n_rec(parser, n, s) == Ok::<(SpecStream, nat, Seq<R>), ParseError>((s1, m + k, rs.push(r)))
-                            }
+pub proof fn spec_parse_repeat_n_rec_step<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+    s: SpecStream,
+)
+    ensures
+        s.start < 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<
+            (SpecStream, nat, Seq<R>),
+            ParseError,
+        >(ParseError::NegativeIndex),
+        s.start > s.data.len() ==> spec_parse_repeat_n_rec(parser, n, s) == Err::<
+            (SpecStream, nat, Seq<R>),
+            ParseError,
+        >(ParseError::Eof),
+        0 <= s.start <= s.data.len() ==> {
+            &&& n == 0 ==> spec_parse_repeat_n_rec(parser, n, s) == Ok::<
+                (SpecStream, nat, Seq<R>),
+                ParseError,
+            >((s, 0, seq![]))
+            &&& n > 0 ==> match spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
+                Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<
+                    (SpecStream, nat, Seq<R>),
+                    ParseError,
+                >(e),
+                Ok((s0, m, rs)) => match parser(s0) {
+                    Err(e) => spec_parse_repeat_n_rec(parser, n, s) == Err::<
+                        (SpecStream, nat, Seq<R>),
+                        ParseError,
+                    >(e),
+                    Ok((s1, k, r)) => {
+                        if m + k > usize::MAX {
+                            spec_parse_repeat_n_rec(parser, n, s) == Err::<
+                                (SpecStream, nat, Seq<R>),
+                                ParseError,
+                            >(ParseError::IntegerOverflow)
+                        } else {
+                            spec_parse_repeat_n_rec(parser, n, s) == Ok::<
+                                (SpecStream, nat, Seq<R>),
+                                ParseError,
+                            >((s1, m + k, rs.push(r)))
                         }
-                    }
-                }
+                    },
+                },
             }
-    {}
+        },
+{
+}
 
-    pub proof fn lemma_parse_repeat_n_correct<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_strong_prefix(parser),
-            prop_parse_correct(parser, serializer)
-        ensures
-            prop_parse_correct(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_parse_correct);
-        assert forall |s: SpecStream, vs: Seq<T>| s.data.len() <= usize::MAX ==> prop_parse_correct_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s, vs) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_repeat_n_correct_on(parser, serializer, n, s, vs);
-            }
+pub proof fn lemma_parse_repeat_n_correct<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_strong_prefix(parser),
+        prop_parse_correct(parser, serializer),
+    ensures
+        prop_parse_correct(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n)),
+{
+    reveal(prop_parse_correct);
+    assert forall|s: SpecStream, vs: Seq<T>|
+        s.data.len() <= usize::MAX ==> prop_parse_correct_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+            vs,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_repeat_n_correct_on(parser, serializer, n, s, vs);
         }
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_serialize_inverse<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_serialize_inverse(parser, serializer)
-        ensures
-            prop_parse_serialize_inverse(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_parse_serialize_inverse);
-        assert forall |s: SpecStream| prop_parse_serialize_inverse_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s) by {
-            lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, n, s);
-        }
+pub proof fn lemma_parse_repeat_n_serialize_inverse<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_serialize_inverse(parser, serializer),
+    ensures
+        prop_parse_serialize_inverse(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+        ),
+{
+    reveal(prop_parse_serialize_inverse);
+    assert forall|s: SpecStream|
+        prop_parse_serialize_inverse_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+        ) by {
+        lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, n, s);
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_well_behaved<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser)
-        ensures
-            prop_parse_well_behaved(spec_parse_repeat_n(parser, n)),
-            forall |s| {
+pub proof fn lemma_parse_repeat_n_well_behaved<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+    ensures
+        prop_parse_well_behaved(spec_parse_repeat_n(parser, n)),
+        forall|s|
+            {
                 if let Ok((_, _, res)) = #[trigger] spec_parse_repeat_n(parser, n)(s) {
                     res.len() == n
                 } else {
                     true
                 }
-            }
-        decreases n
-    {
-        reveal(prop_parse_well_behaved);
-        assert forall |s:SpecStream| prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s) by {
-            lemma_parse_repeat_n_well_behaved_on(parser, n, s);
-        }
-        assert forall |s:SpecStream| {
+            },
+    decreases n,
+{
+    reveal(prop_parse_well_behaved);
+    assert forall|s: SpecStream| prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s) by {
+        lemma_parse_repeat_n_well_behaved_on(parser, n, s);
+    }
+    assert forall|s: SpecStream|
+        {
             if let Ok((_, _, res)) = #[trigger] spec_parse_repeat_n(parser, n)(s) {
                 res.len() == n
             } else {
                 true
             }
         } by {
-            lemma_parse_repeat_n_well_behaved_on(parser, n, s);
+        lemma_parse_repeat_n_well_behaved_on(parser, n, s);
+    }
+}
+
+pub proof fn lemma_serialize_repeat_n_well_behaved<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+    ensures
+        prop_serialize_well_behaved(spec_serialize_repeat_n(serializer, n)),
+{
+    reveal(prop_serialize_well_behaved);
+    assert forall|s: SpecStream, vs: Seq<T>|
+        prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs) by {
+        lemma_serialize_repeat_n_well_behaved_on(serializer, n, s, vs);
+    }
+}
+
+pub proof fn lemma_serialize_repeat_n_deterministic<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n)),
+{
+    reveal(prop_serialize_deterministic);
+    assert forall|s1, s2, v|
+        prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, v) by {
+        lemma_serialize_repeat_n_deterministic_on(serializer, n, s1, s2, v);
+    }
+}
+
+pub proof fn lemma_parse_repeat_n_nonmalleable<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+)
+    requires
+        prop_parse_serialize_inverse(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+        ),
+        prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n)),
+    ensures
+        prop_parse_nonmalleable(spec_parse_repeat_n(parser, n)),
+{
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        spec_parse_repeat_n(parser, n),
+        spec_serialize_repeat_n(serializer, n),
+    );
+}
+
+pub proof fn lemma_parse_repeat_n_strong_prefix<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_parse_strong_prefix(parser),
+    ensures
+        prop_parse_strong_prefix(spec_parse_repeat_n(parser, n)),
+{
+    reveal(prop_parse_strong_prefix);
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2) by {
+        lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, n);
+    }
+}
+
+pub proof fn lemma_parse_repeat_n_correct_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+    vs: Seq<T>,
+)
+    requires
+        s.data.len() <= usize::MAX,
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_strong_prefix(parser),
+        prop_parse_correct(parser, serializer),
+    ensures
+        prop_parse_correct_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+            vs,
+        ),
+    decreases n, vs.len(),
+{
+    if vs.len() != n {
+    } else if s.start < 0 {
+    } else if s.start > s.data.len() {
+    } else if n == 0 {
+        assert(vs =~= seq![]);
+    } else {
+        // induction
+        lemma_parse_repeat_n_correct_on(
+            parser,
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        );
+        lemma_serialize_repeat_n_well_behaved_on(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        );
+        if let Ok((s0, n0)) = spec_serialize_repeat_n_rec(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        ) {
+            lemma_serialize_well_behaved_on(serializer, s0, vs[vs.len() as int - 1]);
+            if let Ok((s1, n1)) = serializer(s0, vs[vs.len() as int - 1]) {
+                assert(s0.data.subrange(s.start, s.start + n0) == s1.data.subrange(
+                    s.start,
+                    s.start + n0,
+                )) by {
+                    assert(s0.data.subrange(0, s0.start).subrange(s.start, s.start + n0)
+                        =~= s0.data.subrange(s.start, s.start + n0));
+                    assert(s1.data.subrange(0, s0.start).subrange(s.start, s.start + n0)
+                        =~= s1.data.subrange(s.start, s.start + n0));
+                }
+                lemma_parse_repeat_n_strong_prefix(parser, (n - 1) as nat);
+                lemma_parse_strong_prefix_on(
+                    spec_parse_repeat_n(parser, (n - 1) as nat),
+                    SpecStream { start: s.start, ..s0 },
+                    SpecStream { start: s.start, ..s1 },
+                );
+                lemma_parse_correct_on(parser, serializer, s0, vs[vs.len() as int - 1]);
+                lemma_parse_repeat_n_well_behaved_on(
+                    parser,
+                    (n - 1) as nat,
+                    SpecStream { start: s.start, ..s1 },
+                );
+                if let Ok((s2, n2, x0)) = spec_parse_repeat_n_rec(
+                    parser,
+                    (n - 1) as nat,
+                    SpecStream { start: s.start, ..s1 },
+                ) {
+                    if let Ok((s3, n3, x1)) = parser(s2) {
+                        assert(n3 == n1 && x1 == vs[vs.len() as int - 1]);
+                        assert(n2 + n3 == n0 + n1);
+                        assert(x0 == vs.subrange(0, vs.len() as int - 1));
+                        assert(x0.push(x1) =~= vs);
+                    }
+                }
+            }
         }
     }
+}
 
-    pub proof fn lemma_serialize_repeat_n_well_behaved<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_serialize_well_behaved(serializer),
-        ensures
-            prop_serialize_well_behaved(spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_serialize_well_behaved);
-        assert forall |s:SpecStream, vs: Seq<T>| prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs) by {
-            lemma_serialize_repeat_n_well_behaved_on(serializer, n, s, vs);
+pub proof fn lemma_parse_repeat_n_serialize_inverse_on<T>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<T>,
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_serialize_well_behaved(serializer),
+        prop_parse_serialize_inverse(parser, serializer),
+    ensures
+        prop_parse_serialize_inverse_on(
+            spec_parse_repeat_n(parser, n),
+            spec_serialize_repeat_n(serializer, n),
+            s,
+        ),
+    decreases n,
+{
+    if s.start < 0 {
+    } else if s.start > s.data.len() {
+    } else if n == 0 {
+    } else {
+        // induction
+        lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, (n - 1) as nat, s);
+        lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
+        if let Ok((s0, n0, x0)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
+            lemma_parse_well_behaved_on(parser, s0);
+            if let Ok((s1, n1, x1)) = parser(s0) {
+                assert(x0.push(x1).subrange(0, x0.push(x1).len() as int - 1) =~= x0);
+                lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, x0);
+                if let Ok((s2, n2)) = spec_serialize_repeat_n_rec(
+                    serializer,
+                    (n - 1) as nat,
+                    s,
+                    x0,
+                ) {
+                    lemma_serialize_well_behaved_on(serializer, s2, x1);
+                    lemma_parse_serialize_inverse_on(parser, serializer, s0);
+                    assert(s2 == s0);
+                    if let Ok((s3, n3)) = serializer(s2, x1) {
+                        assert(n0 + n1 == n2 + n3);
+                        assert(s3.data == s.data);
+                    }
+                }
+            }
         }
     }
+}
 
-    pub proof fn lemma_serialize_repeat_n_deterministic<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_serialize_well_behaved(serializer),
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n))
-    {
-        reveal(prop_serialize_deterministic);
-        assert forall |s1, s2, v| prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, v) by {
-            lemma_serialize_repeat_n_deterministic_on(serializer, n, s1, s2, v);
+pub proof fn lemma_parse_repeat_n_well_behaved_on<R>(
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+    s: SpecStream,
+)
+    requires
+        prop_parse_well_behaved(parser),
+    ensures
+        prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s) && if let Ok((_, _, res)) =
+            spec_parse_repeat_n(parser, n)(s) {
+            res.len() == n
+        } else {
+            true
+        },
+    decreases n,
+{
+    if n == 0 {
+    } else {
+        match spec_parse_repeat_n(parser, n)(s) {
+            Ok((sout, n_total, res)) => {
+                assert(sout.data == s.data && sout.start == s.start + n_total && 0 <= s.start
+                    <= sout.start <= s.data.len() && res.len() == n) by {
+                    if let Ok((s1, n1, res1)) = spec_parse_repeat_n(parser, (n - 1) as nat)(s) {
+                        assert(s1.data == s.data && s1.start == s.start + n1 && 0 <= s.start
+                            <= s1.start <= s.data.len() && res1.len() == n - 1) by {  // induction on n
+                            lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
+                        }
+                        if let Ok((s2, n2, res2)) = parser(s1) {
+                            assert(s2.data == s1.data && s2.start == s1.start + n2 && 0 <= s1.start
+                                <= s2.start <= s1.data.len()) by {
+                                lemma_parse_well_behaved_on(parser, s1);
+                            }
+                            assert(sout == s2 && n_total == n1 + n2 && res == res1.push(res2)
+                                && res.len() == n);
+                        }
+                    }
+                }
+            },
+            Err(_) => {},
         }
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_nonmalleable<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat)
-        requires
-            prop_parse_serialize_inverse(spec_parse_repeat_n(parser, n),
-                                        spec_serialize_repeat_n(serializer, n)),
-            prop_serialize_deterministic(spec_serialize_repeat_n(serializer, n)),
-        ensures
-            prop_parse_nonmalleable(spec_parse_repeat_n(parser, n))
-    {
-        lemma_parse_serialize_inverse_implies_nonmalleable(spec_parse_repeat_n(parser, n),
-                                        spec_serialize_repeat_n(serializer, n));
-    }
+pub proof fn lemma_serialize_repeat_n_well_behaved_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s: SpecStream,
+    vs: Seq<T>,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+    ensures
+        prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs),
+    decreases n,
+{
+    if vs.len() != n {
+    } else if s.start < 0 {
+    } else if s.start > s.data.len() {
+    } else if n == 0 {
+    } else {
+        lemma_serialize_repeat_n_well_behaved_on(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        );
+        match spec_serialize_repeat_n_rec(
+            serializer,
+            (n - 1) as nat,
+            s,
+            vs.subrange(0, vs.len() as int - 1),
+        ) {
+            Ok((s1, n1)) => {
+                assert(s.start + n1 == s1.start);
+                assert(s1.data.subrange(0, s.start) == s.data.subrange(0, s.start));
+                assert(s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(
+                    s.start + n1,
+                    s.data.len() as int,
+                ));
+                lemma_serialize_well_behaved_on(serializer, s1, vs[vs.len() as int - 1]);
+                match serializer(s1, vs[vs.len() as int - 1]) {
+                    Ok((s2, n2)) => {
+                        assert(s1.start + n2 == s2.start);
+                        assert(s2.data.subrange(0, s1.start) == s1.data.subrange(0, s1.start));
+                        assert(s2.data.subrange(s1.start + n2, s.data.len() as int)
+                            == s1.data.subrange(s1.start + n2, s.data.len() as int));
 
-    pub proof fn lemma_parse_repeat_n_strong_prefix<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_parse_strong_prefix(parser),
-        ensures
-            prop_parse_strong_prefix(spec_parse_repeat_n(parser, n))
-    {
-        reveal(prop_parse_strong_prefix);
-        assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2) by {
-            lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, n);
+                        assert(s.start + n1 + n2 == s2.start);
+                        assert(s2.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
+                            assert(s2.data.subrange(0, s1.start).subrange(0, s.start)
+                                =~= s2.data.subrange(0, s.start));
+                            assert(s1.data.subrange(0, s1.start).subrange(0, s.start)
+                                =~= s.data.subrange(0, s.start));
+                        }
+                        assert(s2.data.subrange(s.start + n1 + n2, s.data.len() as int)
+                            == s.data.subrange(s.start + n1 + n2, s.data.len() as int)) by {
+                            assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                                n2 as int,
+                                s.data.len() - s.start - n1,
+                            ) =~= s1.data.subrange(s.start + n1 + n2, s.data.len() as int));
+                            assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(
+                                n2 as int,
+                                s.data.len() - s.start - n1,
+                            ) =~= s.data.subrange(s.start + n1 + n2, s.data.len() as int));
+                        }
+                    },
+                    Err(e) => {},
+                }
+            },
+            Err(e) => {},
         }
     }
+}
 
-    pub proof fn lemma_parse_repeat_n_correct_on<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream,
-        vs: Seq<T>)
-        requires
-            s.data.len() <= usize::MAX,
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_strong_prefix(parser),
-            prop_parse_correct(parser, serializer)
-        ensures
-            prop_parse_correct_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s, vs)
-        decreases n, vs.len()
-    {
+pub proof fn lemma_serialize_repeat_n_deterministic_on<T>(
+    serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
+    n: nat,
+    s1: SpecStream,
+    s2: SpecStream,
+    vs: Seq<T>,
+)
+    requires
+        prop_serialize_well_behaved(serializer),
+        prop_serialize_deterministic(serializer),
+    ensures
+        prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, vs),
+    decreases n, vs.len(),
+{
+    if let (Ok((sn1, m1)), Ok((sn2, m2))) = (
+        spec_serialize_repeat_n(serializer, n)(s1, vs),
+        spec_serialize_repeat_n(serializer, n)(s2, vs),
+    ) {
         if vs.len() != n {
-        } else if s.start < 0 {
-        } else if s.start > s.data.len() {
-        } else if n == 0 {
-            assert(vs =~= seq![]);
-        } else {
-            // induction
-            lemma_parse_repeat_n_correct_on(parser, serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1));
-            lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1));
-            if let Ok((s0, n0)) = spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1)) {
-                lemma_serialize_well_behaved_on(serializer, s0, vs[vs.len() as int - 1]);
-                if let Ok((s1, n1)) = serializer(s0, vs[vs.len() as int - 1]) {
-                    assert(s0.data.subrange(s.start, s.start + n0) == s1.data.subrange(s.start, s.start + n0)) by {
-                        assert(s0.data.subrange(0, s0.start).subrange(s.start, s.start + n0) =~= s0.data.subrange(s.start, s.start + n0));
-                        assert(s1.data.subrange(0, s0.start).subrange(s.start, s.start + n0) =~= s1.data.subrange(s.start, s.start + n0));
-                    }
-                    lemma_parse_repeat_n_strong_prefix(parser, (n - 1) as nat);
-                    lemma_parse_strong_prefix_on(spec_parse_repeat_n(parser, (n - 1) as nat), SpecStream { start: s.start, ..s0 }, SpecStream { start: s.start, ..s1 });
-                    lemma_parse_correct_on(parser, serializer, s0, vs[vs.len() as int - 1]);
-                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, SpecStream { start: s.start, ..s1 });
-                    if let Ok((s2, n2, x0)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, SpecStream { start: s.start, ..s1 }) {
-                        if let Ok((s3, n3, x1)) = parser(s2) {
-                            assert(n3 == n1 && x1 == vs[vs.len() as int - 1]);
-                            assert(n2 + n3 == n0 + n1);
-                            assert(x0 == vs.subrange(0, vs.len() as int - 1));
-                            assert(x0.push(x1) =~= vs);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_repeat_n_serialize_inverse_on<T>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<T>,
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_serialize_well_behaved(serializer),
-            prop_parse_serialize_inverse(parser, serializer)
-        ensures
-            prop_parse_serialize_inverse_on(spec_parse_repeat_n(parser, n), spec_serialize_repeat_n(serializer, n), s)
-        decreases n
-    {
-        if s.start < 0 {
-        } else if s.start > s.data.len() {
+        } else if s1.start < 0 || s2.start < 0 {
+        } else if s1.start > s1.data.len() || s2.start > s2.data.len() {
         } else if n == 0 {
         } else {
-            // induction
-            lemma_parse_repeat_n_serialize_inverse_on(parser, serializer, (n - 1) as nat, s);
-            lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
-            if let Ok((s0, n0, x0)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s) {
-                lemma_parse_well_behaved_on(parser, s0);
-                if let Ok((s1, n1, x1)) = parser(s0) {
-                    assert(x0.push(x1).subrange(0, x0.push(x1).len() as int - 1) =~= x0);
-                    lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, x0);
-                    if let Ok((s2, n2)) = spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, x0) {
-                        lemma_serialize_well_behaved_on(serializer, s2, x1);
-                        lemma_parse_serialize_inverse_on(parser, serializer, s0);
-                        assert(s2 == s0);
-                        if let Ok((s3, n3)) = serializer(s2, x1) {
-                            assert(n0 + n1 == n2 + n3);
-                            assert(s3.data == s.data);
+            // induction on n
+            lemma_serialize_repeat_n_well_behaved_on(
+                serializer,
+                (n - 1) as nat,
+                s1,
+                vs.subrange(0, vs.len() as int - 1),
+            );
+            lemma_serialize_repeat_n_well_behaved_on(
+                serializer,
+                (n - 1) as nat,
+                s2,
+                vs.subrange(0, vs.len() as int - 1),
+            );
+            lemma_serialize_repeat_n_deterministic_on(
+                serializer,
+                (n - 1) as nat,
+                s1,
+                s2,
+                vs.subrange(0, vs.len() as int - 1),
+            );
+            if let (Ok((snn1, nn1)), Ok((snn2, nn2))) = (
+                spec_serialize_repeat_n_rec(
+                    serializer,
+                    (n - 1) as nat,
+                    s1,
+                    vs.subrange(0, vs.len() as int - 1),
+                ),
+                spec_serialize_repeat_n_rec(
+                    serializer,
+                    (n - 1) as nat,
+                    s2,
+                    vs.subrange(0, vs.len() as int - 1),
+                ),
+            ) {
+                assert(nn1 == nn2);
+                assert(snn1.data.subrange(s1.start, s1.start + nn1) == snn2.data.subrange(
+                    s2.start,
+                    s2.start + nn2,
+                ));
+
+                lemma_serialize_well_behaved_on(serializer, snn1, vs[vs.len() as int - 1]);
+                lemma_serialize_well_behaved_on(serializer, snn2, vs[vs.len() as int - 1]);
+                lemma_serialize_deterministic_on(serializer, snn1, snn2, vs[vs.len() as int - 1]);
+                if let Ok((sout1, n1)) = serializer(snn1, vs[vs.len() as int - 1]) {
+                    if let Ok((sout2, n2)) = serializer(snn2, vs[vs.len() as int - 1]) {
+                        assert(n1 + nn1 == n2 + nn2);
+                        assert(sout1.data.subrange(snn1.start, snn1.start + n1)
+                            == sout2.data.subrange(snn2.start, snn2.start + n2));
+
+                        assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1)
+                            == sout2.data.subrange(s2.start, s2.start + n2 + nn2)) by {
+                            assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1)
+                                =~= sout1.data.subrange(s1.start, s1.start + nn1)
+                                + sout1.data.subrange(s1.start + nn1, s1.start + n1 + nn1));
+                            assert(sout2.data.subrange(s2.start, s2.start + n2 + nn2)
+                                =~= sout2.data.subrange(s2.start, s2.start + nn2)
+                                + sout2.data.subrange(s2.start + nn2, s2.start + n2 + nn2));
+
+                            assert(sout1.data.subrange(s1.start, s1.start + nn1)
+                                =~= sout1.data.subrange(0, s1.start + nn1).subrange(
+                                s1.start,
+                                s1.start + nn1,
+                            ));
+                            assert(sout2.data.subrange(s2.start, s2.start + nn2)
+                                =~= sout2.data.subrange(0, s2.start + nn2).subrange(
+                                s2.start,
+                                s2.start + nn2,
+                            ));
+
+                            assert(snn1.data.subrange(s1.start, s1.start + nn1)
+                                =~= snn1.data.subrange(0, s1.start + nn1).subrange(
+                                s1.start,
+                                s1.start + nn1,
+                            ));
+                            assert(snn2.data.subrange(s2.start, s2.start + nn2)
+                                =~= snn2.data.subrange(0, s2.start + nn2).subrange(
+                                s2.start,
+                                s2.start + nn2,
+                            ));
                         }
                     }
                 }
             }
         }
-    }
-
-    pub proof fn lemma_parse_repeat_n_well_behaved_on<R>(
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat,
-        s: SpecStream)
-        requires
-            prop_parse_well_behaved(parser)
-        ensures
-            prop_parse_well_behaved_on(spec_parse_repeat_n(parser, n), s)
-            &&
-            if let Ok((_, _, res)) = spec_parse_repeat_n(parser, n)(s) {
-                res.len() == n
-            } else {
-                true
-            }
-        decreases n
-    {
-        if n == 0 {
-        } else {
-            match spec_parse_repeat_n(parser, n)(s) {
-                Ok((sout, n_total, res)) => {
-                    assert(
-                        sout.data == s.data &&
-                        sout.start == s.start + n_total &&
-                        0 <= s.start <= sout.start <= s.data.len() &&
-                        res.len() == n) by {
-                            if let Ok((s1, n1, res1)) = spec_parse_repeat_n(parser, (n - 1) as nat)(s) {
-                                assert(
-                                    s1.data == s.data &&
-                                    s1.start == s.start + n1 &&
-                                    0 <= s.start <= s1.start <= s.data.len() &&
-                                    res1.len() == n - 1) by { // induction on n
-                                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s);
-                                }
-                                if let Ok((s2, n2, res2)) = parser(s1) {
-                                    assert(
-                                        s2.data == s1.data &&
-                                        s2.start == s1.start + n2 &&
-                                        0 <= s1.start <= s2.start <= s1.data.len()) by {
-                                            lemma_parse_well_behaved_on(parser, s1);
-                                        }
-                                    assert(
-                                        sout == s2 &&
-                                        n_total == n1 + n2 &&
-                                        res == res1.push(res2) &&
-                                        res.len() == n
-                                    );
-                                }
-                            }
-                        }
-                }
-                Err(_) => {}
-            }
-        }
-    }
-
-    pub proof fn lemma_serialize_repeat_n_well_behaved_on<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s: SpecStream,
-        vs: Seq<T>)
-        requires
-            prop_serialize_well_behaved(serializer),
-        ensures
-            prop_serialize_well_behaved_on(spec_serialize_repeat_n(serializer, n), s, vs)
-        decreases n
-    {
-        if vs.len() != n {}
-        else if s.start < 0 {}
-        else if s.start > s.data.len() {}
-        else if n == 0 {}
-        else {
-            lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1));
-            match spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s, vs.subrange(0, vs.len() as int - 1)) {
-                Ok((s1, n1)) =>
-                {
-                    assert(s.start + n1 == s1.start);
-                    assert(s1.data.subrange(0, s.start) == s.data.subrange(0, s.start));
-                    assert(s1.data.subrange(s.start + n1, s.data.len() as int) == s.data.subrange(s.start + n1, s.data.len() as int));
-                    lemma_serialize_well_behaved_on(serializer, s1, vs[vs.len() as int - 1]);
-                    match serializer(s1, vs[vs.len() as int - 1]) {
-                        Ok((s2, n2)) => {
-                            assert(s1.start + n2 == s2.start);
-                            assert(s2.data.subrange(0, s1.start) == s1.data.subrange(0, s1.start));
-                            assert(s2.data.subrange(s1.start + n2, s.data.len() as int) == s1.data.subrange(s1.start + n2, s.data.len() as int));
-
-                            assert(s.start + n1 + n2 == s2.start);
-                            assert(s2.data.subrange(0, s.start) == s.data.subrange(0, s.start)) by {
-                                assert(s2.data.subrange(0, s1.start).subrange(0, s.start) =~= s2.data.subrange(0, s.start));
-                                assert(s1.data.subrange(0, s1.start).subrange(0, s.start) =~= s.data.subrange(0, s.start));
-                            }
-                            assert(s2.data.subrange(s.start + n1 + n2, s.data.len() as int) == s.data.subrange(s.start + n1 + n2, s.data.len() as int)) by {
-                                assert(s1.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s1.data.subrange(s.start + n1 + n2, s.data.len() as int));
-                                assert(s.data.subrange(s.start + n1, s.data.len() as int).subrange(n2 as int, s.data.len() - s.start - n1) =~= s.data.subrange(s.start + n1 + n2, s.data.len() as int));
-                            }
-                        }
-                        Err(e) => {}
-                    }
-                },
-                Err(e) => {}
-            }
-        }
-    }
-
-    pub proof fn lemma_serialize_repeat_n_deterministic_on<T>(
-        serializer: spec_fn(SpecStream, T) -> SpecSerializeResult,
-        n: nat,
-        s1: SpecStream,
-        s2: SpecStream,
-        vs: Seq<T>)
-        requires
-            prop_serialize_well_behaved(serializer),
-            prop_serialize_deterministic(serializer)
-        ensures
-            prop_serialize_deterministic_on(spec_serialize_repeat_n(serializer, n), s1, s2, vs)
-        decreases n, vs.len()
-    {
-        if let (Ok((sn1, m1)), Ok((sn2, m2))) = (spec_serialize_repeat_n(serializer, n)(s1, vs), spec_serialize_repeat_n(serializer, n)(s2, vs))
-        {
-            if vs.len() != n {}
-            else if s1.start < 0 || s2.start < 0 {}
-            else if s1.start > s1.data.len() || s2.start > s2.data.len() {}
-            else if n == 0 {}
-            else {
-                // induction on n
-                lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s1, vs.subrange(0, vs.len() as int - 1));
-                lemma_serialize_repeat_n_well_behaved_on(serializer, (n - 1) as nat, s2, vs.subrange(0, vs.len() as int - 1));
-                lemma_serialize_repeat_n_deterministic_on(serializer, (n - 1) as nat, s1, s2, vs.subrange(0, vs.len() as int - 1));
-                if let (Ok((snn1, nn1)), Ok((snn2, nn2))) = (spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s1, vs.subrange(0, vs.len() as int - 1)), spec_serialize_repeat_n_rec(serializer, (n - 1) as nat, s2, vs.subrange(0, vs.len() as int - 1))) {
-                    assert(nn1 == nn2);
-                    assert(snn1.data.subrange(s1.start, s1.start + nn1) == snn2.data.subrange(s2.start, s2.start + nn2));
-
-                    lemma_serialize_well_behaved_on(serializer, snn1, vs[vs.len() as int - 1]);
-                    lemma_serialize_well_behaved_on(serializer, snn2, vs[vs.len() as int - 1]);
-                    lemma_serialize_deterministic_on(serializer, snn1, snn2, vs[vs.len() as int - 1]);
-                    if let Ok((sout1, n1)) = serializer(snn1, vs[vs.len() as int - 1]) {
-                        if let Ok((sout2, n2)) = serializer(snn2, vs[vs.len() as int - 1]) {
-                            assert(n1 + nn1 == n2 + nn2);
-                            assert(sout1.data.subrange(snn1.start, snn1.start + n1) == sout2.data.subrange(snn2.start, snn2.start + n2));
-
-                            assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1) == sout2.data.subrange(s2.start, s2.start + n2 + nn2)) by {
-                                assert(sout1.data.subrange(s1.start, s1.start + n1 + nn1) =~= sout1.data.subrange(s1.start, s1.start + nn1) + sout1.data.subrange(s1.start + nn1, s1.start + n1 + nn1));
-                                assert(sout2.data.subrange(s2.start, s2.start + n2 + nn2) =~= sout2.data.subrange(s2.start, s2.start + nn2) + sout2.data.subrange(s2.start + nn2, s2.start + n2 + nn2));
-
-                                assert(sout1.data.subrange(s1.start, s1.start + nn1) =~= sout1.data.subrange(0, s1.start + nn1).subrange(s1.start, s1.start + nn1));
-                                assert(sout2.data.subrange(s2.start, s2.start + nn2) =~= sout2.data.subrange(0, s2.start + nn2).subrange(s2.start, s2.start + nn2));
-
-                                assert(snn1.data.subrange(s1.start, s1.start + nn1) =~= snn1.data.subrange(0, s1.start + nn1).subrange(s1.start, s1.start + nn1));
-                                assert(snn2.data.subrange(s2.start, s2.start + nn2) =~= snn2.data.subrange(0, s2.start + nn2).subrange(s2.start, s2.start + nn2));
-                            }
-                        }
-                    }
-                }
-            }
         assert(m1 == m2);
-        assert(sn1.data.subrange(s1.start, s1.start + m1) =~= sn2.data.subrange(s2.start, s2.start + m2));
-        }
+        assert(sn1.data.subrange(s1.start, s1.start + m1) =~= sn2.data.subrange(
+            s2.start,
+            s2.start + m2,
+        ));
     }
+}
 
-
-    pub proof fn lemma_parse_repeat_n_strong_prefix_on<R>(
-        s1: SpecStream,
-        s2: SpecStream,
-        parser: spec_fn(SpecStream) -> SpecParseResult<R>,
-        n: nat)
-        requires
-            prop_parse_well_behaved(parser),
-            prop_parse_strong_prefix(parser),
-        ensures
-            prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2)
-        decreases n
-    {
-        if let Ok((sout1, n1, x1)) = spec_parse_repeat_n(parser, n)(s1) {
-            if 0 <= s1.start <= s1.start + n1 <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + n1 <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + n1) == s2.data.subrange(s2.start, s2.start + n1) {
-                if n == 0 {
-                } else {
-                    // induction on n
-                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s1);
-                    lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s2);
-                    lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, (n - 1) as nat);
-                    if let Ok((sn1, nn1, xn1)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s1) {
-                        assert(s1.data.subrange(s1.start, s1.start + nn1) == s2.data.subrange(s2.start, s2.start + nn1)) by {
-                            assert(s1.data.subrange(s1.start, s1.start + n1).subrange(0, nn1 as int) =~= s1.data.subrange(s1.start, s1.start + nn1));
-                            assert(s2.data.subrange(s2.start, s2.start + n1).subrange(0, nn1 as int) =~= s2.data.subrange(s2.start, s2.start + nn1));
-                        }
-                        if let Ok((sn2, nn2, xn2)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s2) {
-                            assert(nn1 == nn2 && xn1 == xn2);
-                            lemma_parse_well_behaved_on(parser, sn1);
-                            lemma_parse_well_behaved_on(parser, sn2);
-                            lemma_parse_strong_prefix_on(parser, sn1, sn2);
-                            if let Ok((sn1_, nn1_, xn1_)) = parser(sn1) {
-                                // assert(n1 == nn1 + nn1_);
-                                assert(s1.data.subrange(s1.start + nn1, s1.start + n1) == s2.data.subrange(s2.start + nn1, s2.start + n1)) by {
-                                    assert(s1.data.subrange(s1.start, s1.start + n1).subrange(nn1 as int, n1 as int) =~= s1.data.subrange(s1.start + nn1, s1.start + n1));
-                                    assert(s2.data.subrange(s2.start, s2.start + n1).subrange(nn1 as int, n1 as int) =~= s2.data.subrange(s2.start + nn1, s2.start + n1));
-                                }
-                                assert(sn1.data.subrange(sn1.start, sn1.start + nn1_) == sn2.data.subrange(sn2.start, sn2.start + nn1_));
-                                if let Ok((sn2_, nn2_, xn2_)) = parser(sn2) {
-                                    assert(nn1_ == nn2_ && xn1_ == xn2_);
-                                }
+pub proof fn lemma_parse_repeat_n_strong_prefix_on<R>(
+    s1: SpecStream,
+    s2: SpecStream,
+    parser: spec_fn(SpecStream) -> SpecParseResult<R>,
+    n: nat,
+)
+    requires
+        prop_parse_well_behaved(parser),
+        prop_parse_strong_prefix(parser),
+    ensures
+        prop_parse_strong_prefix_on(spec_parse_repeat_n(parser, n), s1, s2),
+    decreases n,
+{
+    if let Ok((sout1, n1, x1)) = spec_parse_repeat_n(parser, n)(s1) {
+        if 0 <= s1.start <= s1.start + n1 <= s1.data.len() <= usize::MAX && 0 <= s2.start
+            <= s2.start + n1 <= s2.data.len() <= usize::MAX && s1.data.subrange(
+            s1.start,
+            s1.start + n1,
+        ) == s2.data.subrange(s2.start, s2.start + n1) {
+            if n == 0 {
+            } else {
+                // induction on n
+                lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s1);
+                lemma_parse_repeat_n_well_behaved_on(parser, (n - 1) as nat, s2);
+                lemma_parse_repeat_n_strong_prefix_on(s1, s2, parser, (n - 1) as nat);
+                if let Ok((sn1, nn1, xn1)) = spec_parse_repeat_n_rec(parser, (n - 1) as nat, s1) {
+                    assert(s1.data.subrange(s1.start, s1.start + nn1) == s2.data.subrange(
+                        s2.start,
+                        s2.start + nn1,
+                    )) by {
+                        assert(s1.data.subrange(s1.start, s1.start + n1).subrange(0, nn1 as int)
+                            =~= s1.data.subrange(s1.start, s1.start + nn1));
+                        assert(s2.data.subrange(s2.start, s2.start + n1).subrange(0, nn1 as int)
+                            =~= s2.data.subrange(s2.start, s2.start + nn1));
+                    }
+                    if let Ok((sn2, nn2, xn2)) = spec_parse_repeat_n_rec(
+                        parser,
+                        (n - 1) as nat,
+                        s2,
+                    ) {
+                        assert(nn1 == nn2 && xn1 == xn2);
+                        lemma_parse_well_behaved_on(parser, sn1);
+                        lemma_parse_well_behaved_on(parser, sn2);
+                        lemma_parse_strong_prefix_on(parser, sn1, sn2);
+                        if let Ok((sn1_, nn1_, xn1_)) = parser(sn1) {
+                            // assert(n1 == nn1 + nn1_);
+                            assert(s1.data.subrange(s1.start + nn1, s1.start + n1)
+                                == s2.data.subrange(s2.start + nn1, s2.start + n1)) by {
+                                assert(s1.data.subrange(s1.start, s1.start + n1).subrange(
+                                    nn1 as int,
+                                    n1 as int,
+                                ) =~= s1.data.subrange(s1.start + nn1, s1.start + n1));
+                                assert(s2.data.subrange(s2.start, s2.start + n1).subrange(
+                                    nn1 as int,
+                                    n1 as int,
+                                ) =~= s2.data.subrange(s2.start + nn1, s2.start + n1));
+                            }
+                            assert(sn1.data.subrange(sn1.start, sn1.start + nn1_)
+                                == sn2.data.subrange(sn2.start, sn2.start + nn1_));
+                            if let Ok((sn2_, nn2_, xn2_)) = parser(sn2) {
+                                assert(nn1_ == nn2_ && xn1_ == xn2_);
                             }
                         }
                     }
@@ -3241,807 +3702,868 @@ verus! {
     }
 }
 
+} // verus!
 verus! {
-    pub open spec fn spec_parse_bytes(s: SpecStream, n: nat) -> SpecParseResult<Seq<u8>>
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.len() {
-            Err(ParseError::Eof) // don't fail when start == data.len(), which is different from the uint parsers
-        } else if s.start + n > usize::MAX {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start + n > s.data.len() {
-            Err(ParseError::NotEnoughData)
-        } else {
-            Ok((
-                SpecStream {
-                    start: s.start + n as int,
-                    ..s
-                },
+
+pub open spec fn spec_parse_bytes(s: SpecStream, n: nat) -> SpecParseResult<Seq<u8>> {
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.len() {
+        Err(
+            ParseError::Eof,
+        )  // don't fail when start == data.len(), which is different from the uint parsers
+
+    } else if s.start + n > usize::MAX {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start + n > s.data.len() {
+        Err(ParseError::NotEnoughData)
+    } else {
+        Ok(
+            (
+                SpecStream { start: s.start + n as int, ..s },
                 n,
                 s.data.subrange(s.start, s.start + n as int),
-            ))
-        }
+            ),
+        )
     }
+}
 
-    pub open spec fn spec_serialize_bytes(s: SpecStream, v: Seq<u8>, n: nat) -> SpecSerializeResult
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start + v.len() > usize::MAX {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.len() > s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.len() != n {
-            Err(SerializeError::BytesLengthMismatch)
-        } else {
-            Ok((
+pub open spec fn spec_serialize_bytes(s: SpecStream, v: Seq<u8>, n: nat) -> SpecSerializeResult {
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start + v.len() > usize::MAX {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.len() > s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.len() != n {
+        Err(SerializeError::BytesLengthMismatch)
+    } else {
+        Ok(
+            (
                 SpecStream {
                     start: s.start + n as int,
-                    data: s.data.subrange(0, s.start) + v + s.data.subrange(s.start + n as int, s.data.len() as int),
+                    data: s.data.subrange(0, s.start) + v + s.data.subrange(
+                        s.start + n as int,
+                        s.data.len() as int,
+                    ),
                 },
                 n,
-            ))
-        }
+            ),
+        )
     }
-
-    pub exec fn parse_bytes(s: Stream, n: usize) -> (res: ParseResult<&[u8]>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.start > usize::MAX - n {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start + n > s.data.length() {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = slice_subrange(s.data, s.start, s.start + n);
-            Ok((
-                Stream {
-                    start: s.start + n,
-                    ..s
-                },
-                n,
-                data,
-            ))
-        }
-    }
-
-    pub exec fn serialize_bytes(data: &mut [u8], start: usize, v: &[u8], n: usize) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, n as nat))
-    {
-        let ghost old_data = data.dview();
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if start + v.length() > data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != n {
-            Err(SerializeError::BytesLengthMismatch)
-        } else {
-            let mut i = start;
-            let mut j = 0;
-
-            while j < n
-                invariant
-                    v.dview().len() == n,
-                    i - start == j,
-                    data.dview().len() == old(data).dview().len(), // critical!
-                    0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
-                    forall |k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k], // data[0..start] == old(data)[0..start]
-                    forall |k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start], // data[start..start + j] == v[0..j]
-                    forall |k| start + n <= k < data.dview().len() ==> data.dview()[k] == old(data).dview()[k], // data[start + n..] == old(data)[start + n..]
-            {
-                data.set(i, *slice_index_get(v, j)); // data[i] = v[j];
-                i = i + 1;
-                j = j + 1;
-            }
-            let ghost spec_res = spec_serialize_bytes(SpecStream {
-                data: old_data,
-                start: start as int,
-            }, v.dview(), n as nat);
-            // assert(spec_res.is_ok() && spec_res.unwrap().1 == n && spec_res.unwrap().0.start == (start + n) as int);
-            let ghost spec_data = spec_res.unwrap().0.data;
-            assert(spec_data == data.dview());
-            Ok((
-                start + n,
-                n,
-            ))
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_well_behaved(n: nat)
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_bytes(s, n))
-    {
-        reveal(prop_parse_well_behaved);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_bytes, s) by {
-            lemma_parse_bytes_well_behaved_on(s, n)
-        }
-    }
-
-    pub proof fn lemma_serialize_bytes_well_behaved(n: nat)
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_serialize_well_behaved);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_bytes, s, v) by {
-            lemma_serialize_bytes_well_behaved_on(s, v, n)
-        }
-    }
-
-    pub proof fn lemma_serialize_bytes_deterministic(n: nat)
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_serialize_deterministic);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_bytes, s1, s2, v) by {
-            lemma_serialize_bytes_deterministic_on(s1, s2, v, n)
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_strong_prefix(n: nat)
-        ensures
-            prop_parse_strong_prefix(|s| spec_parse_bytes(s, n))
-    {
-        reveal(prop_parse_strong_prefix);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_bytes, s1, s2) by {
-            lemma_parse_bytes_strong_prefix_on(s1, s2, n)
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_correct(n: nat)
-        ensures
-            prop_parse_correct(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_parse_correct::<Seq<u8>>);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_bytes, spec_serialize_bytes, s, v) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_bytes_correct_on(s, v, n)
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_serialize_inverse(n: nat)
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n))
-    {
-        reveal(prop_parse_serialize_inverse::<Seq<u8>>);
-        let spec_parse_bytes = |s| spec_parse_bytes(s, n);
-        let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_bytes, spec_serialize_bytes, s) by {
-            lemma_parse_bytes_serialize_inverse_on(s, n)
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_nonmalleable(n: nat)
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_bytes(s, n))
-    {
-        lemma_parse_bytes_serialize_inverse(n);
-        lemma_serialize_bytes_deterministic(n);
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n));
-    }
-
-
-    pub proof fn lemma_parse_bytes_well_behaved_on(s: SpecStream, n: nat)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_bytes(s, n), s)
-    {}
-
-    pub proof fn lemma_serialize_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>, n: nat)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_bytes(s, v, n), s, v)
-    {
-        if let Ok((sout, m)) = spec_serialize_bytes(s, v, n) {
-            assert(m == n);
-            assert(sout.data.len() =~= s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + m, s.data.len() as int) =~= s.data.subrange(s.start + m, s.data.len() as int));
-        }
-    }
-
-    pub proof fn lemma_serialize_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>, n: nat)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_bytes(s, v, n), s1, s2, v)
-    {
-        let n = v.len();
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_bytes(s1, v, n), spec_serialize_bytes(s2, v, n)) {
-            assert(n1 == n && n2 == n);
-            assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(s2.start, s2.start + n));
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream, n: nat)
-        ensures
-            prop_parse_strong_prefix_on(|s| spec_parse_bytes(s, n), s1, s2)
-    {
-        if let Ok((sout1, m1, x1)) = spec_parse_bytes(s1, n) {
-            if 0 <= s1.start <= s1.start + m1 <= s1.data.len() <= usize::MAX
-            && 0 <= s2.start <= s2.start + m1 <= s2.data.len() <= usize::MAX
-            && s1.data.subrange(s1.start, s1.start + m1) == s2.data.subrange(s2.start, s2.start + m1) {
-                if let Ok((sout2, m2, x2)) = spec_parse_bytes(s2, m1) {
-                    assert(m1 == m2);
-                    assert(x1 == x2);
-                }
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_correct_on(s: SpecStream, v: Seq<u8>, n: nat)
-        requires s.data.len() <= usize::MAX,
-        ensures
-            prop_parse_correct_on(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n), s, v)
-    {
-        if let Ok((sout, m1)) = spec_serialize_bytes(s, v, n) {
-            if let Ok((_, m2, res)) = spec_parse_bytes(SpecStream {start: s.start, ..sout}, n) {
-                assert(m1 == m2);
-                assert(res =~= v);
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_bytes_serialize_inverse_on(s: SpecStream, n: nat)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n), s)
-    {
-        if let Ok((sout, m1, x)) = spec_parse_bytes(s, n) {
-            if let Ok((sout2, m2)) = spec_serialize_bytes(s, x, m1) {
-                assert(m1 == m2);
-                assert(sout.data =~= sout2.data);
-            }
-        }
-    }
-
 }
 
+pub exec fn parse_bytes(s: Stream, n: usize) -> (res: ParseResult<&[u8]>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.start > usize::MAX - n {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start + n > s.data.length() {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = slice_subrange(s.data, s.start, s.start + n);
+        Ok((Stream { start: s.start + n, ..s }, n, data))
+    }
+}
+
+pub exec fn serialize_bytes(data: &mut [u8], start: usize, v: &[u8], n: usize) -> (res:
+    SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, n as nat),
+        ),
+{
+    let ghost old_data = data.dview();
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if start + v.length() > data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != n {
+        Err(SerializeError::BytesLengthMismatch)
+    } else {
+        let mut i = start;
+        let mut j = 0;
+
+        while j < n
+            invariant
+                v.dview().len() == n,
+                i - start == j,
+                data.dview().len() == old(data).dview().len(),  // critical!
+                0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
+                forall|k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k],  // data[0..start] == old(data)[0..start]
+                forall|k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start],  // data[start..start + j] == v[0..j]
+                forall|k|
+                    start + n <= k < data.dview().len() ==> data.dview()[k] == old(data).dview()[k],  // data[start + n..] == old(data)[start + n..]
+        {
+            data.set(i, *slice_index_get(v, j));  // data[i] = v[j];
+            i = i + 1;
+            j = j + 1;
+        }
+        let ghost spec_res = spec_serialize_bytes(
+            SpecStream { data: old_data, start: start as int },
+            v.dview(),
+            n as nat,
+        );
+        // assert(spec_res.is_ok() && spec_res.unwrap().1 == n && spec_res.unwrap().0.start == (start + n) as int);
+        let ghost spec_data = spec_res.unwrap().0.data;
+        assert(spec_data == data.dview());
+        Ok((start + n, n))
+    }
+}
+
+pub proof fn lemma_parse_bytes_well_behaved(n: nat)
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_bytes(s, n)),
+{
+    reveal(prop_parse_well_behaved);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_bytes, s) by {
+        lemma_parse_bytes_well_behaved_on(s, n)
+    }
+}
+
+pub proof fn lemma_serialize_bytes_well_behaved(n: nat)
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_bytes(s, v, n)),
+{
+    reveal(prop_serialize_well_behaved);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_bytes, s, v) by {
+        lemma_serialize_bytes_well_behaved_on(s, v, n)
+    }
+}
+
+pub proof fn lemma_serialize_bytes_deterministic(n: nat)
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_bytes(s, v, n)),
+{
+    reveal(prop_serialize_deterministic);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_bytes, s1, s2, v) by {
+        lemma_serialize_bytes_deterministic_on(s1, s2, v, n)
+    }
+}
+
+pub proof fn lemma_parse_bytes_strong_prefix(n: nat)
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_bytes(s, n)),
+{
+    reveal(prop_parse_strong_prefix);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_bytes, s1, s2) by {
+        lemma_parse_bytes_strong_prefix_on(s1, s2, n)
+    }
+}
+
+pub proof fn lemma_parse_bytes_correct(n: nat)
+    ensures
+        prop_parse_correct(|s| spec_parse_bytes(s, n), |s, v| spec_serialize_bytes(s, v, n)),
+{
+    reveal(prop_parse_correct::<Seq<u8>>);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_bytes,
+            spec_serialize_bytes,
+            s,
+            v,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_bytes_correct_on(s, v, n)
+        }
+    }
+}
+
+pub proof fn lemma_parse_bytes_serialize_inverse(n: nat)
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_bytes(s, n),
+            |s, v| spec_serialize_bytes(s, v, n),
+        ),
+{
+    reveal(prop_parse_serialize_inverse::<Seq<u8>>);
+    let spec_parse_bytes = |s| spec_parse_bytes(s, n);
+    let spec_serialize_bytes = |s, v| spec_serialize_bytes(s, v, n);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_bytes, spec_serialize_bytes, s) by {
+        lemma_parse_bytes_serialize_inverse_on(s, n)
+    }
+}
+
+pub proof fn lemma_parse_bytes_nonmalleable(n: nat)
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_bytes(s, n)),
+{
+    lemma_parse_bytes_serialize_inverse(n);
+    lemma_serialize_bytes_deterministic(n);
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_bytes(s, n),
+        |s, v| spec_serialize_bytes(s, v, n),
+    );
+}
+
+pub proof fn lemma_parse_bytes_well_behaved_on(s: SpecStream, n: nat)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_bytes(s, n), s),
+{
+}
+
+pub proof fn lemma_serialize_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>, n: nat)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_bytes(s, v, n), s, v),
+{
+    if let Ok((sout, m)) = spec_serialize_bytes(s, v, n) {
+        assert(m == n);
+        assert(sout.data.len() =~= s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + m, s.data.len() as int) =~= s.data.subrange(
+            s.start + m,
+            s.data.len() as int,
+        ));
+    }
+}
+
+pub proof fn lemma_serialize_bytes_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: Seq<u8>,
+    n: nat,
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_bytes(s, v, n), s1, s2, v),
+{
+    let n = v.len();
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_bytes(s1, v, n),
+        spec_serialize_bytes(s2, v, n),
+    ) {
+        assert(n1 == n && n2 == n);
+        assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ));
+    }
+}
+
+pub proof fn lemma_parse_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream, n: nat)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_bytes(s, n), s1, s2),
+{
+    if let Ok((sout1, m1, x1)) = spec_parse_bytes(s1, n) {
+        if 0 <= s1.start <= s1.start + m1 <= s1.data.len() <= usize::MAX && 0 <= s2.start
+            <= s2.start + m1 <= s2.data.len() <= usize::MAX && s1.data.subrange(
+            s1.start,
+            s1.start + m1,
+        ) == s2.data.subrange(s2.start, s2.start + m1) {
+            if let Ok((sout2, m2, x2)) = spec_parse_bytes(s2, m1) {
+                assert(m1 == m2);
+                assert(x1 == x2);
+            }
+        }
+    }
+}
+
+pub proof fn lemma_parse_bytes_correct_on(s: SpecStream, v: Seq<u8>, n: nat)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_bytes(s, n),
+            |s, v| spec_serialize_bytes(s, v, n),
+            s,
+            v,
+        ),
+{
+    if let Ok((sout, m1)) = spec_serialize_bytes(s, v, n) {
+        if let Ok((_, m2, res)) = spec_parse_bytes(SpecStream { start: s.start, ..sout }, n) {
+            assert(m1 == m2);
+            assert(res =~= v);
+        }
+    }
+}
+
+pub proof fn lemma_parse_bytes_serialize_inverse_on(s: SpecStream, n: nat)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_bytes(s, n),
+            |s, v| spec_serialize_bytes(s, v, n),
+            s,
+        ),
+{
+    if let Ok((sout, m1, x)) = spec_parse_bytes(s, n) {
+        if let Ok((sout2, m2)) = spec_serialize_bytes(s, x, m1) {
+            assert(m1 == m2);
+            assert(sout.data =~= sout2.data);
+        }
+    }
+}
+
+} // verus!
 verus! {
 
-    /// A parser that consumes the rest of the input.
-    pub open spec fn spec_parse_tail(s: SpecStream) -> SpecParseResult<Seq<u8>>
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.data.len() > usize::MAX {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start > s.data.len() {
-            Err(ParseError::Eof) // don't fail when start == data.len(), which is different from the uint parsers
-        } else {
-            let n = s.data.len() as int;
-            Ok((
-                SpecStream {
-                    start: n,
-                    ..s
-                },
-                (n - s.start) as nat,
-                s.data.subrange(s.start, n),
-            ))
+/// A parser that consumes the rest of the input.
+pub open spec fn spec_parse_tail(s: SpecStream) -> SpecParseResult<Seq<u8>> {
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.data.len() > usize::MAX {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start > s.data.len() {
+        Err(
+            ParseError::Eof,
+        )  // don't fail when start == data.len(), which is different from the uint parsers
+
+    } else {
+        let n = s.data.len() as int;
+        Ok((SpecStream { start: n, ..s }, (n - s.start) as nat, s.data.subrange(s.start, n)))
+    }
+}
+
+pub open spec fn spec_serialize_tail(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start + v.len() > usize::MAX {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.len() > s.data.len() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.len() != s.data.len() - s.start {
+        Err(SerializeError::TailLengthMismatch)
+    } else {
+        let n = v.len() as int;
+        Ok((SpecStream { start: s.start + n, data: s.data.subrange(0, s.start) + v }, n as nat))
+    }
+}
+
+pub exec fn parse_tail(s: Stream) -> (res: ParseResult<&[u8]>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else {
+        let n = s.data.length();
+        let data = slice_subrange(s.data, s.start, n);
+        Ok((Stream { start: n, ..s }, n - s.start, data))
+    }
+}
+
+pub exec fn serialize_tail(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_tail(s, v),
+        ),
+{
+    let ghost old_data = data.dview();
+    if start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if start + v.length() > data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != data.length() - start {
+        Err(SerializeError::TailLengthMismatch)
+    } else {
+        let n = v.length();
+        let mut i = start;
+        let mut j = 0;
+
+        while j < n
+            invariant
+                v.dview().len() == n,
+                i - start == j,
+                data.dview().len() == old(data).dview().len(),
+                0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
+                forall|k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k],  // data[0..start] == old(data)[0..start]
+                forall|k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start],  // data[start..start + j] == v[0..j]
+        {
+            data.set(i, *slice_index_get(v, j));  // data[i] = v[j];
+            i = i + 1;
+            j = j + 1;
         }
+        let ghost spec_res = spec_serialize_tail(
+            SpecStream { data: old_data, start: start as int },
+            v.dview(),
+        );
+        let ghost spec_data = spec_res.unwrap().0.data;
+        assert(spec_data == data.dview());
+        Ok((start + n, n))
     }
+}
 
-    pub open spec fn spec_serialize_tail(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start + v.len() > usize::MAX {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.len() > s.data.len() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.len() != s.data.len() - s.start {
-            Err(SerializeError::TailLengthMismatch)
-        } else {
-            let n = v.len() as int;
-            Ok((
-                SpecStream {
-                    start: s.start + n,
-                    data: s.data.subrange(0, s.start) + v,
-                },
-                n as nat,
-            ))
-        }
+pub proof fn lemma_parse_tail_well_behaved()
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_tail(s)),
+{
+    reveal(prop_parse_well_behaved::<Seq<u8>>);
+    let spec_parse_tail = |s| spec_parse_tail(s);
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_tail, s) by {
+        lemma_parse_tail_well_behaved_on(s)
     }
+}
 
-    pub exec fn parse_tail(s: Stream) -> (res: ParseResult<&[u8]>)
-        ensures
-            prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else {
-            let n = s.data.length();
-            let data = slice_subrange(s.data, s.start, n);
-            Ok((
-                Stream {
-                    start: n,
-                    ..s
-                },
-                n - s.start,
-                data,
-            ))
-        }
+pub proof fn lemma_serialize_tail_well_behaved()
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_serialize_well_behaved::<Seq<u8>>);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_tail, s, v) by {
+        lemma_serialize_tail_well_behaved_on(s, v)
     }
+}
 
-    pub exec fn serialize_tail(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
-        ensures
-            prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_tail(s, v))
-    {
-        let ghost old_data = data.dview();
-        if start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if start + v.length() > data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != data.length() - start {
-            Err(SerializeError::TailLengthMismatch)
-        } else {
-            let n = v.length();
-            let mut i = start;
-            let mut j = 0;
-
-            while j < n
-                invariant
-                    v.dview().len() == n,
-                    i - start == j,
-                    data.dview().len() == old(data).dview().len(),
-                    0 <= start <= i <= start + n <= data.dview().len() <= usize::MAX,
-                    forall |k| 0 <= k < start ==> data.dview()[k] == old(data).dview()[k], // data[0..start] == old(data)[0..start]
-                    forall |k| start <= k < start + j ==> data.dview()[k] == v.dview()[k - start], // data[start..start + j] == v[0..j]
-            {
-                data.set(i, *slice_index_get(v, j)); // data[i] = v[j];
-                i = i + 1;
-                j = j + 1;
-            }
-            let ghost spec_res = spec_serialize_tail(SpecStream {
-                data: old_data,
-                start: start as int,
-            }, v.dview());
-            let ghost spec_data = spec_res.unwrap().0.data;
-            assert(spec_data == data.dview());
-            Ok((
-                start + n,
-                n,
-            ))
-        }
+pub proof fn lemma_serialize_tail_deterministic()
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_serialize_deterministic::<Seq<u8>>);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_tail, s1, s2, v) by {
+        lemma_serialize_tail_deterministic_on(s1, s2, v)
     }
+}
 
-    pub proof fn lemma_parse_tail_well_behaved()
-        ensures
-            prop_parse_well_behaved(|s| spec_parse_tail(s))
-    {
-        reveal(prop_parse_well_behaved::<Seq<u8>>);
-        let spec_parse_tail = |s| spec_parse_tail(s);
-        assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_tail, s) by {
-            lemma_parse_tail_well_behaved_on(s)
-        }
-    }
-
-    pub proof fn lemma_serialize_tail_well_behaved()
-        ensures
-            prop_serialize_well_behaved(|s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_serialize_well_behaved::<Seq<u8>>);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_tail, s, v) by {
-            lemma_serialize_tail_well_behaved_on(s, v)
-        }
-    }
-
-    pub proof fn lemma_serialize_tail_deterministic()
-        ensures
-            prop_serialize_deterministic(|s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_serialize_deterministic::<Seq<u8>>);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_tail, s1, s2, v) by {
-            lemma_serialize_tail_deterministic_on(s1, s2, v)
-        }
-    }
-
-    pub proof fn lemma_parse_tail_correct()
-        ensures
-            prop_parse_correct(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_parse_correct::<Seq<u8>>);
-        let spec_parse_tail = |s| spec_parse_tail(s);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_tail, spec_serialize_tail, s, v) by {
-            if s.data.len() <= usize::MAX {
-                lemma_parse_tail_correct_on(s, v)
-            }
-        }
-    }
-
-    pub proof fn lemma_parse_tail_serialize_inverse()
-        ensures
-            prop_parse_serialize_inverse(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v))
-    {
-        reveal(prop_parse_serialize_inverse::<Seq<u8>>);
-        let spec_parse_tail = |s| spec_parse_tail(s);
-        let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
-        assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_tail, spec_serialize_tail, s) by {
-            lemma_parse_tail_serialize_inverse_on(s)
-        }
-    }
-
-    pub proof fn lemma_parse_tail_nonmalleable()
-        ensures
-            prop_parse_nonmalleable(|s| spec_parse_tail(s))
-    {
-        lemma_parse_tail_serialize_inverse();
-        lemma_serialize_tail_deterministic();
-        lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v));
-    }
-
-    proof fn lemma_parse_tail_well_behaved_on(s: SpecStream)
-        ensures
-            prop_parse_well_behaved_on(|s| spec_parse_tail(s), s)
-    {}
-
-    proof fn lemma_serialize_tail_well_behaved_on(s: SpecStream, v: Seq<u8>)
-        ensures
-            prop_serialize_well_behaved_on(|s, v| spec_serialize_tail(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_tail(s, v) {
-            assert(n == v.len());
-            assert(sout.data.len() =~= s.data.len());
-            assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
-            assert(sout.data.subrange(s.start + n, s.data.len() as int) =~= s.data.subrange(s.start + n, s.data.len() as int));
-        }
-    }
-
-    proof fn lemma_serialize_tail_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
-        ensures
-            prop_serialize_deterministic_on(|s, v| spec_serialize_tail(s, v), s1, s2, v)
-    {
-        let n = v.len();
-        if let (Ok((sout1, n1)), Ok((sout2, n2))) = (spec_serialize_tail(s1, v), spec_serialize_tail(s2, v)) {
-            assert(n1 == n && n2 == n);
-            assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(s2.start, s2.start + n));
-        }
-    }
-
-    proof fn lemma_parse_tail_correct_on(s: SpecStream, v: Seq<u8>)
-        requires s.data.len() <= usize::MAX,
-        ensures
-            prop_parse_correct_on(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v), s, v)
-    {
-        if let Ok((sout, n)) = spec_serialize_tail(s, v) {
-            if let Ok((_, m, res)) = spec_parse_tail(SpecStream {start: s.start, ..sout}) {
-                assert(n == m);
-                assert(res =~= v);
-            }
-        }
-    }
-
-    proof fn lemma_parse_tail_serialize_inverse_on(s: SpecStream)
-        ensures
-            prop_parse_serialize_inverse_on(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v), s)
-    {
-        if let Ok((sout, n, x)) = spec_parse_tail(s) {
-            if let Ok((sout2, m)) = spec_serialize_tail(s, x) {
-                assert(n == m);
-                assert(sout.data =~= sout2.data);
-            } else {
-                assert(false);
-            }
+pub proof fn lemma_parse_tail_correct()
+    ensures
+        prop_parse_correct(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_parse_correct::<Seq<u8>>);
+    let spec_parse_tail = |s| spec_parse_tail(s);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_tail,
+            spec_serialize_tail,
+            s,
+            v,
+        ) by {
+        if s.data.len() <= usize::MAX {
+            lemma_parse_tail_correct_on(s, v)
         }
     }
 }
 
+pub proof fn lemma_parse_tail_serialize_inverse()
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v)),
+{
+    reveal(prop_parse_serialize_inverse::<Seq<u8>>);
+    let spec_parse_tail = |s| spec_parse_tail(s);
+    let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_tail, spec_serialize_tail, s) by {
+        lemma_parse_tail_serialize_inverse_on(s)
+    }
+}
+
+pub proof fn lemma_parse_tail_nonmalleable()
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_tail(s)),
+{
+    lemma_parse_tail_serialize_inverse();
+    lemma_serialize_tail_deterministic();
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_tail(s),
+        |s, v| spec_serialize_tail(s, v),
+    );
+}
+
+proof fn lemma_parse_tail_well_behaved_on(s: SpecStream)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_tail(s), s),
+{
+}
+
+proof fn lemma_serialize_tail_well_behaved_on(s: SpecStream, v: Seq<u8>)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_tail(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_tail(s, v) {
+        assert(n == v.len());
+        assert(sout.data.len() =~= s.data.len());
+        assert(sout.data.subrange(0, s.start) =~= s.data.subrange(0, s.start));
+        assert(sout.data.subrange(s.start + n, s.data.len() as int) =~= s.data.subrange(
+            s.start + n,
+            s.data.len() as int,
+        ));
+    }
+}
+
+proof fn lemma_serialize_tail_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_tail(s, v), s1, s2, v),
+{
+    let n = v.len();
+    if let (Ok((sout1, n1)), Ok((sout2, n2))) = (
+        spec_serialize_tail(s1, v),
+        spec_serialize_tail(s2, v),
+    ) {
+        assert(n1 == n && n2 == n);
+        assert(sout1.data.subrange(s1.start, s1.start + n) =~= sout2.data.subrange(
+            s2.start,
+            s2.start + n,
+        ));
+    }
+}
+
+proof fn lemma_parse_tail_correct_on(s: SpecStream, v: Seq<u8>)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_tail(s), |s, v| spec_serialize_tail(s, v), s, v),
+{
+    if let Ok((sout, n)) = spec_serialize_tail(s, v) {
+        if let Ok((_, m, res)) = spec_parse_tail(SpecStream { start: s.start, ..sout }) {
+            assert(n == m);
+            assert(res =~= v);
+        }
+    }
+}
+
+proof fn lemma_parse_tail_serialize_inverse_on(s: SpecStream)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_tail(s),
+            |s, v| spec_serialize_tail(s, v),
+            s,
+        ),
+{
+    if let Ok((sout, n, x)) = spec_parse_tail(s) {
+        if let Ok((sout2, m)) = spec_serialize_tail(s, x) {
+            assert(n == m);
+            assert(sout.data =~= sout2.data);
+        } else {
+            assert(false);
+        }
+    }
+}
+
+} // verus!
 // secret parsers and serializers
-
 verus! {
 
-    #[verifier(opaque)]
-    pub open spec fn prop_sec_parse_exec_spec_equiv<T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-        where
-            P: FnOnce(SecStream) -> SecParseResult<T>,
-            T: DView,
-    {
-        &&& forall |s| #[trigger] exec_parser.requires((s,))
-        &&& forall |s, res| #[trigger] exec_parser.ensures((s,), res) ==> prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser)
+#[verifier(opaque)]
+pub open spec fn prop_sec_parse_exec_spec_equiv<T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool where P: FnOnce(SecStream) -> SecParseResult<T>, T: DView {
+    &&& forall|s| #[trigger] exec_parser.requires((s,))
+    &&& forall|s, res| #[trigger]
+        exec_parser.ensures((s,), res) ==> prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser)
+}
+
+#[verifier(opaque)]
+pub open spec fn prop_sec_serialize_exec_spec_equiv<T, P>(
+    exec_serializer: P,
+    spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+) -> bool where P: FnOnce(SecStream, T) -> SecSerializeResult, T: std::fmt::Debug + DView {
+    &&& forall|s, v| #[trigger] exec_serializer.requires((s, v))
+    &&& forall|s, v, res| #[trigger]
+        exec_serializer.ensures((s, v), res) ==> prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            spec_serializer,
+        )
+}
+
+pub proof fn lemma_sec_parse_exec_spec_equiv_on<T, P>(
+    exec_parser: P,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+    s: SecStream,
+    res: SecParseResult<T>,
+) where P: FnOnce(SecStream) -> SecParseResult<T>, T: DView
+    requires
+        prop_sec_parse_exec_spec_equiv(exec_parser, spec_parser),
+        exec_parser.ensures((s,), res),
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser),
+{
+    reveal(prop_sec_parse_exec_spec_equiv);
+}
+
+pub proof fn lemma_sec_serialize_exec_spec_equiv_on<T, P>(
+    exec_serializer: P,
+    spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+    s: SecStream,
+    v: T,
+    res: SecSerializeResult,
+) where P: FnOnce(SecStream, T) -> SecSerializeResult, T: std::fmt::Debug + DView
+    requires
+        prop_sec_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
+        exec_serializer.ensures((s, v), res),
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serializer),
+{
+    reveal(prop_sec_serialize_exec_spec_equiv);
+}
+
+// would be great if Verus supports impl DView<V = SpecStream>
+pub open spec fn prop_sec_parse_exec_spec_equiv_on<T: DView>(
+    s: SecStream,
+    res: SecParseResult<T>,
+    spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
+) -> bool {
+    match spec_parser(s.dview()) {
+        Ok((sout, sn, sx)) => {
+            if let Ok((s, n, x)) = res {
+                &&& s.dview() == sout
+                &&& n == sn
+                &&& x.dview() == sx
+            } else {
+                false
+            }
+        },
+        Err(e) => {
+            if let Err(e2) = res {
+                e == e2
+            } else {
+                false
+            }
+        },
     }
+}
 
-    #[verifier(opaque)]
-    pub open spec fn prop_sec_serialize_exec_spec_equiv<T, P>(
-        exec_serializer: P,
-        spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
-        where
-            P: FnOnce(SecStream, T) -> SecSerializeResult,
-            T: std::fmt::Debug + DView,
-    {
-        &&& forall |s, v| #[trigger] exec_serializer.requires((s, v))
-        &&& forall |s, v, res| #[trigger] exec_serializer.ensures((s, v), res) ==> prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
+pub open spec fn prop_sec_serialize_exec_spec_equiv_on<T: DView>(
+    s: SecStream,
+    v: T,
+    res: SecSerializeResult,
+    spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
+) -> bool where T: std::fmt::Debug + DView {
+    match spec_serializer(s.dview(), v.dview()) {
+        Ok((sout, sn)) => {
+            &&& res.is_ok()
+            &&& res.unwrap().0.dview() == sout
+            &&& res.unwrap().1 == sn
+        },
+        Err(e) => res.is_err() && res.unwrap_err() == e,
     }
+}
 
+} // verus!
+verus! {
 
-    pub proof fn lemma_sec_parse_exec_spec_equiv_on<T, P>(
-        exec_parser: P,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>,
-        s: SecStream, res: SecParseResult<T>)
-        where
-            P: FnOnce(SecStream) -> SecParseResult<T>,
-            T: DView,
-        requires
-            prop_sec_parse_exec_spec_equiv(exec_parser, spec_parser),
-            exec_parser.ensures((s,), res)
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, spec_parser)
-    {
+pub exec fn sec_parse_pair<P1, P2, R1, R2>(
+    exec_parser1: P1,
+    exec_parser2: P2,
+    Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
+    Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
+    s: SecStream,
+) -> (res: SecParseResult<(R1, R2)>) where
+    R1: DView,
+    R2: DView,
+    P1: FnOnce(SecStream) -> SecParseResult<R1>,
+    P2: FnOnce(SecStream) -> SecParseResult<R2>,
+
+    requires
+        prop_sec_parse_exec_spec_equiv(exec_parser1, spec_parser1),
+        prop_sec_parse_exec_spec_equiv(exec_parser2, spec_parser2),
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_pair(spec_parser1, spec_parser2),
+        ),
+        // prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
+
+{
+    proof {
         reveal(prop_sec_parse_exec_spec_equiv);
     }
+    let res1 = exec_parser1(s);
+    proof {
+        lemma_sec_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1);
+    }
+    match res1 {
+        Ok((s1, n1, r1)) => {
+            let res2 = exec_parser2(s1);
+            proof {
+                lemma_sec_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2);
+            }
+            match res2 {
+                Ok((s2, n2, r2)) => {
+                    if n1 > usize::MAX - n2 {
+                        Err(ParseError::IntegerOverflow)
+                    } else {
+                        Ok((s2, n1 + n2, (r1, r2)))
+                    }
+                },
+                Err(e) => Err(e),
+            }
+        },
+        Err(e) => Err(e),
+    }
+}
 
-    pub proof fn lemma_sec_serialize_exec_spec_equiv_on<T, P>(
-        exec_serializer: P,
-        spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult,
-        s: SecStream, v: T, res: SecSerializeResult)
-        where
-            P: FnOnce(SecStream, T) -> SecSerializeResult,
-            T: std::fmt::Debug + DView,
-        requires
-            prop_sec_serialize_exec_spec_equiv(exec_serializer, spec_serializer),
-            exec_serializer.ensures((s, v), res)
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serializer)
-    {
+pub exec fn sec_serialize_pair<S1, S2, T1, T2>(
+    exec_serializer1: S1,
+    exec_serializer2: S2,
+    Ghost(spec_serializer1): Ghost<spec_fn(SpecStream, T1::V) -> SpecSerializeResult>,
+    Ghost(spec_serializer2): Ghost<spec_fn(SpecStream, T2::V) -> SpecSerializeResult>,
+    s: SecStream,
+    v: (T1, T2),
+) -> (res: SecSerializeResult) where
+    S1: FnOnce(SecStream, T1) -> SecSerializeResult,
+    S2: FnOnce(SecStream, T2) -> SecSerializeResult,
+    T1: std::fmt::Debug + DView,
+    T2: std::fmt::Debug + DView,
+
+    requires
+        prop_sec_serialize_exec_spec_equiv(exec_serializer1, spec_serializer1),
+        prop_sec_serialize_exec_spec_equiv(exec_serializer2, spec_serializer2),
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            spec_serialize_pair(spec_serializer1, spec_serializer2),
+        ),
+{
+    proof {
         reveal(prop_sec_serialize_exec_spec_equiv);
     }
-
-
-    // would be great if Verus supports impl DView<V = SpecStream>
-
-    pub open spec fn prop_sec_parse_exec_spec_equiv_on<T: DView>(
-        s: SecStream,
-        res: SecParseResult<T>,
-        spec_parser: spec_fn(SpecStream) -> SpecParseResult<T::V>) -> bool
-    {
-        match spec_parser(s.dview()) {
-            Ok((sout, sn, sx)) => {
-                if let Ok((s, n, x)) = res {
-                    &&& s.dview() == sout
-                    &&& n == sn
-                    &&& x.dview() == sx
-                } else {
-                    false
-                }
-            }
-            Err(e) => {
-                if let Err(e2) = res {
-                    e == e2
-                } else {
-                    false
-                }
-            }
-        }
+    let res1 = exec_serializer1(s, v.0);
+    proof {
+        lemma_sec_serialize_exec_spec_equiv_on(exec_serializer1, spec_serializer1, s, v.0, res1);
     }
-
-    pub open spec fn prop_sec_serialize_exec_spec_equiv_on<T: DView>(
-        s: SecStream,
-        v: T,
-        res: SecSerializeResult,
-        spec_serializer: spec_fn(SpecStream, T::V) -> SpecSerializeResult) -> bool
-        where T: std::fmt::Debug + DView
-    {
-        match spec_serializer(s.dview(), v.dview()) {
-            Ok((sout, sn)) => {
-                &&& res.is_ok()
-                &&& res.unwrap().0.dview() == sout
-                &&& res.unwrap().1 == sn
+    match res1 {
+        Ok((s, n)) => {
+            let res2 = exec_serializer2(s, v.1);
+            proof {
+                lemma_sec_serialize_exec_spec_equiv_on(
+                    exec_serializer2,
+                    spec_serializer2,
+                    s,
+                    v.1,
+                    res2,
+                );
             }
-            Err(e) => res.is_err() && res.unwrap_err() == e
-        }
+            match res2 {
+                Ok((s, m)) => {
+                    if n > usize::MAX - m {
+                        Err(SerializeError::IntegerOverflow)
+                    } else {
+                        Ok((s, n + m))
+                    }
+                },
+                Err(e) => Err(e),
+            }
+        },
+        Err(e) => Err(e),
     }
-
 }
 
-verus! {
-    pub exec fn sec_parse_pair<P1, P2, R1, R2>(
-        exec_parser1: P1,
-        exec_parser2: P2,
-        Ghost(spec_parser1): Ghost<spec_fn(SpecStream) -> SpecParseResult<R1::V>>,
-        Ghost(spec_parser2): Ghost<spec_fn(SpecStream) -> SpecParseResult<R2::V>>,
-        s: SecStream) -> (res: SecParseResult<(R1,R2)>)
-        where
-            R1: DView,
-            R2: DView,
-            P1: FnOnce(SecStream) -> SecParseResult<R1>,
-            P2: FnOnce(SecStream) -> SecParseResult<R2>,
-        requires
-            prop_sec_parse_exec_spec_equiv(exec_parser1, spec_parser1),
-            prop_sec_parse_exec_spec_equiv(exec_parser2, spec_parser2),
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2))
-        // prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
-    {
-        proof { reveal(prop_sec_parse_exec_spec_equiv); }
-        let res1 = exec_parser1(s);
-        proof { lemma_sec_parse_exec_spec_equiv_on(exec_parser1, spec_parser1, s, res1); }
-        match res1 {
-            Ok((s1, n1, r1)) => {
-                let res2 = exec_parser2(s1);
-                proof { lemma_sec_parse_exec_spec_equiv_on(exec_parser2, spec_parser2, s1, res2); }
-                match res2 {
-                    Ok((s2, n2, r2)) => {
-                        if n1 > usize::MAX - n2 {
-                            Err(ParseError::IntegerOverflow)
-                        } else {
-                            Ok((s2, n1 + n2, (r1, r2)))
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-    pub exec fn sec_serialize_pair<S1, S2, T1, T2>(
-        exec_serializer1: S1,
-        exec_serializer2: S2,
-        Ghost(spec_serializer1): Ghost<spec_fn(SpecStream, T1::V) -> SpecSerializeResult>,
-        Ghost(spec_serializer2): Ghost<spec_fn(SpecStream, T2::V) -> SpecSerializeResult>,
-        s: SecStream, v: (T1, T2)) -> (res: SecSerializeResult)
-        where
-            S1: FnOnce(SecStream, T1) -> SecSerializeResult,
-            S2: FnOnce(SecStream, T2) -> SecSerializeResult,
-            T1: std::fmt::Debug + DView,
-            T2: std::fmt::Debug + DView,
-        requires
-            prop_sec_serialize_exec_spec_equiv(exec_serializer1, spec_serializer1),
-            prop_sec_serialize_exec_spec_equiv(exec_serializer2, spec_serializer2),
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, spec_serialize_pair(spec_serializer1, spec_serializer2))
-    {
-        proof { reveal(prop_sec_serialize_exec_spec_equiv); }
-        let res1 = exec_serializer1(s, v.0);
-        proof { lemma_sec_serialize_exec_spec_equiv_on(exec_serializer1, spec_serializer1, s, v.0, res1); }
-        match res1 {
-            Ok((s, n)) => {
-                let res2 = exec_serializer2(s, v.1);
-                proof { lemma_sec_serialize_exec_spec_equiv_on(exec_serializer2, spec_serializer2, s, v.1, res2); }
-                match res2 {
-                    Ok((s, m)) => {
-                        if n > usize::MAX - m {
-                            Err(SerializeError::IntegerOverflow)
-                        } else {
-                            Ok((s, n + m))
-                        }
-                    }
-                    Err(e) => Err(e),
-                }
-            }
-            Err(e) => Err(e),
-        }
-    }
-
-}
-
+} // verus!
 verus! {
 
-    pub exec fn parse_sec_bytes(s: SecStream, n: usize) -> (res: SecParseResult<SecBytes>)
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else if s.start > usize::MAX - n {
-            Err(ParseError::IntegerOverflow)
-        } else if s.start + n > s.data.length() {
-            Err(ParseError::NotEnoughData)
-        } else {
-            let data = s.data.subrange(s.start, s.start + n);
-            Ok((
-                SecStream {
-                    start: s.start + n,
-                    ..s
-                },
-                n,
-                data,
-            ))
-        }
-    }
-
-    pub exec fn serialize_sec_bytes(s: SecStream, v: SecBytes, n: usize) -> (res: SecSerializeResult)
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_bytes(s, v, n as nat))
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.length() > s.data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != n {
-            Err(SerializeError::BytesLengthMismatch)
-        } else {
-            let mut data = s.data.subrange(0, s.start);
-            let mut rem = s.data.subrange(s.start + n, s.data.length());
-            let mut v = v;
-            data.append(&mut v);
-            data.append(&mut rem);
-            Ok((
-                SecStream {
-                    start: s.start + n,
-                    data,
-                },
-                n,
-            ))
-        }
-    }
-
-    pub exec fn sec_parse_tail(s: SecStream) -> (res: SecParseResult<SecBytes>)
-        ensures
-            prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s))
-    {
-        if s.start < 0 {
-            Err(ParseError::NegativeIndex)
-        } else if s.start > s.data.length() {
-            Err(ParseError::Eof)
-        } else {
-            let n = s.data.length();
-            // data is the rest of the input starting from s.start
-            let data = s.data.subrange(s.start, n);
-            Ok((
-                SecStream {
-                    start: n,
-                    ..s
-                },
-                (n - s.start),
-                data,
-            ))
-        }
-    }
-
-    pub exec fn sec_serialize_tail(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
-        ensures
-            prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_tail(s, v))
-    {
-        if s.start < 0 {
-            Err(SerializeError::NegativeIndex)
-        } else if s.start > usize::MAX - v.length() {
-            Err(SerializeError::IntegerOverflow)
-        } else if s.start + v.length() > s.data.length() {
-            Err(SerializeError::NotEnoughSpace)
-        } else if v.length() != s.data.length() - s.start {
-            Err(SerializeError::TailLengthMismatch)
-        } else {
-            let n = v.length();
-
-            let mut data = s.data.subrange(0, s.start);
-            let mut v = v;
-            data.append(&mut v);
-            Ok((
-                SecStream {
-                    start: s.start + n,
-                    data
-                },
-                n,
-            ))
-        }
-    }
-}
-verus!{
-
-pub open spec fn spec_parse_u8_le_1(s: SpecStream) -> SpecParseResult<u8>
+pub exec fn parse_sec_bytes(s: SecStream, n: usize) -> (res: SecParseResult<SecBytes>)
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_bytes(s, n as nat)),
 {
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else if s.start > usize::MAX - n {
+        Err(ParseError::IntegerOverflow)
+    } else if s.start + n > s.data.length() {
+        Err(ParseError::NotEnoughData)
+    } else {
+        let data = s.data.subrange(s.start, s.start + n);
+        Ok((SecStream { start: s.start + n, ..s }, n, data))
+    }
+}
+
+pub exec fn serialize_sec_bytes(s: SecStream, v: SecBytes, n: usize) -> (res: SecSerializeResult)
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(
+            s,
+            v,
+            res,
+            |s, v| spec_serialize_bytes(s, v, n as nat),
+        ),
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.length() > s.data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != n {
+        Err(SerializeError::BytesLengthMismatch)
+    } else {
+        let mut data = s.data.subrange(0, s.start);
+        let mut rem = s.data.subrange(s.start + n, s.data.length());
+        let mut v = v;
+        data.append(&mut v);
+        data.append(&mut rem);
+        Ok((SecStream { start: s.start + n, data }, n))
+    }
+}
+
+pub exec fn sec_parse_tail(s: SecStream) -> (res: SecParseResult<SecBytes>)
+    ensures
+        prop_sec_parse_exec_spec_equiv_on(s, res, |s| spec_parse_tail(s)),
+{
+    if s.start < 0 {
+        Err(ParseError::NegativeIndex)
+    } else if s.start > s.data.length() {
+        Err(ParseError::Eof)
+    } else {
+        let n = s.data.length();
+        // data is the rest of the input starting from s.start
+        let data = s.data.subrange(s.start, n);
+        Ok((SecStream { start: n, ..s }, (n - s.start), data))
+    }
+}
+
+pub exec fn sec_serialize_tail(s: SecStream, v: SecBytes) -> (res: SecSerializeResult)
+    ensures
+        prop_sec_serialize_exec_spec_equiv_on(s, v, res, |s, v| spec_serialize_tail(s, v)),
+{
+    if s.start < 0 {
+        Err(SerializeError::NegativeIndex)
+    } else if s.start > usize::MAX - v.length() {
+        Err(SerializeError::IntegerOverflow)
+    } else if s.start + v.length() > s.data.length() {
+        Err(SerializeError::NotEnoughSpace)
+    } else if v.length() != s.data.length() - s.start {
+        Err(SerializeError::TailLengthMismatch)
+    } else {
+        let n = v.length();
+
+        let mut data = s.data.subrange(0, s.start);
+        let mut v = v;
+        data.append(&mut v);
+        Ok((SecStream { start: s.start + n, data }, n))
+    }
+}
+
+} // verus!
+verus! {
+
+pub open spec fn spec_parse_u8_le_1(s: SpecStream) -> SpecParseResult<u8> {
     match spec_parse_u8_le(s) {
         Ok((s, n, v)) => {
             if v == 1 {
@@ -4049,13 +4571,12 @@ pub open spec fn spec_parse_u8_le_1(s: SpecStream) -> SpecParseResult<u8>
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_u8_le_1(s: SpecStream, v: u8) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_u8_le_1(s: SpecStream, v: u8) -> SpecSerializeResult {
     if v == 1 {
         spec_serialize_u8_le(s, v)
     } else {
@@ -4065,7 +4586,7 @@ pub open spec fn spec_serialize_u8_le_1(s: SpecStream, v: u8) -> SpecSerializeRe
 
 pub exec fn parse_u8_le_1(s: Stream) -> (res: ParseResult<u8>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_1(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_1(s)),
 {
     let (s, n, v) = parse_u8_le(s)?;
     if v == 1 {
@@ -4077,7 +4598,14 @@ pub exec fn parse_u8_le_1(s: Stream) -> (res: ParseResult<u8>)
 
 pub exec fn serialize_u8_le_1(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u8_le_1(s, v))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u8_le_1(s, v),
+        ),
 {
     if v == 1 {
         serialize_u8_le(data, start, v)
@@ -4088,84 +4616,91 @@ pub exec fn serialize_u8_le_1(data: &mut [u8], start: usize, v: u8) -> (res: Ser
 
 pub proof fn lemma_parse_u8_le_1_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_u8_le_1(s))
+        prop_parse_well_behaved(|s| spec_parse_u8_le_1(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_1, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_1, s) by {
         lemma_parse_u8_le_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_1_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_1(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_1(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_1, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_1, s, v) by {
         lemma_serialize_u8_le_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_1_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_1(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_1(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u8_le_1, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u8_le_1, s1, s2, v) by {
         lemma_serialize_u8_le_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_1_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_u8_le_1(s))
+        prop_parse_strong_prefix(|s| spec_parse_u8_le_1(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_1, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_1, s1, s2) by {
         lemma_parse_u8_le_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_u8_le_1_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_u8_le_1(s), |s, v| spec_serialize_u8_le_1(s, v))
+        prop_parse_correct(|s| spec_parse_u8_le_1(s), |s, v| spec_serialize_u8_le_1(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u8_le_1, spec_serialize_u8_le_1, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u8_le_1, spec_serialize_u8_le_1, s, v) by {
         lemma_parse_u8_le_correct_on(s, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_1_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_u8_le_1(s), |s, v| spec_serialize_u8_le_1(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_u8_le_1(s),
+            |s, v| spec_serialize_u8_le_1(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u8_le_1, spec_serialize_u8_le_1, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u8_le_1, spec_serialize_u8_le_1, s) by {
         lemma_parse_u8_le_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_u8_le_1_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_u8_le_1(s))
+        prop_parse_nonmalleable(|s| spec_parse_u8_le_1(s)),
 {
     lemma_parse_u8_le_1_serialize_inverse();
     lemma_serialize_u8_le_1_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u8_le_1(s), |s, v| spec_serialize_u8_le_1(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u8_le_1(s),
+        |s, v| spec_serialize_u8_le_1(s, v),
+    );
 }
 
-
-pub open spec fn spec_parse_3_bytes_5058554103549626993(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_3_bytes_5058554103549626993(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     match spec_parse_bytes(s, 3) {
         Ok((s, n, xs)) => {
             if xs == seq![0u8, 0u8, 0u8] {
@@ -4173,13 +4708,15 @@ pub open spec fn spec_parse_3_bytes_5058554103549626993(s: SpecStream) -> SpecPa
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_3_bytes_5058554103549626993(s: SpecStream, vs: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_3_bytes_5058554103549626993(
+    s: SpecStream,
+    vs: Seq<u8>,
+) -> SpecSerializeResult {
     if vs == seq![0u8, 0u8, 0u8] {
         spec_serialize_bytes(s, vs, 3)
     } else {
@@ -4187,65 +4724,95 @@ pub open spec fn spec_serialize_3_bytes_5058554103549626993(s: SpecStream, vs: S
     }
 }
 
-
 pub proof fn lemma_parse_3_bytes_5058554103549626993_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_3_bytes_5058554103549626993(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_3_bytes_5058554103549626993(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_3_bytes_5058554103549626993, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_well_behaved_on(spec_parse_3_bytes_5058554103549626993, s) by {
         lemma_parse_3_bytes_5058554103549626993_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_3_bytes_5058554103549626993_well_behaved()
-    ensures prop_serialize_well_behaved(|s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs))
+    ensures
+        prop_serialize_well_behaved(|s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs)),
 {
     reveal(prop_serialize_well_behaved);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs);
-    assert forall |s, vs| #[trigger] prop_serialize_well_behaved_on(spec_serialize_3_bytes_5058554103549626993, s, vs) by {
+    let spec_serialize_3_bytes_5058554103549626993 = |s, vs|
+        spec_serialize_3_bytes_5058554103549626993(s, vs);
+    assert forall|s, vs| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_3_bytes_5058554103549626993, s, vs) by {
         lemma_serialize_3_bytes_5058554103549626993_well_behaved_on(s, vs);
     }
 }
 
 pub proof fn lemma_serialize_3_bytes_5058554103549626993_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_3_bytes_5058554103549626993(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_3_bytes_5058554103549626993(s, v)),
 {
     reveal(prop_serialize_deterministic);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_3_bytes_5058554103549626993, s1, s2, v) by {
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_3_bytes_5058554103549626993, s1, s2, v) by {
         lemma_serialize_3_bytes_5058554103549626993_deterministic_on(s1, s2, v);
     }
 }
 
 pub proof fn lemma_parse_3_bytes_5058554103549626993_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_3_bytes_5058554103549626993(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_3_bytes_5058554103549626993(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
-    assert forall |s1: SpecStream, s2: SpecStream| prop_parse_strong_prefix_on(spec_parse_3_bytes_5058554103549626993, s1, s2) by {
+    assert forall|s1: SpecStream, s2: SpecStream|
+        prop_parse_strong_prefix_on(spec_parse_3_bytes_5058554103549626993, s1, s2) by {
         lemma_parse_3_bytes_5058554103549626993_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_3_bytes_5058554103549626993_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_3_bytes_5058554103549626993(s), |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs))
+    ensures
+        prop_parse_serialize_inverse(
+            |s| spec_parse_3_bytes_5058554103549626993(s),
+            |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_3_bytes_5058554103549626993, spec_serialize_3_bytes_5058554103549626993, s) by {
+    let spec_serialize_3_bytes_5058554103549626993 = |s, vs|
+        spec_serialize_3_bytes_5058554103549626993(s, vs);
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(
+            spec_parse_3_bytes_5058554103549626993,
+            spec_serialize_3_bytes_5058554103549626993,
+            s,
+        ) by {
         lemma_parse_3_bytes_5058554103549626993_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_3_bytes_5058554103549626993_correct()
-    ensures prop_parse_correct(|s| spec_parse_3_bytes_5058554103549626993(s), |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs))
+    ensures
+        prop_parse_correct(
+            |s| spec_parse_3_bytes_5058554103549626993(s),
+            |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs),
+        ),
 {
     reveal(prop_parse_correct);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs);
-    assert forall |s: SpecStream, vs| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_3_bytes_5058554103549626993, spec_serialize_3_bytes_5058554103549626993, s, vs) by {
+    let spec_serialize_3_bytes_5058554103549626993 = |s, vs|
+        spec_serialize_3_bytes_5058554103549626993(s, vs);
+    assert forall|s: SpecStream, vs|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_3_bytes_5058554103549626993,
+            spec_serialize_3_bytes_5058554103549626993,
+            s,
+            vs,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_3_bytes_5058554103549626993_correct_on(s, vs);
         }
@@ -4253,45 +4820,76 @@ pub proof fn lemma_parse_3_bytes_5058554103549626993_correct()
 }
 
 proof fn lemma_parse_3_bytes_5058554103549626993_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_3_bytes_5058554103549626993(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_3_bytes_5058554103549626993(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 3)
 }
 
 proof fn lemma_serialize_3_bytes_5058554103549626993_well_behaved_on(s: SpecStream, vs: Seq<u8>)
-    ensures prop_serialize_well_behaved_on(|s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs), s, vs)
+    ensures
+        prop_serialize_well_behaved_on(
+            |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs),
+            s,
+            vs,
+        ),
 {
     lemma_serialize_bytes_well_behaved_on(s, vs, 3)
 }
 
-proof fn lemma_serialize_3_bytes_5058554103549626993_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_3_bytes_5058554103549626993(s, v), s1, s2, v)
+proof fn lemma_serialize_3_bytes_5058554103549626993_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: Seq<u8>,
+)
+    ensures
+        prop_serialize_deterministic_on(
+            |s, v| spec_serialize_3_bytes_5058554103549626993(s, v),
+            s1,
+            s2,
+            v,
+        ),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 3)
 }
 
 proof fn lemma_parse_3_bytes_5058554103549626993_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_3_bytes_5058554103549626993(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_3_bytes_5058554103549626993(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 3)
 }
 
 proof fn lemma_parse_3_bytes_5058554103549626993_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_3_bytes_5058554103549626993(s), |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_3_bytes_5058554103549626993(s),
+            |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 3)
 }
 
 proof fn lemma_parse_3_bytes_5058554103549626993_correct_on(s: SpecStream, vs: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_3_bytes_5058554103549626993(s), |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs), s, vs)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(
+            |s| spec_parse_3_bytes_5058554103549626993(s),
+            |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs),
+            s,
+            vs,
+        ),
 {
     lemma_parse_bytes_correct_on(s, vs, 3)
 }
 
-pub exec fn slice_u8_check_5058554103549626993(xs : &[u8]) -> (res : bool)
-    requires xs.dview().len() == 3
-    ensures res <==> xs.dview() == seq![0u8, 0u8, 0u8]
+pub exec fn slice_u8_check_5058554103549626993(xs: &[u8]) -> (res: bool)
+    requires
+        xs.dview().len() == 3,
+    ensures
+        res <==> xs.dview() == seq![0u8, 0u8, 0u8],
 {
     let constant: [u8; 3] = [0u8, 0u8, 0u8];
     assert(constant.view() =~= seq![0u8, 0u8, 0u8]);
@@ -4306,7 +4904,9 @@ pub exec fn slice_u8_check_5058554103549626993(xs : &[u8]) -> (res : bool)
         let (constant_i, xi) = (*array_index_get(&constant, i), *slice_index_get(&xs, i));
         if constant_i == xi {
             i = i + 1;
-            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(xi));
+            assert(xs.dview().subrange(0, i as int) =~= xs.dview().subrange(0, i as int - 1).push(
+                xi,
+            ));
         } else {
             return false;
         }
@@ -4314,14 +4914,13 @@ pub exec fn slice_u8_check_5058554103549626993(xs : &[u8]) -> (res : bool)
     assert(xs.dview() =~= seq![0u8, 0u8, 0u8]) by {
         assert(xs.dview().subrange(0, 3) =~= xs.dview());
     }
-
     true
 }
 
 pub exec fn parse_3_bytes_5058554103549626993(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
         prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_3_bytes_5058554103549626993(s)),
-        res.is_ok() ==> res.unwrap().2.dview() == seq![0u8, 0u8, 0u8]
+        res.is_ok() ==> res.unwrap().2.dview() == seq![0u8, 0u8, 0u8],
 {
     let (s0, n, xs) = parse_bytes(s, 3)?;
     assert(xs.dview().len() == 3);
@@ -4333,9 +4932,17 @@ pub exec fn parse_3_bytes_5058554103549626993(s: Stream) -> (res: ParseResult<&[
     }
 }
 
-pub exec fn serialize_3_bytes_5058554103549626993(data: &mut [u8], start: usize, vs: &[u8]) -> (res: SerializeResult)
+pub exec fn serialize_3_bytes_5058554103549626993(data: &mut [u8], start: usize, vs: &[u8]) -> (res:
+    SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), vs.dview(), res, |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            vs.dview(),
+            res,
+            |s, vs| spec_serialize_3_bytes_5058554103549626993(s, vs),
+        ),
 {
     if vs.length() == 3 && slice_u8_check_5058554103549626993(vs) {
         serialize_bytes(data, start, vs, 3)
@@ -4344,68 +4951,73 @@ pub exec fn serialize_3_bytes_5058554103549626993(data: &mut [u8], start: usize,
     }
 }
 
-pub open spec fn spec_parse_4_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_4_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 4)
 }
 
-pub open spec fn spec_serialize_4_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_4_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 4)
 }
 
 pub proof fn lemma_parse_4_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_4_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_4_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_4_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_4_bytes, s) by {
         lemma_parse_4_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_4_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_4_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_4_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_4_bytes, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_4_bytes, s, v) by {
         lemma_serialize_4_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_4_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_4_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_4_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_4_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_4_bytes, s1, s2, v) by {
         lemma_serialize_4_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_4_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_4_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_4_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_4_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_4_bytes, s1, s2) by {
         lemma_parse_4_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_4_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_4_bytes, spec_serialize_4_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_4_bytes,
+            spec_serialize_4_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_4_bytes_correct_on(s, v)
         }
@@ -4414,145 +5026,169 @@ pub proof fn lemma_parse_4_bytes_correct()
 
 pub proof fn lemma_parse_4_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_4_bytes(s),
+            |s, v| spec_serialize_4_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_4_bytes, spec_serialize_4_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_4_bytes, spec_serialize_4_bytes, s) by {
         lemma_parse_4_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_4_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_4_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_4_bytes(s)),
 {
     lemma_parse_4_bytes_serialize_inverse();
     lemma_serialize_4_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_4_bytes(s),
+        |s, v| spec_serialize_4_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_4_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_4_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_4_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 4);
 }
 
 proof fn lemma_serialize_4_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_4_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_4_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 4);
 }
 
 proof fn lemma_serialize_4_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_4_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_4_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 4);
 }
 
 proof fn lemma_parse_4_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_4_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_4_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 4);
 }
 
 proof fn lemma_parse_4_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v), s, v)
+        prop_parse_correct_on(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v), s, v),
 {
     lemma_parse_bytes_correct_on(s, v, 4);
 }
 
 proof fn lemma_parse_4_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_4_bytes(s), |s, v| spec_serialize_4_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_4_bytes(s),
+            |s, v| spec_serialize_4_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 4);
 }
 
 pub exec fn parse_4_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_4_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_4_bytes(s)),
 {
     parse_bytes(s, 4)
 }
+
 pub exec fn serialize_4_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 4 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 4 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 4)
 }
 
-            
-pub open spec fn spec_parse_32_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_32_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 32)
 }
 
-pub open spec fn spec_serialize_32_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_32_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 32)
 }
 
 pub proof fn lemma_parse_32_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_32_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_32_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_32_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_32_bytes, s) by {
         lemma_parse_32_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_32_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_32_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_32_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_32_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_32_bytes, s, v) by {
         lemma_serialize_32_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_32_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_32_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_32_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_32_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_32_bytes, s1, s2, v) by {
         lemma_serialize_32_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_32_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_32_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_32_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_32_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_32_bytes, s1, s2) by {
         lemma_parse_32_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_32_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_32_bytes, spec_serialize_32_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_32_bytes,
+            spec_serialize_32_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_32_bytes_correct_on(s, v)
         }
@@ -4561,145 +5197,174 @@ pub proof fn lemma_parse_32_bytes_correct()
 
 pub proof fn lemma_parse_32_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_32_bytes(s),
+            |s, v| spec_serialize_32_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_32_bytes, spec_serialize_32_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_32_bytes, spec_serialize_32_bytes, s) by {
         lemma_parse_32_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_32_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_32_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_32_bytes(s)),
 {
     lemma_parse_32_bytes_serialize_inverse();
     lemma_serialize_32_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_32_bytes(s),
+        |s, v| spec_serialize_32_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_32_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_32_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_32_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 32);
 }
 
 proof fn lemma_serialize_32_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_32_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_32_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 32);
 }
 
 proof fn lemma_serialize_32_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_32_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_32_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 32);
 }
 
 proof fn lemma_parse_32_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_32_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_32_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 32);
 }
 
 proof fn lemma_parse_32_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_32_bytes(s),
+            |s, v| spec_serialize_32_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 32);
 }
 
 proof fn lemma_parse_32_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_32_bytes(s), |s, v| spec_serialize_32_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_32_bytes(s),
+            |s, v| spec_serialize_32_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 32);
 }
 
 pub exec fn parse_32_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_32_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_32_bytes(s)),
 {
     parse_bytes(s, 32)
 }
+
 pub exec fn serialize_32_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 32 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 32 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 32)
 }
 
-            
-pub open spec fn spec_parse_48_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_48_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 48)
 }
 
-pub open spec fn spec_serialize_48_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_48_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 48)
 }
 
 pub proof fn lemma_parse_48_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_48_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_48_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_48_bytes = |s| spec_parse_48_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_48_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_48_bytes, s) by {
         lemma_parse_48_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_48_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_48_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_48_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_48_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_48_bytes, s, v) by {
         lemma_serialize_48_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_48_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_48_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_48_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_48_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_48_bytes, s1, s2, v) by {
         lemma_serialize_48_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_48_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_48_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_48_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_48_bytes = |s| spec_parse_48_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_48_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_48_bytes, s1, s2) by {
         lemma_parse_48_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_48_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_48_bytes(s), |s, v| spec_serialize_48_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_48_bytes(s), |s, v| spec_serialize_48_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_48_bytes = |s| spec_parse_48_bytes(s);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_48_bytes, spec_serialize_48_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_48_bytes,
+            spec_serialize_48_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_48_bytes_correct_on(s, v)
         }
@@ -4708,145 +5373,174 @@ pub proof fn lemma_parse_48_bytes_correct()
 
 pub proof fn lemma_parse_48_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_48_bytes(s), |s, v| spec_serialize_48_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_48_bytes(s),
+            |s, v| spec_serialize_48_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_48_bytes = |s| spec_parse_48_bytes(s);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_48_bytes, spec_serialize_48_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_48_bytes, spec_serialize_48_bytes, s) by {
         lemma_parse_48_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_48_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_48_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_48_bytes(s)),
 {
     lemma_parse_48_bytes_serialize_inverse();
     lemma_serialize_48_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_48_bytes(s), |s, v| spec_serialize_48_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_48_bytes(s),
+        |s, v| spec_serialize_48_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_48_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_48_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_48_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 48);
 }
 
 proof fn lemma_serialize_48_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_48_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_48_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 48);
 }
 
 proof fn lemma_serialize_48_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_48_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_48_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 48);
 }
 
 proof fn lemma_parse_48_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_48_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_48_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 48);
 }
 
 proof fn lemma_parse_48_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_48_bytes(s), |s, v| spec_serialize_48_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_48_bytes(s),
+            |s, v| spec_serialize_48_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 48);
 }
 
 proof fn lemma_parse_48_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_48_bytes(s), |s, v| spec_serialize_48_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_48_bytes(s),
+            |s, v| spec_serialize_48_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 48);
 }
 
 pub exec fn parse_48_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_48_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_48_bytes(s)),
 {
     parse_bytes(s, 48)
 }
+
 pub exec fn serialize_48_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 48 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 48 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 48)
 }
 
-            
-pub open spec fn spec_parse_28_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_28_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 28)
 }
 
-pub open spec fn spec_serialize_28_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_28_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 28)
 }
 
 pub proof fn lemma_parse_28_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_28_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_28_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_28_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_28_bytes, s) by {
         lemma_parse_28_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_28_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_28_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_28_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_28_bytes = |s, v| spec_serialize_28_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_28_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_28_bytes, s, v) by {
         lemma_serialize_28_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_28_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_28_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_28_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_28_bytes = |s, v| spec_serialize_28_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_28_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_28_bytes, s1, s2, v) by {
         lemma_serialize_28_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_28_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_28_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_28_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_28_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_28_bytes, s1, s2) by {
         lemma_parse_28_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_28_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_28_bytes(s), |s, v| spec_serialize_28_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_28_bytes(s), |s, v| spec_serialize_28_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
     let spec_serialize_28_bytes = |s, v| spec_serialize_28_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_28_bytes, spec_serialize_28_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_28_bytes,
+            spec_serialize_28_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_28_bytes_correct_on(s, v)
         }
@@ -4855,145 +5549,174 @@ pub proof fn lemma_parse_28_bytes_correct()
 
 pub proof fn lemma_parse_28_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_28_bytes(s), |s, v| spec_serialize_28_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_28_bytes(s),
+            |s, v| spec_serialize_28_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
     let spec_serialize_28_bytes = |s, v| spec_serialize_28_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_28_bytes, spec_serialize_28_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_28_bytes, spec_serialize_28_bytes, s) by {
         lemma_parse_28_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_28_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_28_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_28_bytes(s)),
 {
     lemma_parse_28_bytes_serialize_inverse();
     lemma_serialize_28_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_28_bytes(s), |s, v| spec_serialize_28_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_28_bytes(s),
+        |s, v| spec_serialize_28_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_28_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_28_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_28_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 28);
 }
 
 proof fn lemma_serialize_28_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_28_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_28_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 28);
 }
 
 proof fn lemma_serialize_28_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_28_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_28_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 28);
 }
 
 proof fn lemma_parse_28_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_28_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_28_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 28);
 }
 
 proof fn lemma_parse_28_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_28_bytes(s), |s, v| spec_serialize_28_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_28_bytes(s),
+            |s, v| spec_serialize_28_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 28);
 }
 
 proof fn lemma_parse_28_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_28_bytes(s), |s, v| spec_serialize_28_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_28_bytes(s),
+            |s, v| spec_serialize_28_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 28);
 }
 
 pub exec fn parse_28_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_28_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_28_bytes(s)),
 {
     parse_bytes(s, 28)
 }
+
 pub exec fn serialize_28_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 28 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 28 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 28)
 }
 
-            
-pub open spec fn spec_parse_16_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>>
-{
+pub open spec fn spec_parse_16_bytes(s: SpecStream) -> SpecParseResult<Seq<u8>> {
     spec_parse_bytes(s, 16)
 }
 
-pub open spec fn spec_serialize_16_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_16_bytes(s: SpecStream, v: Seq<u8>) -> SpecSerializeResult {
     spec_serialize_bytes(s, v, 16)
 }
 
 pub proof fn lemma_parse_16_bytes_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_16_bytes(s))
+        prop_parse_well_behaved(|s| spec_parse_16_bytes(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_16_bytes, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_16_bytes, s) by {
         lemma_parse_16_bytes_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_16_bytes_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_16_bytes(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_16_bytes(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_16_bytes, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_serialize_well_behaved_on(spec_serialize_16_bytes, s, v) by {
         lemma_serialize_16_bytes_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_16_bytes_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_16_bytes(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_16_bytes(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_16_bytes, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_16_bytes, s1, s2, v) by {
         lemma_serialize_16_bytes_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_16_bytes_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_16_bytes(s))
+        prop_parse_strong_prefix(|s| spec_parse_16_bytes(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_16_bytes, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_16_bytes, s1, s2) by {
         lemma_parse_16_bytes_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_16_bytes_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_16_bytes(s), |s, v| spec_serialize_16_bytes(s, v))
+        prop_parse_correct(|s| spec_parse_16_bytes(s), |s, v| spec_serialize_16_bytes(s, v)),
 {
     reveal(prop_parse_correct::<Seq<u8>>);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_16_bytes, spec_serialize_16_bytes, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_16_bytes,
+            spec_serialize_16_bytes,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_16_bytes_correct_on(s, v)
         }
@@ -5002,83 +5725,107 @@ pub proof fn lemma_parse_16_bytes_correct()
 
 pub proof fn lemma_parse_16_bytes_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_16_bytes(s), |s, v| spec_serialize_16_bytes(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_16_bytes(s),
+            |s, v| spec_serialize_16_bytes(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse::<Seq<u8>>);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_16_bytes, spec_serialize_16_bytes, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_16_bytes, spec_serialize_16_bytes, s) by {
         lemma_parse_16_bytes_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_16_bytes_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_16_bytes(s))
+        prop_parse_nonmalleable(|s| spec_parse_16_bytes(s)),
 {
     lemma_parse_16_bytes_serialize_inverse();
     lemma_serialize_16_bytes_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_16_bytes(s), |s, v| spec_serialize_16_bytes(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_16_bytes(s),
+        |s, v| spec_serialize_16_bytes(s, v),
+    );
 }
-
 
 proof fn lemma_parse_16_bytes_well_behaved_on(s: SpecStream)
     ensures
-        prop_parse_well_behaved_on(|s| spec_parse_16_bytes(s), s)
+        prop_parse_well_behaved_on(|s| spec_parse_16_bytes(s), s),
 {
     lemma_parse_bytes_well_behaved_on(s, 16);
 }
 
 proof fn lemma_serialize_16_bytes_well_behaved_on(s: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_well_behaved_on(|s, v| spec_serialize_16_bytes(s, v), s, v)
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_16_bytes(s, v), s, v),
 {
     lemma_serialize_bytes_well_behaved_on(s, v, 16);
 }
 
 proof fn lemma_serialize_16_bytes_deterministic_on(s1: SpecStream, s2: SpecStream, v: Seq<u8>)
     ensures
-        prop_serialize_deterministic_on(|s, v| spec_serialize_16_bytes(s, v), s1, s2, v)
+        prop_serialize_deterministic_on(|s, v| spec_serialize_16_bytes(s, v), s1, s2, v),
 {
     lemma_serialize_bytes_deterministic_on(s1, s2, v, 16);
 }
 
 proof fn lemma_parse_16_bytes_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     ensures
-        prop_parse_strong_prefix_on(|s| spec_parse_16_bytes(s), s1, s2)
+        prop_parse_strong_prefix_on(|s| spec_parse_16_bytes(s), s1, s2),
 {
     lemma_parse_bytes_strong_prefix_on(s1, s2, 16);
 }
 
 proof fn lemma_parse_16_bytes_correct_on(s: SpecStream, v: Seq<u8>)
-    requires s.data.len() <= usize::MAX,
+    requires
+        s.data.len() <= usize::MAX,
     ensures
-        prop_parse_correct_on(|s| spec_parse_16_bytes(s), |s, v| spec_serialize_16_bytes(s, v), s, v)
+        prop_parse_correct_on(
+            |s| spec_parse_16_bytes(s),
+            |s, v| spec_serialize_16_bytes(s, v),
+            s,
+            v,
+        ),
 {
     lemma_parse_bytes_correct_on(s, v, 16);
 }
 
 proof fn lemma_parse_16_bytes_serialize_inverse_on(s: SpecStream)
     ensures
-        prop_parse_serialize_inverse_on(|s| spec_parse_16_bytes(s), |s, v| spec_serialize_16_bytes(s, v), s)
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_16_bytes(s),
+            |s, v| spec_serialize_16_bytes(s, v),
+            s,
+        ),
 {
     lemma_parse_bytes_serialize_inverse_on(s, 16);
 }
 
 pub exec fn parse_16_bytes(s: Stream) -> (res: ParseResult<&[u8]>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_16_bytes(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_16_bytes(s)),
 {
     parse_bytes(s, 16)
 }
+
 pub exec fn serialize_16_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_bytes(s, v, 16 as nat))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_bytes(s, v, 16 as nat),
+        ),
 {
     serialize_bytes(data, start, v, 16)
 }
 
-            pub struct SpecMsg1 {
+pub struct SpecMsg1 {
     ty: u8,
     reserved: Seq<u8>,
     sender: Seq<u8>,
@@ -5087,8 +5834,8 @@ pub exec fn serialize_16_bytes(data: &mut [u8], start: usize, v: &[u8]) -> (res:
     timestamp: Seq<u8>,
     mac1: Seq<u8>,
     mac2: Seq<u8>,
-
 }
+
 pub struct Msg1 {
     ty: u8,
     reserved: Vec<u8>,
@@ -5098,7 +5845,6 @@ pub struct Msg1 {
     timestamp: Vec<u8>,
     mac1: Vec<u8>,
     mac2: Vec<u8>,
-
 }
 
 pub open spec fn spec_parse_8_fold<R1, R2, R3, R4, R5, R6, R7, R8>(
@@ -5109,12 +5855,25 @@ pub open spec fn spec_parse_8_fold<R1, R2, R3, R4, R5, R6, R7, R8>(
     parser5: spec_fn(SpecStream) -> SpecParseResult<R5>,
     parser6: spec_fn(SpecStream) -> SpecParseResult<R6>,
     parser7: spec_fn(SpecStream) -> SpecParseResult<R7>,
-    parser8: spec_fn(SpecStream) -> SpecParseResult<R8>) -> spec_fn(SpecStream) -> SpecParseResult<(((((((R1, R2), R3), R4), R5), R6), R7), R8)>
-{
-    spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4), parser5), parser6), parser7), parser8)
+    parser8: spec_fn(SpecStream) -> SpecParseResult<R8>,
+) -> spec_fn(SpecStream) -> SpecParseResult<(((((((R1, R2), R3), R4), R5), R6), R7), R8)> {
+    spec_parse_pair(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_pair(parser1, parser2), parser3),
+                        parser4,
+                    ),
+                    parser5,
+                ),
+                parser6,
+            ),
+            parser7,
+        ),
+        parser8,
+    )
 }
-
-
 
 pub open spec fn spec_serialize_8_fold<T1, T2, T3, T4, T5, T6, T7, T8>(
     serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
@@ -5124,11 +5883,28 @@ pub open spec fn spec_serialize_8_fold<T1, T2, T3, T4, T5, T6, T7, T8>(
     serializer5: spec_fn(SpecStream, T5) -> SpecSerializeResult,
     serializer6: spec_fn(SpecStream, T6) -> SpecSerializeResult,
     serializer7: spec_fn(SpecStream, T7) -> SpecSerializeResult,
-    serializer8: spec_fn(SpecStream, T8) -> SpecSerializeResult) -> spec_fn(SpecStream, (((((((T1, T2), T3), T4), T5), T6), T7), T8)) -> SpecSerializeResult
-{
-    spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3), serializer4), serializer5), serializer6), serializer7), serializer8)
+    serializer8: spec_fn(SpecStream, T8) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, (((((((T1, T2), T3), T4), T5), T6), T7), T8)) -> SpecSerializeResult {
+    spec_serialize_pair(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(serializer1, serializer2),
+                            serializer3,
+                        ),
+                        serializer4,
+                    ),
+                    serializer5,
+                ),
+                serializer6,
+            ),
+            serializer7,
+        ),
+        serializer8,
+    )
 }
-
 
 pub exec fn parse_8_fold<'a, P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5, R6, R7, R8>(
     exec_parser1: P1,
@@ -5147,8 +5923,8 @@ pub exec fn parse_8_fold<'a, P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5,
     Ghost(spec_parser6): Ghost<spec_fn(SpecStream) -> SpecParseResult<R6::V>>,
     Ghost(spec_parser7): Ghost<spec_fn(SpecStream) -> SpecParseResult<R7::V>>,
     Ghost(spec_parser8): Ghost<spec_fn(SpecStream) -> SpecParseResult<R8::V>>,
-    s: Stream<'a>) -> (res: ParseResult<(((((((R1, R2), R3), R4), R5), R6), R7), R8)>)
-    where
+    s: Stream<'a>,
+) -> (res: ParseResult<(((((((R1, R2), R3), R4), R5), R6), R7), R8)>) where
     R1: DView,
     P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
     R2: DView,
@@ -5165,6 +5941,7 @@ pub exec fn parse_8_fold<'a, P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5,
     P7: FnOnce(Stream<'a>) -> ParseResult<R7>,
     R8: DView,
     P8: FnOnce(Stream<'a>) -> ParseResult<R8>,
+
     requires
         prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
@@ -5175,21 +5952,203 @@ pub exec fn parse_8_fold<'a, P1, P2, P3, P4, P5, P6, P7, P8, R1, R2, R3, R4, R5,
         prop_parse_exec_spec_equiv(exec_parser7, spec_parser7),
         prop_parse_exec_spec_equiv(exec_parser8, spec_parser8),
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, spec_parse_8_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4, spec_parser5, spec_parser6, spec_parser7, spec_parser8))
+        prop_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_8_fold(
+                spec_parser1,
+                spec_parser2,
+                spec_parser3,
+                spec_parser4,
+                spec_parser5,
+                spec_parser6,
+                spec_parser7,
+                spec_parser8,
+            ),
+        ),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), { parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s) };
-    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), { parse_pair(parse_3_fold, exec_parser4, Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), Ghost(spec_parser4), s) };
-    let parse_5_fold = |s| -> (res: ParseResult<((((R1, R2), R3), R4), R5)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5)), { parse_pair(parse_4_fold, exec_parser5, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), Ghost(spec_parser5), s) };
-    let parse_6_fold = |s| -> (res: ParseResult<(((((R1, R2), R3), R4), R5), R6)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5), spec_parser6)), { parse_pair(parse_5_fold, exec_parser6, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5)), Ghost(spec_parser6), s) };
-    let parse_7_fold = |s| -> (res: ParseResult<((((((R1, R2), R3), R4), R5), R6), R7)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5), spec_parser6), spec_parser7)), { parse_pair(parse_6_fold, exec_parser7, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5), spec_parser6)), Ghost(spec_parser7), s) };
-    parse_pair(parse_7_fold, exec_parser8, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4), spec_parser5), spec_parser6), spec_parser7)), Ghost(spec_parser8), s)
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+            ),
+        {
+            parse_pair(
+                parse_2_fold,
+                exec_parser3,
+                Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+                Ghost(spec_parser3),
+                s,
+            )
+        };
+    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                    spec_parser4,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_3_fold,
+                exec_parser4,
+                Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)),
+                Ghost(spec_parser4),
+                s,
+            )
+        };
+    let parse_5_fold = |s| -> (res: ParseResult<((((R1, R2), R3), R4), R5)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                        spec_parser4,
+                    ),
+                    spec_parser5,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_4_fold,
+                exec_parser5,
+                Ghost(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                        spec_parser4,
+                    ),
+                ),
+                Ghost(spec_parser5),
+                s,
+            )
+        };
+    let parse_6_fold = |s| -> (res: ParseResult<(((((R1, R2), R3), R4), R5), R6)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_pair(spec_parser1, spec_parser2),
+                                spec_parser3,
+                            ),
+                            spec_parser4,
+                        ),
+                        spec_parser5,
+                    ),
+                    spec_parser6,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_5_fold,
+                exec_parser6,
+                Ghost(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_pair(spec_parser1, spec_parser2),
+                                spec_parser3,
+                            ),
+                            spec_parser4,
+                        ),
+                        spec_parser5,
+                    ),
+                ),
+                Ghost(spec_parser6),
+                s,
+            )
+        };
+    let parse_7_fold = |s| -> (res: ParseResult<((((((R1, R2), R3), R4), R5), R6), R7)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_pair(
+                                    spec_parse_pair(spec_parser1, spec_parser2),
+                                    spec_parser3,
+                                ),
+                                spec_parser4,
+                            ),
+                            spec_parser5,
+                        ),
+                        spec_parser6,
+                    ),
+                    spec_parser7,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_6_fold,
+                exec_parser7,
+                Ghost(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_pair(
+                                    spec_parse_pair(spec_parser1, spec_parser2),
+                                    spec_parser3,
+                                ),
+                                spec_parser4,
+                            ),
+                            spec_parser5,
+                        ),
+                        spec_parser6,
+                    ),
+                ),
+                Ghost(spec_parser7),
+                s,
+            )
+        };
+    parse_pair(
+        parse_7_fold,
+        exec_parser8,
+        Ghost(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_pair(spec_parser1, spec_parser2),
+                                spec_parser3,
+                            ),
+                            spec_parser4,
+                        ),
+                        spec_parser5,
+                    ),
+                    spec_parser6,
+                ),
+                spec_parser7,
+            ),
+        ),
+        Ghost(spec_parser8),
+        s,
+    )
 }
 
-
-pub open spec fn spec_parse_msg1(s: SpecStream) -> SpecParseResult<(((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>)>
-{
+pub open spec fn spec_parse_msg1(s: SpecStream) -> SpecParseResult<
+    (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+> {
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
@@ -5198,59 +6157,91 @@ pub open spec fn spec_parse_msg1(s: SpecStream) -> SpecParseResult<(((((((u8, Se
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
 
-    spec_parse_8_fold(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993, spec_parse_4_bytes, spec_parse_32_bytes, spec_parse_48_bytes, spec_parse_28_bytes, spec_parse_16_bytes, spec_parse_16_bytes)(s)
+    spec_parse_8_fold(
+        spec_parse_u8_le_1,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_parse_4_bytes,
+        spec_parse_32_bytes,
+        spec_parse_48_bytes,
+        spec_parse_28_bytes,
+        spec_parse_16_bytes,
+        spec_parse_16_bytes,
+    )(s)
 }
 
-pub open spec fn spec_serialize_msg1(s: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_msg1(
+    s: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
     let spec_serialize_28_bytes = |s, v| spec_serialize_28_bytes(s, v);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
 
-    spec_serialize_8_fold(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993, spec_serialize_4_bytes, spec_serialize_32_bytes, spec_serialize_48_bytes, spec_serialize_28_bytes, spec_serialize_16_bytes, spec_serialize_16_bytes)(s, v)
+    spec_serialize_8_fold(
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+        spec_serialize_4_bytes,
+        spec_serialize_32_bytes,
+        spec_serialize_48_bytes,
+        spec_serialize_28_bytes,
+        spec_serialize_16_bytes,
+        spec_serialize_16_bytes,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_msg1_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_msg1(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_msg1(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_msg1 = |s| spec_parse_msg1(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_msg1, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_msg1, s) by {
         lemma_parse_msg1_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_msg1_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_msg1(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_msg1(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_msg1 = |s, v| spec_serialize_msg1(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_msg1, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_msg1, s, v) by {
         lemma_serialize_msg1_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_msg1_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_msg1(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_msg1(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_msg1 = |s, v| spec_serialize_msg1(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_msg1, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_msg1, s1, s2, v) by {
         lemma_serialize_msg1_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_msg1_correct()
-    ensures prop_parse_correct(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_msg1 = |s| spec_parse_msg1(s);
     let spec_serialize_msg1 = |s, v| spec_serialize_msg1(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_msg1, spec_serialize_msg1, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_msg1,
+            spec_serialize_msg1,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_msg1_correct_on(s, v);
         }
@@ -5258,26 +6249,33 @@ pub proof fn lemma_parse_msg1_correct()
 }
 
 pub proof fn lemma_parse_msg1_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v))
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v)),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_msg1 = |s| spec_parse_msg1(s);
     let spec_serialize_msg1 = |s, v| spec_serialize_msg1(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_msg1, spec_serialize_msg1, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_msg1, spec_serialize_msg1, s) by {
         lemma_parse_msg1_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_msg1_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_msg1(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_msg1(s)),
 {
     lemma_parse_msg1_serialize_inverse();
     lemma_serialize_msg1_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_msg1(s),
+        |s, v| spec_serialize_msg1(s, v),
+    );
 }
 
 pub proof fn lemma_parse_msg1_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_msg1(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_msg1(s), s),
 {
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5294,19 +6292,91 @@ pub proof fn lemma_parse_msg1_well_behaved_on(s: SpecStream)
     lemma_parse_28_bytes_well_behaved();
     lemma_parse_16_bytes_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes), spec_parse_16_bytes, s);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_1,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_32_bytes,
+                    ),
+                    spec_parse_48_bytes,
+                ),
+                spec_parse_28_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_msg1_well_behaved_on(s: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_msg1(s, v), s, v)
+pub proof fn lemma_serialize_msg1_well_behaved_on(
+    s: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_msg1(s, v), s, v),
 {
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
@@ -5319,20 +6389,106 @@ pub proof fn lemma_serialize_msg1_well_behaved_on(s: SpecStream, v: (((((((u8, S
     lemma_serialize_48_bytes_well_behaved();
     lemma_serialize_28_bytes_well_behaved();
     lemma_serialize_16_bytes_well_behaved();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_1,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_32_bytes,
+                    ),
+                    spec_serialize_48_bytes,
+                ),
+                spec_serialize_28_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_msg1_deterministic_on(s1: SpecStream, s2: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_msg1(s, v), s1, s2, v)
+pub proof fn lemma_serialize_msg1_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_msg1(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
@@ -5352,24 +6508,167 @@ pub proof fn lemma_serialize_msg1_deterministic_on(s1: SpecStream, s2: SpecStrea
     lemma_serialize_48_bytes_deterministic();
     lemma_serialize_28_bytes_deterministic();
     lemma_serialize_16_bytes_deterministic();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_deterministic(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_1,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_32_bytes,
+                    ),
+                    spec_serialize_48_bytes,
+                ),
+                spec_serialize_28_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s1,
+        s2,
+        v,
+    );
 }
 
-pub proof fn lemma_parse_msg1_correct_on(s: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v), s, v)
+pub proof fn lemma_parse_msg1_correct_on(
+    s: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v), s, v),
 {
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5379,7 +6678,8 @@ pub proof fn lemma_parse_msg1_correct_on(s: SpecStream, v: (((((((u8, Seq<u8>), 
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
@@ -5414,34 +6714,328 @@ pub proof fn lemma_parse_msg1_correct_on(s: SpecStream, v: (((((((u8, Seq<u8>), 
     lemma_parse_28_bytes_correct();
     lemma_parse_16_bytes_correct();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
     lemma_parse_pair_strong_prefix(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_correct(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993, spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u8_le_1,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_1,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_32_bytes,
+                    ),
+                    spec_parse_48_bytes,
+                ),
+                spec_parse_28_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_1,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_32_bytes,
+                    ),
+                    spec_serialize_48_bytes,
+                ),
+                spec_serialize_28_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_msg1_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_msg1(s), |s, v| spec_serialize_msg1(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_msg1(s),
+            |s, v| spec_serialize_msg1(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5451,7 +7045,8 @@ pub proof fn lemma_parse_msg1_serialize_inverse_on(s: SpecStream)
     let spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
     let spec_serialize_u8_le_1 = |s, v| spec_serialize_u8_le_1(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_48_bytes = |s, v| spec_serialize_48_bytes(s, v);
@@ -5479,38 +7074,283 @@ pub proof fn lemma_parse_msg1_serialize_inverse_on(s: SpecStream)
     lemma_parse_28_bytes_serialize_inverse();
     lemma_parse_16_bytes_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_serialize_inverse(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993, spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_48_bytes), spec_serialize_28_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u8_le_1,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_serialize_u8_le_1,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+        spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_1, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_1,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_48_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_1,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_48_bytes,
+        ),
+        spec_serialize_28_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_1,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_48_bytes,
+            ),
+            spec_serialize_28_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_1,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_32_bytes,
+                    ),
+                    spec_parse_48_bytes,
+                ),
+                spec_parse_28_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_1,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_32_bytes,
+                    ),
+                    spec_serialize_48_bytes,
+                ),
+                spec_serialize_28_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_msg1_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_msg1(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_msg1(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_msg1 = |s| spec_parse_msg1(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_msg1, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_msg1, s1, s2) by {
         lemma_parse_msg1_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_msg1_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_msg1(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_msg1(s), s1, s2),
 {
     let spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5535,59 +7375,221 @@ pub proof fn lemma_parse_msg1_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     lemma_parse_16_bytes_strong_prefix();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_strong_prefix_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_48_bytes), spec_parse_28_bytes), spec_parse_16_bytes), spec_parse_16_bytes, s1, s2);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_48_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_48_bytes,
+        ),
+        spec_parse_28_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_1, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_48_bytes,
+            ),
+            spec_parse_28_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_1,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_32_bytes,
+                    ),
+                    spec_parse_48_bytes,
+                ),
+                spec_parse_28_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        s1,
+        s2,
+    );
 }
 
-pub exec fn parse_msg1(s: Stream) -> (res: ParseResult<(((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8])>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_msg1(s))
+pub exec fn parse_msg1(s: Stream) -> (res: ParseResult<
+    (((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]),
+>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_msg1(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le_1 = |s| spec_parse_u8_le_1(s);
-    let ghost spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
+    let ghost spec_parse_3_bytes_5058554103549626993 = |s|
+        spec_parse_3_bytes_5058554103549626993(s);
     let ghost spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let ghost spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let ghost spec_parse_48_bytes = |s| spec_parse_48_bytes(s);
     let ghost spec_parse_28_bytes = |s| spec_parse_28_bytes(s);
     let ghost spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
 
-    parse_8_fold(parse_u8_le_1, parse_3_bytes_5058554103549626993, parse_4_bytes, parse_32_bytes, parse_48_bytes, parse_28_bytes, parse_16_bytes, parse_16_bytes, Ghost(spec_parse_u8_le_1), Ghost(spec_parse_3_bytes_5058554103549626993), Ghost(spec_parse_4_bytes), Ghost(spec_parse_32_bytes), Ghost(spec_parse_48_bytes), Ghost(spec_parse_28_bytes), Ghost(spec_parse_16_bytes), Ghost(spec_parse_16_bytes), s)
+    parse_8_fold(
+        parse_u8_le_1,
+        parse_3_bytes_5058554103549626993,
+        parse_4_bytes,
+        parse_32_bytes,
+        parse_48_bytes,
+        parse_28_bytes,
+        parse_16_bytes,
+        parse_16_bytes,
+        Ghost(spec_parse_u8_le_1),
+        Ghost(spec_parse_3_bytes_5058554103549626993),
+        Ghost(spec_parse_4_bytes),
+        Ghost(spec_parse_32_bytes),
+        Ghost(spec_parse_48_bytes),
+        Ghost(spec_parse_28_bytes),
+        Ghost(spec_parse_16_bytes),
+        Ghost(spec_parse_16_bytes),
+        s,
+    )
 }
-pub exec fn serialize_msg1(data: &mut [u8], start: usize, v: (((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8])) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_msg1(s, v))
+
+pub exec fn serialize_msg1(
+    data: &mut [u8],
+    start: usize,
+    v: (((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]),
+) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_msg1(s, v),
+        ),
 {
     let (((((((v0, v1), v2), v3), v4), v5), v6), v7) = v;
     let (new_start, n0) = serialize_u8_le_1(data, start, v0)?;
 
-let (new_start, n1) = serialize_3_bytes_5058554103549626993(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_4_bytes(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n3) = serialize_32_bytes(data, new_start, v3)?;
-    if n0 + n1 + n2 > usize::MAX - n3 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n4) = serialize_48_bytes(data, new_start, v4)?;
-    if n0 + n1 + n2 + n3 > usize::MAX - n4 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n5) = serialize_28_bytes(data, new_start, v5)?;
-    if n0 + n1 + n2 + n3 + n4 > usize::MAX - n5 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n6) = serialize_16_bytes(data, new_start, v6)?;
-    if n0 + n1 + n2 + n3 + n4 + n5 > usize::MAX - n6 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n7) = serialize_16_bytes(data, new_start, v7)?;
-    if n0 + n1 + n2 + n3 + n4 + n5 + n6 > usize::MAX - n7 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_3_bytes_5058554103549626993(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_4_bytes(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n3) = serialize_32_bytes(data, new_start, v3)?;
+    if n0 + n1 + n2 > usize::MAX - n3 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n4) = serialize_48_bytes(data, new_start, v4)?;
+    if n0 + n1 + n2 + n3 > usize::MAX - n4 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n5) = serialize_28_bytes(data, new_start, v5)?;
+    if n0 + n1 + n2 + n3 + n4 > usize::MAX - n5 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n6) = serialize_16_bytes(data, new_start, v6)?;
+    if n0 + n1 + n2 + n3 + n4 + n5 > usize::MAX - n6 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n7) = serialize_16_bytes(data, new_start, v7)?;
+    if n0 + n1 + n2 + n3 + n4 + n5 + n6 > usize::MAX - n7 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2 + n3 + n4 + n5 + n6 + n7))
 }
 
-                    
-pub open spec fn spec_parse_u8_le_2(s: SpecStream) -> SpecParseResult<u8>
-{
+pub open spec fn spec_parse_u8_le_2(s: SpecStream) -> SpecParseResult<u8> {
     match spec_parse_u8_le(s) {
         Ok((s, n, v)) => {
             if v == 2 {
@@ -5595,13 +7597,12 @@ pub open spec fn spec_parse_u8_le_2(s: SpecStream) -> SpecParseResult<u8>
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_u8_le_2(s: SpecStream, v: u8) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_u8_le_2(s: SpecStream, v: u8) -> SpecSerializeResult {
     if v == 2 {
         spec_serialize_u8_le(s, v)
     } else {
@@ -5611,7 +7612,7 @@ pub open spec fn spec_serialize_u8_le_2(s: SpecStream, v: u8) -> SpecSerializeRe
 
 pub exec fn parse_u8_le_2(s: Stream) -> (res: ParseResult<u8>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_2(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_2(s)),
 {
     let (s, n, v) = parse_u8_le(s)?;
     if v == 2 {
@@ -5623,7 +7624,14 @@ pub exec fn parse_u8_le_2(s: Stream) -> (res: ParseResult<u8>)
 
 pub exec fn serialize_u8_le_2(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u8_le_2(s, v))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u8_le_2(s, v),
+        ),
 {
     if v == 2 {
         serialize_u8_le(data, start, v)
@@ -5634,80 +7642,90 @@ pub exec fn serialize_u8_le_2(data: &mut [u8], start: usize, v: u8) -> (res: Ser
 
 pub proof fn lemma_parse_u8_le_2_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_u8_le_2(s))
+        prop_parse_well_behaved(|s| spec_parse_u8_le_2(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_2, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_2, s) by {
         lemma_parse_u8_le_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_2_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_2(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_2(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_2, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_2, s, v) by {
         lemma_serialize_u8_le_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_2_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_2(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_2(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u8_le_2, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u8_le_2, s1, s2, v) by {
         lemma_serialize_u8_le_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_2_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_u8_le_2(s))
+        prop_parse_strong_prefix(|s| spec_parse_u8_le_2(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_2, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_2, s1, s2) by {
         lemma_parse_u8_le_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_u8_le_2_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_u8_le_2(s), |s, v| spec_serialize_u8_le_2(s, v))
+        prop_parse_correct(|s| spec_parse_u8_le_2(s), |s, v| spec_serialize_u8_le_2(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u8_le_2, spec_serialize_u8_le_2, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u8_le_2, spec_serialize_u8_le_2, s, v) by {
         lemma_parse_u8_le_correct_on(s, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_2_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_u8_le_2(s), |s, v| spec_serialize_u8_le_2(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_u8_le_2(s),
+            |s, v| spec_serialize_u8_le_2(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u8_le_2, spec_serialize_u8_le_2, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u8_le_2, spec_serialize_u8_le_2, s) by {
         lemma_parse_u8_le_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_u8_le_2_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_u8_le_2(s))
+        prop_parse_nonmalleable(|s| spec_parse_u8_le_2(s)),
 {
     lemma_parse_u8_le_2_serialize_inverse();
     lemma_serialize_u8_le_2_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u8_le_2(s), |s, v| spec_serialize_u8_le_2(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u8_le_2(s),
+        |s, v| spec_serialize_u8_le_2(s, v),
+    );
 }
+
 pub struct SpecMsg2 {
     ty: u8,
     reserved: Seq<u8>,
@@ -5717,8 +7735,8 @@ pub struct SpecMsg2 {
     empty: Seq<u8>,
     mac1: Seq<u8>,
     mac2: Seq<u8>,
-
 }
+
 pub struct Msg2 {
     ty: u8,
     reserved: Vec<u8>,
@@ -5728,68 +7746,100 @@ pub struct Msg2 {
     empty: Vec<u8>,
     mac1: Vec<u8>,
     mac2: Vec<u8>,
-
 }
 
-pub open spec fn spec_parse_msg2(s: SpecStream) -> SpecParseResult<(((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>)>
-{
+pub open spec fn spec_parse_msg2(s: SpecStream) -> SpecParseResult<
+    (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+> {
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
 
-    spec_parse_8_fold(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993, spec_parse_4_bytes, spec_parse_4_bytes, spec_parse_32_bytes, spec_parse_16_bytes, spec_parse_16_bytes, spec_parse_16_bytes)(s)
+    spec_parse_8_fold(
+        spec_parse_u8_le_2,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_parse_4_bytes,
+        spec_parse_4_bytes,
+        spec_parse_32_bytes,
+        spec_parse_16_bytes,
+        spec_parse_16_bytes,
+        spec_parse_16_bytes,
+    )(s)
 }
 
-pub open spec fn spec_serialize_msg2(s: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_msg2(
+    s: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
 
-    spec_serialize_8_fold(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993, spec_serialize_4_bytes, spec_serialize_4_bytes, spec_serialize_32_bytes, spec_serialize_16_bytes, spec_serialize_16_bytes, spec_serialize_16_bytes)(s, v)
+    spec_serialize_8_fold(
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+        spec_serialize_4_bytes,
+        spec_serialize_4_bytes,
+        spec_serialize_32_bytes,
+        spec_serialize_16_bytes,
+        spec_serialize_16_bytes,
+        spec_serialize_16_bytes,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_msg2_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_msg2(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_msg2(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_msg2 = |s| spec_parse_msg2(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_msg2, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_msg2, s) by {
         lemma_parse_msg2_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_msg2_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_msg2(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_msg2(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_msg2 = |s, v| spec_serialize_msg2(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_msg2, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_msg2, s, v) by {
         lemma_serialize_msg2_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_msg2_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_msg2(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_msg2(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_msg2 = |s, v| spec_serialize_msg2(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_msg2, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_msg2, s1, s2, v) by {
         lemma_serialize_msg2_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_msg2_correct()
-    ensures prop_parse_correct(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_msg2 = |s| spec_parse_msg2(s);
     let spec_serialize_msg2 = |s, v| spec_serialize_msg2(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_msg2, spec_serialize_msg2, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_msg2,
+            spec_serialize_msg2,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_msg2_correct_on(s, v);
         }
@@ -5797,26 +7847,33 @@ pub proof fn lemma_parse_msg2_correct()
 }
 
 pub proof fn lemma_parse_msg2_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v))
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v)),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_msg2 = |s| spec_parse_msg2(s);
     let spec_serialize_msg2 = |s, v| spec_serialize_msg2(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_msg2, spec_serialize_msg2, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_msg2, spec_serialize_msg2, s) by {
         lemma_parse_msg2_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_msg2_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_msg2(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_msg2(s)),
 {
     lemma_parse_msg2_serialize_inverse();
     lemma_serialize_msg2_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_msg2(s),
+        |s, v| spec_serialize_msg2(s, v),
+    );
 }
 
 pub proof fn lemma_parse_msg2_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_msg2(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_msg2(s), s),
 {
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5829,19 +7886,91 @@ pub proof fn lemma_parse_msg2_well_behaved_on(s: SpecStream)
     lemma_parse_32_bytes_well_behaved();
     lemma_parse_16_bytes_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes), spec_parse_16_bytes, s);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_2,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_16_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_msg2_well_behaved_on(s: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_msg2(s, v), s, v)
+pub proof fn lemma_serialize_msg2_well_behaved_on(
+    s: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_msg2(s, v), s, v),
 {
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
@@ -5850,20 +7979,106 @@ pub proof fn lemma_serialize_msg2_well_behaved_on(s: SpecStream, v: (((((((u8, S
     lemma_serialize_4_bytes_well_behaved();
     lemma_serialize_32_bytes_well_behaved();
     lemma_serialize_16_bytes_well_behaved();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_2,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_16_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_msg2_deterministic_on(s1: SpecStream, s2: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_msg2(s, v), s1, s2, v)
+pub proof fn lemma_serialize_msg2_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_msg2(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
@@ -5877,24 +8092,167 @@ pub proof fn lemma_serialize_msg2_deterministic_on(s1: SpecStream, s2: SpecStrea
     lemma_serialize_4_bytes_deterministic();
     lemma_serialize_32_bytes_deterministic();
     lemma_serialize_16_bytes_deterministic();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_deterministic(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_2,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_16_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s1,
+        s2,
+        v,
+    );
 }
 
-pub proof fn lemma_parse_msg2_correct_on(s: SpecStream, v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v), s, v)
+pub proof fn lemma_parse_msg2_correct_on(
+    s: SpecStream,
+    v: (((((((u8, Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>), Seq<u8>),
+)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v), s, v),
 {
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5902,7 +8260,8 @@ pub proof fn lemma_parse_msg2_correct_on(s: SpecStream, v: (((((((u8, Seq<u8>), 
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
@@ -5927,34 +8286,328 @@ pub proof fn lemma_parse_msg2_correct_on(s: SpecStream, v: (((((((u8, Seq<u8>), 
     lemma_parse_32_bytes_correct();
     lemma_parse_16_bytes_correct();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
     lemma_parse_pair_strong_prefix(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_correct(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993, spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u8_le_2,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_2,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_16_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_2,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_16_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_msg2_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_msg2(s), |s, v| spec_serialize_msg2(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_msg2(s),
+            |s, v| spec_serialize_msg2(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -5962,7 +8615,8 @@ pub proof fn lemma_parse_msg2_serialize_inverse_on(s: SpecStream)
     let spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
     let spec_serialize_u8_le_2 = |s, v| spec_serialize_u8_le_2(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_32_bytes = |s, v| spec_serialize_32_bytes(s, v);
     let spec_serialize_16_bytes = |s, v| spec_serialize_16_bytes(s, v);
@@ -5982,38 +8636,283 @@ pub proof fn lemma_parse_msg2_serialize_inverse_on(s: SpecStream)
     lemma_parse_32_bytes_serialize_inverse();
     lemma_parse_16_bytes_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_serialize_inverse(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993, spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes), spec_parse_16_bytes, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_4_bytes), spec_serialize_32_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes), spec_serialize_16_bytes, s);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u8_le_2,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_serialize_u8_le_2,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+        spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_2, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_2,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_u8_le_2,
+                        spec_serialize_3_bytes_5058554103549626993,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_32_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_u8_le_2,
+                            spec_serialize_3_bytes_5058554103549626993,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_4_bytes,
+                ),
+                spec_serialize_32_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_2,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_16_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_pair(
+                        spec_serialize_pair(
+                            spec_serialize_pair(
+                                spec_serialize_u8_le_2,
+                                spec_serialize_3_bytes_5058554103549626993,
+                            ),
+                            spec_serialize_4_bytes,
+                        ),
+                        spec_serialize_4_bytes,
+                    ),
+                    spec_serialize_32_bytes,
+                ),
+                spec_serialize_16_bytes,
+            ),
+            spec_serialize_16_bytes,
+        ),
+        spec_serialize_16_bytes,
+        s,
+    );
 }
 
 pub proof fn lemma_parse_msg2_strong_prefix()
-    ensures prop_parse_strong_prefix(|s| spec_parse_msg2(s))
+    ensures
+        prop_parse_strong_prefix(|s| spec_parse_msg2(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_msg2 = |s| spec_parse_msg2(s);
-    assert forall |s1, s2| prop_parse_strong_prefix_on(spec_parse_msg2, s1, s2) by {
+    assert forall|s1, s2| prop_parse_strong_prefix_on(spec_parse_msg2, s1, s2) by {
         lemma_parse_msg2_strong_prefix_on(s1, s2);
     }
 }
 
 pub proof fn lemma_parse_msg2_strong_prefix_on(s1: SpecStream, s2: SpecStream)
-    ensures prop_parse_strong_prefix_on(|s| spec_parse_msg2(s), s1, s2)
+    ensures
+        prop_parse_strong_prefix_on(|s| spec_parse_msg2(s), s1, s2),
 {
     let spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -6032,57 +8931,219 @@ pub proof fn lemma_parse_msg2_strong_prefix_on(s1: SpecStream, s2: SpecStream)
     lemma_parse_16_bytes_strong_prefix();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993);
     lemma_parse_pair_strong_prefix(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes);
-    lemma_parse_pair_strong_prefix_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_4_bytes), spec_parse_32_bytes), spec_parse_16_bytes), spec_parse_16_bytes), spec_parse_16_bytes, s1, s2);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_32_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_32_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(spec_parse_u8_le_2, spec_parse_3_bytes_5058554103549626993),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_4_bytes,
+                ),
+                spec_parse_32_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+    );
+    lemma_parse_pair_strong_prefix_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(
+                    spec_parse_pair(
+                        spec_parse_pair(
+                            spec_parse_pair(
+                                spec_parse_u8_le_2,
+                                spec_parse_3_bytes_5058554103549626993,
+                            ),
+                            spec_parse_4_bytes,
+                        ),
+                        spec_parse_4_bytes,
+                    ),
+                    spec_parse_32_bytes,
+                ),
+                spec_parse_16_bytes,
+            ),
+            spec_parse_16_bytes,
+        ),
+        spec_parse_16_bytes,
+        s1,
+        s2,
+    );
 }
 
-pub exec fn parse_msg2(s: Stream) -> (res: ParseResult<(((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8])>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_msg2(s))
+pub exec fn parse_msg2(s: Stream) -> (res: ParseResult<
+    (((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]),
+>)
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_msg2(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le_2 = |s| spec_parse_u8_le_2(s);
-    let ghost spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
+    let ghost spec_parse_3_bytes_5058554103549626993 = |s|
+        spec_parse_3_bytes_5058554103549626993(s);
     let ghost spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let ghost spec_parse_32_bytes = |s| spec_parse_32_bytes(s);
     let ghost spec_parse_16_bytes = |s| spec_parse_16_bytes(s);
 
-    parse_8_fold(parse_u8_le_2, parse_3_bytes_5058554103549626993, parse_4_bytes, parse_4_bytes, parse_32_bytes, parse_16_bytes, parse_16_bytes, parse_16_bytes, Ghost(spec_parse_u8_le_2), Ghost(spec_parse_3_bytes_5058554103549626993), Ghost(spec_parse_4_bytes), Ghost(spec_parse_4_bytes), Ghost(spec_parse_32_bytes), Ghost(spec_parse_16_bytes), Ghost(spec_parse_16_bytes), Ghost(spec_parse_16_bytes), s)
+    parse_8_fold(
+        parse_u8_le_2,
+        parse_3_bytes_5058554103549626993,
+        parse_4_bytes,
+        parse_4_bytes,
+        parse_32_bytes,
+        parse_16_bytes,
+        parse_16_bytes,
+        parse_16_bytes,
+        Ghost(spec_parse_u8_le_2),
+        Ghost(spec_parse_3_bytes_5058554103549626993),
+        Ghost(spec_parse_4_bytes),
+        Ghost(spec_parse_4_bytes),
+        Ghost(spec_parse_32_bytes),
+        Ghost(spec_parse_16_bytes),
+        Ghost(spec_parse_16_bytes),
+        Ghost(spec_parse_16_bytes),
+        s,
+    )
 }
-pub exec fn serialize_msg2(data: &mut [u8], start: usize, v: (((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8])) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_msg2(s, v))
+
+pub exec fn serialize_msg2(
+    data: &mut [u8],
+    start: usize,
+    v: (((((((u8, &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]), &[u8]),
+) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_msg2(s, v),
+        ),
 {
     let (((((((v0, v1), v2), v3), v4), v5), v6), v7) = v;
     let (new_start, n0) = serialize_u8_le_2(data, start, v0)?;
 
-let (new_start, n1) = serialize_3_bytes_5058554103549626993(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_4_bytes(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n3) = serialize_4_bytes(data, new_start, v3)?;
-    if n0 + n1 + n2 > usize::MAX - n3 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n4) = serialize_32_bytes(data, new_start, v4)?;
-    if n0 + n1 + n2 + n3 > usize::MAX - n4 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n5) = serialize_16_bytes(data, new_start, v5)?;
-    if n0 + n1 + n2 + n3 + n4 > usize::MAX - n5 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n6) = serialize_16_bytes(data, new_start, v6)?;
-    if n0 + n1 + n2 + n3 + n4 + n5 > usize::MAX - n6 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n7) = serialize_16_bytes(data, new_start, v7)?;
-    if n0 + n1 + n2 + n3 + n4 + n5 + n6 > usize::MAX - n7 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_3_bytes_5058554103549626993(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_4_bytes(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n3) = serialize_4_bytes(data, new_start, v3)?;
+    if n0 + n1 + n2 > usize::MAX - n3 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n4) = serialize_32_bytes(data, new_start, v4)?;
+    if n0 + n1 + n2 + n3 > usize::MAX - n4 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n5) = serialize_16_bytes(data, new_start, v5)?;
+    if n0 + n1 + n2 + n3 + n4 > usize::MAX - n5 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n6) = serialize_16_bytes(data, new_start, v6)?;
+    if n0 + n1 + n2 + n3 + n4 + n5 > usize::MAX - n6 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n7) = serialize_16_bytes(data, new_start, v7)?;
+    if n0 + n1 + n2 + n3 + n4 + n5 + n6 > usize::MAX - n7 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2 + n3 + n4 + n5 + n6 + n7))
 }
 
-                    
-pub open spec fn spec_parse_u8_le_4(s: SpecStream) -> SpecParseResult<u8>
-{
+pub open spec fn spec_parse_u8_le_4(s: SpecStream) -> SpecParseResult<u8> {
     match spec_parse_u8_le(s) {
         Ok((s, n, v)) => {
             if v == 4 {
@@ -6090,13 +9151,12 @@ pub open spec fn spec_parse_u8_le_4(s: SpecStream) -> SpecParseResult<u8>
             } else {
                 Err(ParseError::ConstMismatch)
             }
-        }
+        },
         Err(e) => Err(e),
     }
 }
 
-pub open spec fn spec_serialize_u8_le_4(s: SpecStream, v: u8) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_u8_le_4(s: SpecStream, v: u8) -> SpecSerializeResult {
     if v == 4 {
         spec_serialize_u8_le(s, v)
     } else {
@@ -6106,7 +9166,7 @@ pub open spec fn spec_serialize_u8_le_4(s: SpecStream, v: u8) -> SpecSerializeRe
 
 pub exec fn parse_u8_le_4(s: Stream) -> (res: ParseResult<u8>)
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_4(s))
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_u8_le_4(s)),
 {
     let (s, n, v) = parse_u8_le(s)?;
     if v == 4 {
@@ -6118,7 +9178,14 @@ pub exec fn parse_u8_le_4(s: Stream) -> (res: ParseResult<u8>)
 
 pub exec fn serialize_u8_le_4(data: &mut [u8], start: usize, v: u8) -> (res: SerializeResult)
     ensures
-        prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v, res, |s, v| spec_serialize_u8_le_4(s, v))
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v,
+            res,
+            |s, v| spec_serialize_u8_le_4(s, v),
+        ),
 {
     if v == 4 {
         serialize_u8_le(data, start, v)
@@ -6129,95 +9196,104 @@ pub exec fn serialize_u8_le_4(data: &mut [u8], start: usize, v: u8) -> (res: Ser
 
 pub proof fn lemma_parse_u8_le_4_well_behaved()
     ensures
-        prop_parse_well_behaved(|s| spec_parse_u8_le_4(s))
+        prop_parse_well_behaved(|s| spec_parse_u8_le_4(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_4, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_u8_le_4, s) by {
         lemma_parse_u8_le_well_behaved_on(s)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_4_well_behaved()
     ensures
-        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_4(s, v))
+        prop_serialize_well_behaved(|s, v| spec_serialize_u8_le_4(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_4, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_u8_le_4, s, v) by {
         lemma_serialize_u8_le_well_behaved_on(s, v)
     }
 }
 
 pub proof fn lemma_serialize_u8_le_4_deterministic()
     ensures
-        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_4(s, v))
+        prop_serialize_deterministic(|s, v| spec_serialize_u8_le_4(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_u8_le_4, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_u8_le_4, s1, s2, v) by {
         lemma_serialize_u8_le_deterministic_on(s1, s2, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_4_strong_prefix()
     ensures
-        prop_parse_strong_prefix(|s| spec_parse_u8_le_4(s))
+        prop_parse_strong_prefix(|s| spec_parse_u8_le_4(s)),
 {
     reveal(prop_parse_strong_prefix);
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
-    assert forall |s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_4, s1, s2) by {
+    assert forall|s1, s2| #[trigger] prop_parse_strong_prefix_on(spec_parse_u8_le_4, s1, s2) by {
         lemma_parse_u8_le_strong_prefix_on(s1, s2)
     }
 }
 
 pub proof fn lemma_parse_u8_le_4_correct()
     ensures
-        prop_parse_correct(|s| spec_parse_u8_le_4(s), |s, v| spec_serialize_u8_le_4(s, v))
+        prop_parse_correct(|s| spec_parse_u8_le_4(s), |s, v| spec_serialize_u8_le_4(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    assert forall |s, v| #[trigger] prop_parse_correct_on(spec_parse_u8_le_4, spec_serialize_u8_le_4, s, v) by {
+    assert forall|s, v| #[trigger]
+        prop_parse_correct_on(spec_parse_u8_le_4, spec_serialize_u8_le_4, s, v) by {
         lemma_parse_u8_le_correct_on(s, v)
     }
 }
 
 pub proof fn lemma_parse_u8_le_4_serialize_inverse()
     ensures
-        prop_parse_serialize_inverse(|s| spec_parse_u8_le_4(s), |s, v| spec_serialize_u8_le_4(s, v))
+        prop_parse_serialize_inverse(
+            |s| spec_parse_u8_le_4(s),
+            |s, v| spec_serialize_u8_le_4(s, v),
+        ),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_u8_le_4, spec_serialize_u8_le_4, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_u8_le_4, spec_serialize_u8_le_4, s) by {
         lemma_parse_u8_le_serialize_inverse_on(s)
     }
 }
 
 pub proof fn lemma_parse_u8_le_4_nonmalleable()
     ensures
-        prop_parse_nonmalleable(|s| spec_parse_u8_le_4(s))
+        prop_parse_nonmalleable(|s| spec_parse_u8_le_4(s)),
 {
     lemma_parse_u8_le_4_serialize_inverse();
     lemma_serialize_u8_le_4_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_u8_le_4(s), |s, v| spec_serialize_u8_le_4(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_u8_le_4(s),
+        |s, v| spec_serialize_u8_le_4(s, v),
+    );
 }
+
 pub struct SpecTransp {
     ty: u8,
     reserved: Seq<u8>,
     receiver: Seq<u8>,
     counter: u64,
     packet: Seq<u8>,
-
 }
+
 pub struct Transp {
     ty: u8,
     reserved: Vec<u8>,
     receiver: Vec<u8>,
     counter: u64,
     packet: Vec<u8>,
-
 }
 
 pub open spec fn spec_parse_5_fold<R1, R2, R3, R4, R5>(
@@ -6225,23 +9301,29 @@ pub open spec fn spec_parse_5_fold<R1, R2, R3, R4, R5>(
     parser2: spec_fn(SpecStream) -> SpecParseResult<R2>,
     parser3: spec_fn(SpecStream) -> SpecParseResult<R3>,
     parser4: spec_fn(SpecStream) -> SpecParseResult<R4>,
-    parser5: spec_fn(SpecStream) -> SpecParseResult<R5>) -> spec_fn(SpecStream) -> SpecParseResult<((((R1, R2), R3), R4), R5)>
-{
-    spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4), parser5)
+    parser5: spec_fn(SpecStream) -> SpecParseResult<R5>,
+) -> spec_fn(SpecStream) -> SpecParseResult<((((R1, R2), R3), R4), R5)> {
+    spec_parse_pair(
+        spec_parse_pair(spec_parse_pair(spec_parse_pair(parser1, parser2), parser3), parser4),
+        parser5,
+    )
 }
-
-
 
 pub open spec fn spec_serialize_5_fold<T1, T2, T3, T4, T5>(
     serializer1: spec_fn(SpecStream, T1) -> SpecSerializeResult,
     serializer2: spec_fn(SpecStream, T2) -> SpecSerializeResult,
     serializer3: spec_fn(SpecStream, T3) -> SpecSerializeResult,
     serializer4: spec_fn(SpecStream, T4) -> SpecSerializeResult,
-    serializer5: spec_fn(SpecStream, T5) -> SpecSerializeResult) -> spec_fn(SpecStream, ((((T1, T2), T3), T4), T5)) -> SpecSerializeResult
-{
-    spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3), serializer4), serializer5)
+    serializer5: spec_fn(SpecStream, T5) -> SpecSerializeResult,
+) -> spec_fn(SpecStream, ((((T1, T2), T3), T4), T5)) -> SpecSerializeResult {
+    spec_serialize_pair(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_pair(serializer1, serializer2), serializer3),
+            serializer4,
+        ),
+        serializer5,
+    )
 }
-
 
 pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
     exec_parser1: P1,
@@ -6254,8 +9336,8 @@ pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
     Ghost(spec_parser3): Ghost<spec_fn(SpecStream) -> SpecParseResult<R3::V>>,
     Ghost(spec_parser4): Ghost<spec_fn(SpecStream) -> SpecParseResult<R4::V>>,
     Ghost(spec_parser5): Ghost<spec_fn(SpecStream) -> SpecParseResult<R5::V>>,
-    s: Stream<'a>) -> (res: ParseResult<((((R1, R2), R3), R4), R5)>)
-    where
+    s: Stream<'a>,
+) -> (res: ParseResult<((((R1, R2), R3), R4), R5)>) where
     R1: DView,
     P1: FnOnce(Stream<'a>) -> ParseResult<R1>,
     R2: DView,
@@ -6266,6 +9348,7 @@ pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
     P4: FnOnce(Stream<'a>) -> ParseResult<R4>,
     R5: DView,
     P5: FnOnce(Stream<'a>) -> ParseResult<R5>,
+
     requires
         prop_parse_exec_spec_equiv(exec_parser1, spec_parser1),
         prop_parse_exec_spec_equiv(exec_parser2, spec_parser2),
@@ -6273,75 +9356,154 @@ pub exec fn parse_5_fold<'a, P1, P2, P3, P4, P5, R1, R2, R3, R4, R5>(
         prop_parse_exec_spec_equiv(exec_parser4, spec_parser4),
         prop_parse_exec_spec_equiv(exec_parser5, spec_parser5),
     ensures
-        prop_parse_exec_spec_equiv_on(s, res, spec_parse_5_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4, spec_parser5))
+        prop_parse_exec_spec_equiv_on(
+            s,
+            res,
+            spec_parse_5_fold(spec_parser1, spec_parser2, spec_parser3, spec_parser4, spec_parser5),
+        ),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
-    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)), { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
-    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), { parse_pair(parse_2_fold, exec_parser3, Ghost(spec_parse_pair(spec_parser1, spec_parser2)), Ghost(spec_parser3), s) };
-    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>) ensures prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), { parse_pair(parse_3_fold, exec_parser4, Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)), Ghost(spec_parser4), s) };
-    parse_pair(parse_4_fold, exec_parser5, Ghost(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3), spec_parser4)), Ghost(spec_parser5), s)
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
+    let parse_2_fold = |s| -> (res: ParseResult<(R1, R2)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(s, res, spec_parse_pair(spec_parser1, spec_parser2)),
+        { parse_pair(exec_parser1, exec_parser2, Ghost(spec_parser1), Ghost(spec_parser2), s) };
+    let parse_3_fold = |s| -> (res: ParseResult<((R1, R2), R3)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+            ),
+        {
+            parse_pair(
+                parse_2_fold,
+                exec_parser3,
+                Ghost(spec_parse_pair(spec_parser1, spec_parser2)),
+                Ghost(spec_parser3),
+                s,
+            )
+        };
+    let parse_4_fold = |s| -> (res: ParseResult<(((R1, R2), R3), R4)>)
+        ensures
+            prop_parse_exec_spec_equiv_on(
+                s,
+                res,
+                spec_parse_pair(
+                    spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                    spec_parser4,
+                ),
+            ),
+        {
+            parse_pair(
+                parse_3_fold,
+                exec_parser4,
+                Ghost(spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3)),
+                Ghost(spec_parser4),
+                s,
+            )
+        };
+    parse_pair(
+        parse_4_fold,
+        exec_parser5,
+        Ghost(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_pair(spec_parser1, spec_parser2), spec_parser3),
+                spec_parser4,
+            ),
+        ),
+        Ghost(spec_parser5),
+        s,
+    )
 }
 
-
-pub open spec fn spec_parse_transp(s: SpecStream) -> SpecParseResult<((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>)>
-{
+pub open spec fn spec_parse_transp(s: SpecStream) -> SpecParseResult<
+    ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>),
+> {
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
     let spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_tail = |s| spec_parse_tail(s);
 
-    spec_parse_5_fold(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993, spec_parse_4_bytes, spec_parse_u64_le, spec_parse_tail)(s)
+    spec_parse_5_fold(
+        spec_parse_u8_le_4,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_parse_4_bytes,
+        spec_parse_u64_le,
+        spec_parse_tail,
+    )(s)
 }
 
-pub open spec fn spec_serialize_transp(s: SpecStream, v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>)) -> SpecSerializeResult
-{
+pub open spec fn spec_serialize_transp(
+    s: SpecStream,
+    v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>),
+) -> SpecSerializeResult {
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
 
-    spec_serialize_5_fold(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993, spec_serialize_4_bytes, spec_serialize_u64_le, spec_serialize_tail)(s, v)
+    spec_serialize_5_fold(
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+        spec_serialize_4_bytes,
+        spec_serialize_u64_le,
+        spec_serialize_tail,
+    )(s, v)
 }
 
 pub proof fn lemma_parse_transp_well_behaved()
-    ensures prop_parse_well_behaved(|s| spec_parse_transp(s))
+    ensures
+        prop_parse_well_behaved(|s| spec_parse_transp(s)),
 {
     reveal(prop_parse_well_behaved);
     let spec_parse_transp = |s| spec_parse_transp(s);
-    assert forall |s| #[trigger] prop_parse_well_behaved_on(spec_parse_transp, s) by {
+    assert forall|s| #[trigger] prop_parse_well_behaved_on(spec_parse_transp, s) by {
         lemma_parse_transp_well_behaved_on(s);
     }
 }
 
 pub proof fn lemma_serialize_transp_well_behaved()
-    ensures prop_serialize_well_behaved(|s, v| spec_serialize_transp(s, v))
+    ensures
+        prop_serialize_well_behaved(|s, v| spec_serialize_transp(s, v)),
 {
     reveal(prop_serialize_well_behaved);
     let spec_serialize_transp = |s, v| spec_serialize_transp(s, v);
-    assert forall |s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_transp, s, v) by {
+    assert forall|s, v| #[trigger] prop_serialize_well_behaved_on(spec_serialize_transp, s, v) by {
         lemma_serialize_transp_well_behaved_on(s, v);
     }
 }
 
 pub proof fn lemma_serialize_transp_deterministic()
-    ensures prop_serialize_deterministic(|s, v| spec_serialize_transp(s, v))
+    ensures
+        prop_serialize_deterministic(|s, v| spec_serialize_transp(s, v)),
 {
     reveal(prop_serialize_deterministic);
     let spec_serialize_transp = |s, v| spec_serialize_transp(s, v);
-    assert forall |s1, s2, v| #[trigger] prop_serialize_deterministic_on(spec_serialize_transp, s1, s2, v) by {
+    assert forall|s1, s2, v| #[trigger]
+        prop_serialize_deterministic_on(spec_serialize_transp, s1, s2, v) by {
         lemma_serialize_transp_deterministic_on(s1, s2, v);
     }
 }
-    
+
 pub proof fn lemma_parse_transp_correct()
-    ensures prop_parse_correct(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v))
+    ensures
+        prop_parse_correct(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v)),
 {
     reveal(prop_parse_correct);
     let spec_parse_transp = |s| spec_parse_transp(s);
     let spec_serialize_transp = |s, v| spec_serialize_transp(s, v);
-    assert forall |s: SpecStream, v| s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(spec_parse_transp, spec_serialize_transp, s, v) by {
+    assert forall|s: SpecStream, v|
+        s.data.len() <= usize::MAX ==> #[trigger] prop_parse_correct_on(
+            spec_parse_transp,
+            spec_serialize_transp,
+            s,
+            v,
+        ) by {
         if s.data.len() <= usize::MAX {
             lemma_parse_transp_correct_on(s, v);
         }
@@ -6349,26 +9511,33 @@ pub proof fn lemma_parse_transp_correct()
 }
 
 pub proof fn lemma_parse_transp_serialize_inverse()
-    ensures prop_parse_serialize_inverse(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v))
+    ensures
+        prop_parse_serialize_inverse(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v)),
 {
     reveal(prop_parse_serialize_inverse);
     let spec_parse_transp = |s| spec_parse_transp(s);
     let spec_serialize_transp = |s, v| spec_serialize_transp(s, v);
-    assert forall |s| #[trigger] prop_parse_serialize_inverse_on(spec_parse_transp, spec_serialize_transp, s) by {
+    assert forall|s| #[trigger]
+        prop_parse_serialize_inverse_on(spec_parse_transp, spec_serialize_transp, s) by {
         lemma_parse_transp_serialize_inverse_on(s);
     }
 }
 
 pub proof fn lemma_parse_transp_nonmalleable()
-    ensures prop_parse_nonmalleable(|s| spec_parse_transp(s))
+    ensures
+        prop_parse_nonmalleable(|s| spec_parse_transp(s)),
 {
     lemma_parse_transp_serialize_inverse();
     lemma_serialize_transp_deterministic();
-    lemma_parse_serialize_inverse_implies_nonmalleable(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v));
+    lemma_parse_serialize_inverse_implies_nonmalleable(
+        |s| spec_parse_transp(s),
+        |s, v| spec_serialize_transp(s, v),
+    );
 }
 
 pub proof fn lemma_parse_transp_well_behaved_on(s: SpecStream)
-    ensures prop_parse_well_behaved_on(|s| spec_parse_transp(s), s)
+    ensures
+        prop_parse_well_behaved_on(|s| spec_parse_transp(s), s),
 {
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -6381,16 +9550,40 @@ pub proof fn lemma_parse_transp_well_behaved_on(s: SpecStream)
     lemma_parse_u64_le_well_behaved();
     lemma_parse_tail_well_behaved();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le);
-    lemma_parse_pair_well_behaved_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le), spec_parse_tail, s);
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_u64_le,
+    );
+    lemma_parse_pair_well_behaved_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_u64_le,
+        ),
+        spec_parse_tail,
+        s,
+    );
 }
 
-pub proof fn lemma_serialize_transp_well_behaved_on(s: SpecStream, v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>))
-    ensures prop_serialize_well_behaved_on(|s, v| spec_serialize_transp(s, v), s, v)
+pub proof fn lemma_serialize_transp_well_behaved_on(
+    s: SpecStream,
+    v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>),
+)
+    ensures
+        prop_serialize_well_behaved_on(|s, v| spec_serialize_transp(s, v), s, v),
 {
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -6399,17 +9592,49 @@ pub proof fn lemma_serialize_transp_well_behaved_on(s: SpecStream, v: ((((u8, Se
     lemma_serialize_4_bytes_well_behaved();
     lemma_serialize_u64_le_well_behaved();
     lemma_serialize_tail_well_behaved();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_serialize_pair_well_behaved_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le), spec_serialize_tail, s, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_serialize_pair_well_behaved_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_4,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_u64_le,
+        ),
+        spec_serialize_tail,
+        s,
+        v,
+    );
 }
 
-pub proof fn lemma_serialize_transp_deterministic_on(s1: SpecStream, s2: SpecStream, v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>))
-    ensures prop_serialize_deterministic_on(|s, v| spec_serialize_transp(s, v), s1, s2, v)
+pub proof fn lemma_serialize_transp_deterministic_on(
+    s1: SpecStream,
+    s2: SpecStream,
+    v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>),
+)
+    ensures
+        prop_serialize_deterministic_on(|s, v| spec_serialize_transp(s, v), s1, s2, v),
 {
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -6423,18 +9648,62 @@ pub proof fn lemma_serialize_transp_deterministic_on(s1: SpecStream, s2: SpecStr
     lemma_serialize_4_bytes_deterministic();
     lemma_serialize_u64_le_deterministic();
     lemma_serialize_tail_deterministic();
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_deterministic(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_serialize_pair_deterministic(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_serialize_pair_deterministic_on(spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le), spec_serialize_tail, s1, s2, v);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_serialize_pair_deterministic(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_serialize_pair_deterministic_on(
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_4,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_u64_le,
+        ),
+        spec_serialize_tail,
+        s1,
+        s2,
+        v,
+    );
 }
 
-pub proof fn lemma_parse_transp_correct_on(s: SpecStream, v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>))
-    requires s.data.len() <= usize::MAX,
-    ensures prop_parse_correct_on(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v), s, v)
+pub proof fn lemma_parse_transp_correct_on(
+    s: SpecStream,
+    v: ((((u8, Seq<u8>), Seq<u8>), u64), Seq<u8>),
+)
+    requires
+        s.data.len() <= usize::MAX,
+    ensures
+        prop_parse_correct_on(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v), s, v),
 {
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -6442,7 +9711,8 @@ pub proof fn lemma_parse_transp_correct_on(s: SpecStream, v: ((((u8, Seq<u8>), S
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_tail = |s| spec_parse_tail(s);
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -6460,29 +9730,107 @@ pub proof fn lemma_parse_transp_correct_on(s: SpecStream, v: ((((u8, Seq<u8>), S
     lemma_parse_3_bytes_5058554103549626993_strong_prefix();
     lemma_parse_4_bytes_strong_prefix();
     lemma_parse_u64_le_strong_prefix();
-    
+
     lemma_parse_u8_le_4_correct();
     lemma_parse_3_bytes_5058554103549626993_correct();
     lemma_parse_4_bytes_correct();
     lemma_parse_u64_le_correct();
     lemma_parse_tail_correct();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
     lemma_parse_pair_strong_prefix(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993);
-    lemma_parse_pair_correct(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993, spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_parse_pair_strong_prefix(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le);
-    lemma_parse_pair_correct(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_parse_pair_correct_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le), spec_parse_tail, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le), spec_serialize_tail, s, v);
+    lemma_parse_pair_correct(
+        spec_parse_u8_le_4,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_u64_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_parse_pair_strong_prefix(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_u64_le,
+    );
+    lemma_parse_pair_correct(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_u64_le,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_parse_pair_correct_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_u64_le,
+        ),
+        spec_parse_tail,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_4,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_u64_le,
+        ),
+        spec_serialize_tail,
+        s,
+        v,
+    );
 }
 
 pub proof fn lemma_parse_transp_serialize_inverse_on(s: SpecStream)
-    ensures prop_parse_serialize_inverse_on(|s| spec_parse_transp(s), |s, v| spec_serialize_transp(s, v), s)
+    ensures
+        prop_parse_serialize_inverse_on(
+            |s| spec_parse_transp(s),
+            |s, v| spec_serialize_transp(s, v),
+            s,
+        ),
 {
     let spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
     let spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
@@ -6490,7 +9838,8 @@ pub proof fn lemma_parse_transp_serialize_inverse_on(s: SpecStream)
     let spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let spec_parse_tail = |s| spec_parse_tail(s);
     let spec_serialize_u8_le_4 = |s, v| spec_serialize_u8_le_4(s, v);
-    let spec_serialize_3_bytes_5058554103549626993 = |s, v| spec_serialize_3_bytes_5058554103549626993(s, v);
+    let spec_serialize_3_bytes_5058554103549626993 = |s, v|
+        spec_serialize_3_bytes_5058554103549626993(s, v);
     let spec_serialize_4_bytes = |s, v| spec_serialize_4_bytes(s, v);
     let spec_serialize_u64_le = |s, v| spec_serialize_u64_le(s, v);
     let spec_serialize_tail = |s, v| spec_serialize_tail(s, v);
@@ -6510,45 +9859,147 @@ pub proof fn lemma_parse_transp_serialize_inverse_on(s: SpecStream)
     lemma_parse_u64_le_serialize_inverse();
     lemma_parse_tail_serialize_inverse();
     lemma_parse_pair_well_behaved(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993);
-    lemma_serialize_pair_well_behaved(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_serialize_inverse(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993, spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes, spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes);
-    lemma_parse_pair_well_behaved(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le);
-    lemma_serialize_pair_well_behaved(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_parse_pair_serialize_inverse(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le, spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le);
-    lemma_parse_pair_serialize_inverse_on(spec_parse_pair(spec_parse_pair(spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993), spec_parse_4_bytes), spec_parse_u64_le), spec_parse_tail, spec_serialize_pair(spec_serialize_pair(spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993), spec_serialize_4_bytes), spec_serialize_u64_le), spec_serialize_tail, s);
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_u8_le_4,
+        spec_parse_3_bytes_5058554103549626993,
+        spec_serialize_u8_le_4,
+        spec_serialize_3_bytes_5058554103549626993,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+        spec_parse_4_bytes,
+        spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+        spec_serialize_4_bytes,
+    );
+    lemma_parse_pair_well_behaved(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_u64_le,
+    );
+    lemma_serialize_pair_well_behaved(
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_parse_pair_serialize_inverse(
+        spec_parse_pair(
+            spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+            spec_parse_4_bytes,
+        ),
+        spec_parse_u64_le,
+        spec_serialize_pair(
+            spec_serialize_pair(spec_serialize_u8_le_4, spec_serialize_3_bytes_5058554103549626993),
+            spec_serialize_4_bytes,
+        ),
+        spec_serialize_u64_le,
+    );
+    lemma_parse_pair_serialize_inverse_on(
+        spec_parse_pair(
+            spec_parse_pair(
+                spec_parse_pair(spec_parse_u8_le_4, spec_parse_3_bytes_5058554103549626993),
+                spec_parse_4_bytes,
+            ),
+            spec_parse_u64_le,
+        ),
+        spec_parse_tail,
+        spec_serialize_pair(
+            spec_serialize_pair(
+                spec_serialize_pair(
+                    spec_serialize_u8_le_4,
+                    spec_serialize_3_bytes_5058554103549626993,
+                ),
+                spec_serialize_4_bytes,
+            ),
+            spec_serialize_u64_le,
+        ),
+        spec_serialize_tail,
+        s,
+    );
 }
+
 pub exec fn parse_transp(s: Stream) -> (res: ParseResult<((((u8, &[u8]), &[u8]), u64), &[u8])>)
-    ensures prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_transp(s))
+    ensures
+        prop_parse_exec_spec_equiv_on(s, res, |s| spec_parse_transp(s)),
 {
-    proof { reveal(prop_parse_exec_spec_equiv); }
+    proof {
+        reveal(prop_parse_exec_spec_equiv);
+    }
     let ghost spec_parse_u8_le_4 = |s| spec_parse_u8_le_4(s);
-    let ghost spec_parse_3_bytes_5058554103549626993 = |s| spec_parse_3_bytes_5058554103549626993(s);
+    let ghost spec_parse_3_bytes_5058554103549626993 = |s|
+        spec_parse_3_bytes_5058554103549626993(s);
     let ghost spec_parse_4_bytes = |s| spec_parse_4_bytes(s);
     let ghost spec_parse_u64_le = |s| spec_parse_u64_le(s);
     let ghost spec_parse_tail = |s| spec_parse_tail(s);
 
-    parse_5_fold(parse_u8_le_4, parse_3_bytes_5058554103549626993, parse_4_bytes, parse_u64_le, parse_tail, Ghost(spec_parse_u8_le_4), Ghost(spec_parse_3_bytes_5058554103549626993), Ghost(spec_parse_4_bytes), Ghost(spec_parse_u64_le), Ghost(spec_parse_tail), s)
+    parse_5_fold(
+        parse_u8_le_4,
+        parse_3_bytes_5058554103549626993,
+        parse_4_bytes,
+        parse_u64_le,
+        parse_tail,
+        Ghost(spec_parse_u8_le_4),
+        Ghost(spec_parse_3_bytes_5058554103549626993),
+        Ghost(spec_parse_4_bytes),
+        Ghost(spec_parse_u64_le),
+        Ghost(spec_parse_tail),
+        s,
+    )
 }
-pub exec fn serialize_transp(data: &mut [u8], start: usize, v: ((((u8, &[u8]), &[u8]), u64), &[u8])) -> (res: SerializeResult)
-    ensures prop_serialize_exec_spec_equiv_on(old(data).dview(), start, data.dview(), v.dview(), res, |s, v| spec_serialize_transp(s, v))
+
+pub exec fn serialize_transp(
+    data: &mut [u8],
+    start: usize,
+    v: ((((u8, &[u8]), &[u8]), u64), &[u8]),
+) -> (res: SerializeResult)
+    ensures
+        prop_serialize_exec_spec_equiv_on(
+            old(data).dview(),
+            start,
+            data.dview(),
+            v.dview(),
+            res,
+            |s, v| spec_serialize_transp(s, v),
+        ),
 {
     let ((((v0, v1), v2), v3), v4) = v;
     let (new_start, n0) = serialize_u8_le_4(data, start, v0)?;
 
-let (new_start, n1) = serialize_3_bytes_5058554103549626993(data, new_start, v1)?;
-    if n0 > usize::MAX - n1 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n2) = serialize_4_bytes(data, new_start, v2)?;
-    if n0 + n1 > usize::MAX - n2 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n3) = serialize_u64_le(data, new_start, v3)?;
-    if n0 + n1 + n2 > usize::MAX - n3 { return Err(SerializeError::IntegerOverflow) }
-let (new_start, n4) = serialize_tail(data, new_start, v4)?;
-    if n0 + n1 + n2 + n3 > usize::MAX - n4 { return Err(SerializeError::IntegerOverflow) }
+    let (new_start, n1) = serialize_3_bytes_5058554103549626993(data, new_start, v1)?;
+    if n0 > usize::MAX - n1 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n2) = serialize_4_bytes(data, new_start, v2)?;
+    if n0 + n1 > usize::MAX - n2 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n3) = serialize_u64_le(data, new_start, v3)?;
+    if n0 + n1 + n2 > usize::MAX - n3 {
+        return Err(SerializeError::IntegerOverflow)
+    }
+    let (new_start, n4) = serialize_tail(data, new_start, v4)?;
+    if n0 + n1 + n2 + n3 > usize::MAX - n4 {
+        return Err(SerializeError::IntegerOverflow)
+    }
     Ok((new_start, n0 + n1 + n2 + n3 + n4))
 }
 
-                    
-fn main() {}
+fn main() {
 }
+
+} // verus!

--- a/vest-examples/src/map.rs
+++ b/vest-examples/src/map.rs
@@ -592,7 +592,7 @@ fn parse_serialize4() -> Result<(), ()> {
     let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16, (Bytes(3), Tail))), mapper: Msg1Mapper });
     let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper });
     let msg3 = Preceded(tag3, Mapped { inner: BytesN::<6>, mapper: Msg3Mapper });
-    let msg_inner = OrdChoice::new(OrdChoice::new(msg1, msg2), msg3);
+    let msg_inner = OrdChoice(OrdChoice(msg1, msg2), msg3);
     let msg = Mapped { inner: msg_inner, mapper: Msg4Mapper };
     let mut data = my_vec![1u8, 123u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
     let mut s = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -625,7 +625,7 @@ fn serialize_parse4() -> Result<(), ()> {
     let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16, (Bytes(3), Tail))), mapper: Msg1Mapper });
     let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper });
     let msg3 = Preceded(tag3, Mapped { inner: BytesN::<6>, mapper: Msg3Mapper });
-    let msg_inner = OrdChoice::new(OrdChoice::new(msg1, msg2), msg3);
+    let msg_inner = OrdChoice(OrdChoice(msg1, msg2), msg3);
     let msg = Mapped { inner: msg_inner, mapper: Msg4Mapper };
     let bytes1: [u8; 3] = [0u8, 0u8, 1u8];
     let bytes2: [u8; 3] = [0u8, 0u8, 2u8];

--- a/vest/src/properties.rs
+++ b/vest/src/properties.rs
@@ -15,7 +15,7 @@ pub trait SpecCombinator {
 
     /// The specification of [`Combinator::serialize`].
     spec fn spec_serialize(&self, v: Self::SpecResult) -> Result<Seq<u8>, ()>;
-    
+
     /// A helper fact to ensure that the result of parsing is within the input bounds.
     proof fn spec_parse_wf(&self, s: Seq<u8>)
         ensures
@@ -52,8 +52,9 @@ pub trait SecureSpecCombinator: SpecCombinator {
         requires
             s1.len() + s2.len() <= usize::MAX,
         ensures
-            Self::spec_is_prefix_secure() ==> self.spec_parse(s1).is_ok() ==> self.spec_parse(s1.add(s2))
-                == self.spec_parse(s1),
+            Self::spec_is_prefix_secure() ==> self.spec_parse(s1).is_ok() ==> self.spec_parse(
+                s1.add(s2),
+            ) == self.spec_parse(s1),
     ;
 }
 

--- a/vest/src/regular/choice.rs
+++ b/vest/src/regular/choice.rs
@@ -1,4 +1,4 @@
-use super::disjoint::{DisjointFrom, SpecDisjointFrom};
+use super::disjoint::DisjointFrom;
 use crate::properties::*;
 use vstd::prelude::*;
 
@@ -24,30 +24,7 @@ impl<A: View, B: View> View for Either<A, B> {
 /// Combinator that tries the `Fst` combinator and if it fails, tries the `Snd` combinator.
 pub struct OrdChoice<Fst, Snd>(pub Fst, pub Snd);
 
-impl<Fst, Snd> OrdChoice<Fst, Snd> where
-    Fst: Combinator,
-    Snd: Combinator + DisjointFrom<Fst>,
-    Fst::V: SecureSpecCombinator<SpecResult = <Fst::Owned as View>::V>,
-    Snd::V: SecureSpecCombinator<SpecResult = <Snd::Owned as View>::V> + SpecDisjointFrom<Fst::V>,
- {
-    /// Creates a new `OrdChoice` combinator.
-    /// > **Note**: The `Snd` parser must be disjoint from the `Fst` parser.
-    pub fn new(parser1: Fst, parser2: Snd) -> (o: Self)
-        requires
-            parser2@.spec_disjoint_from(&parser1@),
-        ensures
-            o.0 == parser1 && o.1 == parser2,
-    {
-        OrdChoice(parser1, parser2)
-    }
-}
-
-impl<Fst, Snd> View for OrdChoice<Fst, Snd> where
-    Fst: Combinator,
-    Snd: Combinator + DisjointFrom<Fst>,
-    Fst::V: SecureSpecCombinator<SpecResult = <Fst::Owned as View>::V>,
-    Snd::V: SecureSpecCombinator<SpecResult = <Snd::Owned as View>::V> + SpecDisjointFrom<Fst::V>,
- {
+impl<Fst: View, Snd: View> View for OrdChoice<Fst, Snd> where  {
     type V = OrdChoice<Fst::V, Snd::V>;
 
     open spec fn view(&self) -> Self::V {
@@ -57,12 +34,12 @@ impl<Fst, Snd> View for OrdChoice<Fst, Snd> where
 
 impl<Fst, Snd> SpecCombinator for OrdChoice<Fst, Snd> where
     Fst: SpecCombinator,
-    Snd: SpecCombinator + SpecDisjointFrom<Fst>,
+    Snd: SpecCombinator + DisjointFrom<Fst>,
  {
     type SpecResult = Either<Fst::SpecResult, Snd::SpecResult>;
 
     open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::SpecResult), ()> {
-        if self.1.spec_disjoint_from(&self.0) {
+        if self.1.disjoint_from(&self.0) {
             if let Ok((n, v)) = self.0.spec_parse(s) {
                 Ok((n, Either::Left(v)))
             } else {
@@ -88,7 +65,7 @@ impl<Fst, Snd> SpecCombinator for OrdChoice<Fst, Snd> where
     }
 
     open spec fn spec_serialize(&self, v: Self::SpecResult) -> Result<Seq<u8>, ()> {
-        if self.1.spec_disjoint_from(&self.0) {
+        if self.1.disjoint_from(&self.0) {
             match v {
                 Either::Left(v) => self.0.spec_serialize(v),
                 Either::Right(v) => self.1.spec_serialize(v),
@@ -101,16 +78,16 @@ impl<Fst, Snd> SpecCombinator for OrdChoice<Fst, Snd> where
 
 impl<Fst, Snd> SecureSpecCombinator for OrdChoice<Fst, Snd> where
     Fst: SecureSpecCombinator,
-    Snd: SecureSpecCombinator + SpecDisjointFrom<Fst>,
+    Snd: SecureSpecCombinator + DisjointFrom<Fst>,
  {
     open spec fn spec_is_prefix_secure() -> bool {
         Fst::spec_is_prefix_secure() && Snd::spec_is_prefix_secure()
     }
 
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>) {
-        if self.1.spec_disjoint_from(&self.0) {
+        if self.1.disjoint_from(&self.0) {
             // must also explicitly state that parser1 will fail on anything that parser2 will succeed on
-            self.1.spec_parse_disjoint_on(&self.0, s1.add(s2));
+            self.1.parse_disjoint_on(&self.0, s1.add(s2));
             if Self::spec_is_prefix_secure() {
                 self.0.lemma_prefix_secure(s1, s2);
                 self.1.lemma_prefix_secure(s1, s2);
@@ -126,8 +103,8 @@ impl<Fst, Snd> SecureSpecCombinator for OrdChoice<Fst, Snd> where
             Either::Right(v) => {
                 self.1.theorem_serialize_parse_roundtrip(v);
                 let buf = self.1.spec_serialize(v).unwrap();
-                if self.1.spec_disjoint_from(&self.0) {
-                    self.1.spec_parse_disjoint_on(&self.0, buf);
+                if self.1.disjoint_from(&self.0) {
+                    self.1.parse_disjoint_on(&self.0, buf);
                 }
             },
         }
@@ -146,9 +123,10 @@ impl<Fst, Snd> SecureSpecCombinator for OrdChoice<Fst, Snd> where
 
 impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
     Fst: Combinator,
-    Snd: Combinator + DisjointFrom<Fst>,
+    Snd: Combinator,
     Fst::V: SecureSpecCombinator<SpecResult = <Fst::Owned as View>::V>,
-    Snd::V: SecureSpecCombinator<SpecResult = <Snd::Owned as View>::V> + SpecDisjointFrom<Fst::V>,
+    Snd::V: SecureSpecCombinator<SpecResult = <Snd::Owned as View>::V>,
+    Snd::V: DisjointFrom<Fst::V>,
  {
     type Result<'a> = Either<Fst::Result<'a>, Snd::Result<'a>>;
 
@@ -167,54 +145,48 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
     }
 
     open spec fn parse_requires(&self) -> bool {
-        self.0.parse_requires() && self.1.parse_requires()
+        self.0.parse_requires() && self.1.parse_requires() && self@.1.disjoint_from(&self@.0)
     }
 
     fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
-        if self.1.disjoint_from(&self.0) {
-            if let Ok((n, v)) = self.0.parse(s) {
-                Ok((n, Either::Left(v)))
-            } else {
-                if let Ok((n, v)) = self.1.parse(s) {
-                    Ok((n, Either::Right(v)))
-                } else {
-                    Err(())
-                }
-            }
+        if let Ok((n, v)) = self.0.parse(s) {
+            Ok((n, Either::Left(v)))
         } else {
-            Err(())
+            if let Ok((n, v)) = self.1.parse(s) {
+                Ok((n, Either::Right(v)))
+            } else {
+                Err(())
+            }
         }
     }
 
     open spec fn serialize_requires(&self) -> bool {
-        self.0.serialize_requires() && self.1.serialize_requires()
+        self.0.serialize_requires() && self.1.serialize_requires() && self@.1.disjoint_from(
+            &self@.0,
+        )
     }
 
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
         usize,
         (),
     >) {
-        if self.1.disjoint_from(&self.0) {
-            match v {
-                Either::Left(v) => {
-                    let n = self.0.serialize(v, data, pos)?;
-                    if n <= usize::MAX - pos && n + pos <= data.len() {
-                        Ok(n)
-                    } else {
-                        Err(())
-                    }
-                },
-                Either::Right(v) => {
-                    let n = self.1.serialize(v, data, pos)?;
-                    if n <= usize::MAX - pos && n + pos <= data.len() {
-                        Ok(n)
-                    } else {
-                        Err(())
-                    }
-                },
-            }
-        } else {
-            Err(())
+        match v {
+            Either::Left(v) => {
+                let n = self.0.serialize(v, data, pos)?;
+                if n <= usize::MAX - pos && n + pos <= data.len() {
+                    Ok(n)
+                } else {
+                    Err(())
+                }
+            },
+            Either::Right(v) => {
+                let n = self.1.serialize(v, data, pos)?;
+                if n <= usize::MAX - pos && n + pos <= data.len() {
+                    Ok(n)
+                } else {
+                    Err(())
+                }
+            },
         }
     }
 }
@@ -551,5 +523,4 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
 //         }
 //     }
 // }
-
 } // verus!

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -137,12 +137,6 @@ use crate::utils::*;
 use vstd::prelude::*;
 verus! {
 
-pub type SpecContent0 = Seq<u8>;
-
-pub type Content0<'a> = &'a [u8];
-
-pub type Content0Owned = Vec<u8>;
-
 pub struct SpecMsgD {
     pub f1: Seq<u8>,
     pub f2: u16,
@@ -248,6 +242,169 @@ impl From<MsgDOwnedInner> for MsgDOwned {
     fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
         let (f1, f2) = m;
         MsgDOwned { f1, f2 }
+    }
+}
+
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
+
+pub type SpecContent0 = Seq<u8>;
+
+pub type Content0<'a> = &'a [u8];
+
+pub type Content0Owned = Vec<u8>;
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecMsgCF4Inner = Either<Either<Either<SpecContent0, u16>, u32>, Seq<u8>>;
+
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
+        match m {
+            SpecMsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
+            SpecMsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
+            SpecMsgCF4::C2(m) => Either::Left(Either::Right(m)),
+            SpecMsgCF4::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => SpecMsgCF4::C0(m),
+            Either::Left(Either::Left(Either::Right(m))) => SpecMsgCF4::C1(m),
+            Either::Left(Either::Right(m)) => SpecMsgCF4::C2(m),
+            Either::Right(m) => SpecMsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
+    Unrecognized(&'a [u8]),
+}
+
+pub type MsgCF4Inner<'a> = Either<Either<Either<Content0<'a>, u16>, u32>, &'a [u8]>;
+
+impl View for MsgCF4<'_> {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
+        match m {
+            MsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
+            MsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
+            MsgCF4::C2(m) => Either::Left(Either::Right(m)),
+            MsgCF4::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => MsgCF4::C0(m),
+            Either::Left(Either::Left(Either::Right(m))) => MsgCF4::C1(m),
+            Either::Left(Either::Right(m)) => MsgCF4::C2(m),
+            Either::Right(m) => MsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub struct MsgCF4Mapper;
+
+impl View for MsgCF4Mapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgCF4Mapper {
+    type Src = SpecMsgCF4Inner;
+
+    type Dst = SpecMsgCF4;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgCF4Mapper {
+    type Src<'a> = MsgCF4Inner<'a>;
+
+    type Dst<'a> = MsgCF4<'a>;
+
+    type SrcOwned = MsgCF4OwnedInner;
+
+    type DstOwned = MsgCF4Owned;
+}
+
+pub enum MsgCF4Owned {
+    C0(Content0Owned),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Vec<u8>),
+}
+
+pub type MsgCF4OwnedInner = Either<Either<Either<Content0Owned, u16>, u32>, Vec<u8>>;
+
+impl View for MsgCF4Owned {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl From<MsgCF4Owned> for MsgCF4OwnedInner {
+    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
+        match m {
+            MsgCF4Owned::C0(m) => Either::Left(Either::Left(Either::Left(m))),
+            MsgCF4Owned::C1(m) => Either::Left(Either::Left(Either::Right(m))),
+            MsgCF4Owned::C2(m) => Either::Left(Either::Right(m)),
+            MsgCF4Owned::Unrecognized(m) => Either::Right(m),
+        }
+    }
+}
+
+impl From<MsgCF4OwnedInner> for MsgCF4Owned {
+    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
+        match m {
+            Either::Left(Either::Left(Either::Left(m))) => MsgCF4Owned::C0(m),
+            Either::Left(Either::Left(Either::Right(m))) => MsgCF4Owned::C1(m),
+            Either::Left(Either::Right(m)) => MsgCF4Owned::C2(m),
+            Either::Right(m) => MsgCF4Owned::Unrecognized(m),
+        }
     }
 }
 
@@ -464,152 +621,6 @@ impl From<MsgAOwnedInner> for MsgAOwned {
     }
 }
 
-pub type SpecContentType = u8;
-
-pub type ContentType = u8;
-
-pub type ContentTypeOwned = u8;
-
-pub enum SpecMsgCF4 {
-    C0(SpecContent0),
-    C1(u16),
-    C2(u32),
-}
-
-pub type SpecMsgCF4Inner = Either<Either<SpecContent0, u16>, u32>;
-
-impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
-    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
-        match m {
-            SpecMsgCF4::C0(m) => Either::Left(Either::Left(m)),
-            SpecMsgCF4::C1(m) => Either::Left(Either::Right(m)),
-            SpecMsgCF4::C2(m) => Either::Right(m),
-        }
-    }
-}
-
-impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
-    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
-        match m {
-            Either::Left(Either::Left(m)) => SpecMsgCF4::C0(m),
-            Either::Left(Either::Right(m)) => SpecMsgCF4::C1(m),
-            Either::Right(m) => SpecMsgCF4::C2(m),
-        }
-    }
-}
-
-pub enum MsgCF4<'a> {
-    C0(Content0<'a>),
-    C1(u16),
-    C2(u32),
-}
-
-pub type MsgCF4Inner<'a> = Either<Either<Content0<'a>, u16>, u32>;
-
-impl View for MsgCF4<'_> {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
-    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
-        match m {
-            MsgCF4::C0(m) => Either::Left(Either::Left(m)),
-            MsgCF4::C1(m) => Either::Left(Either::Right(m)),
-            MsgCF4::C2(m) => Either::Right(m),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
-    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
-        match m {
-            Either::Left(Either::Left(m)) => MsgCF4::C0(m),
-            Either::Left(Either::Right(m)) => MsgCF4::C1(m),
-            Either::Right(m) => MsgCF4::C2(m),
-        }
-    }
-}
-
-pub struct MsgCF4Mapper;
-
-impl View for MsgCF4Mapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for MsgCF4Mapper {
-    type Src = SpecMsgCF4Inner;
-
-    type Dst = SpecMsgCF4;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for MsgCF4Mapper {
-    type Src<'a> = MsgCF4Inner<'a>;
-
-    type Dst<'a> = MsgCF4<'a>;
-
-    type SrcOwned = MsgCF4OwnedInner;
-
-    type DstOwned = MsgCF4Owned;
-}
-
-pub enum MsgCF4Owned {
-    C0(Content0Owned),
-    C1(u16),
-    C2(u32),
-}
-
-pub type MsgCF4OwnedInner = Either<Either<Content0Owned, u16>, u32>;
-
-impl View for MsgCF4Owned {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
-        }
-    }
-}
-
-impl From<MsgCF4Owned> for MsgCF4OwnedInner {
-    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
-        match m {
-            MsgCF4Owned::C0(m) => Either::Left(Either::Left(m)),
-            MsgCF4Owned::C1(m) => Either::Left(Either::Right(m)),
-            MsgCF4Owned::C2(m) => Either::Right(m),
-        }
-    }
-}
-
-impl From<MsgCF4OwnedInner> for MsgCF4Owned {
-    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
-        match m {
-            Either::Left(Either::Left(m)) => MsgCF4Owned::C0(m),
-            Either::Left(Either::Right(m)) => MsgCF4Owned::C1(m),
-            Either::Right(m) => MsgCF4Owned::C2(m),
-        }
-    }
-}
-
 pub struct SpecMsgC {
     pub f2: SpecContentType,
     pub f3: u8,
@@ -721,8 +732,6 @@ impl From<MsgCOwnedInner> for MsgCOwned {
     }
 }
 
-pub type Content0Combinator = Bytes;
-
 pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
 
 pub exec const MSGD_F1: [u8; 4]
@@ -797,38 +806,26 @@ pub type MsgDCombinator = Mapped<
     MsgDMapper,
 >;
 
-pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
-
-pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
-
 pub type ContentTypeCombinator = U8;
+
+pub type Content0Combinator = Bytes;
 
 pub type MsgCF4Combinator = AndThen<
     Bytes,
     Mapped<
-        OrdChoice<
-            OrdChoice<Cond<Content0Combinator>, Cond<U16>>,
-            Cond<U32>,
-        >,
+        OrdChoice<OrdChoice<OrdChoice<Cond<Content0Combinator>, Cond<U16>>, Cond<U32>>, Cond<Tail>>,
         MsgCF4Mapper,
     >,
 >;
+
+pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
+
+pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
 
 pub type MsgCCombinator = Mapped<
     SpecDepend<(ContentTypeCombinator, U8), MsgCF4Combinator>,
     MsgCMapper,
 >;
-
-pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
-    Bytes(num as usize)
-}
-
-pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
-    ensures
-        o@ == spec_content_0(num@),
-{
-    Bytes(num as usize)
-}
 
 pub open spec fn spec_msg_d() -> MsgDCombinator {
     Mapped {
@@ -853,6 +850,69 @@ pub fn msg_d() -> (o: MsgDCombinator)
     }
 }
 
+pub open spec fn spec_content_type() -> ContentTypeCombinator {
+    U8
+}
+
+pub fn content_type() -> (o: ContentTypeCombinator)
+    ensures
+        o@ == spec_content_type(),
+{
+    U8
+}
+
+pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
+    Bytes(num as usize)
+}
+
+pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
+    ensures
+        o@ == spec_content_0(num@),
+{
+    Bytes(num as usize)
+}
+
+pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator {
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    OrdChoice(
+                        Cond { cond: f2 == 0, inner: spec_content_0(f3) },
+                        Cond { cond: f2 == 1, inner: U16 },
+                    ),
+                    Cond { cond: f2 == 2, inner: U32 },
+                ),
+                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
+    ensures
+        o@ == spec_msg_c_f4(f3@, f2@),
+{
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                OrdChoice(
+                    OrdChoice(
+                        Cond { cond: f2 == 0, inner: content_0(f3) },
+                        Cond { cond: f2 == 1, inner: U16 },
+                    ),
+                    Cond { cond: f2 == 2, inner: U32 },
+                ),
+                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
 pub open spec fn spec_msg_b() -> MsgBCombinator {
     Mapped { inner: spec_msg_d(), mapper: MsgBMapper }
 }
@@ -875,50 +935,57 @@ pub fn msg_a() -> (o: MsgACombinator)
     Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
 }
 
-pub open spec fn spec_content_type() -> ContentTypeCombinator {
-    U8
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
 }
 
-pub fn content_type() -> (o: ContentTypeCombinator)
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
+}
+
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
     ensures
-        o@ == spec_content_type(),
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
 {
-    U8
+    msg_d().parse(i)
 }
 
-pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> MsgCF4Combinator {
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    Cond { cond: f2 == 0, inner: spec_content_0(f3) },
-                    Cond { cond: f2 == 1, inner: U16 },
-                ),
-                Cond { cond: f2 == 2, inner: U32 },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
-pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
     ensures
-        o@ == spec_msg_c_f4(f2@, f3@),
-{
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    Cond { cond: f2 == 0, inner: content_0(f3) },
-                    Cond { cond: f2 == 1, inner: U16 },
-                ),
-                Cond { cond: f2 == 2, inner: U32 },
-            ),
-            mapper: MsgCF4Mapper,
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
-    )
+{
+    msg_d().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
+    spec_content_type().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
+    spec_content_type().spec_serialize(msg)
+}
+
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
+    ensures
+        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
+{
+    content_type().parse(i)
+}
+
+pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    (),
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_content_type(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    content_type().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
@@ -947,29 +1014,41 @@ pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, nu
     content_0(num).serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
-    spec_msg_d().spec_parse(i)
+pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f3: u8, f2: SpecContentType) -> Result<
+    (usize, SpecMsgCF4),
+    (),
+> {
+    spec_msg_c_f4(f3, f2).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
-    spec_msg_d().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f3: u8, f2: SpecContentType) -> Result<
+    Seq<u8>,
+    (),
+> {
+    spec_msg_c_f4(f3, f2).spec_serialize(msg)
 }
 
-pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
+pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<(usize, MsgCF4<'_>), ()>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f3@, f2@) matches Ok(r_) && r@ == r_,
 {
-    msg_d().parse(i)
+    msg_c_f4(f3, f2).parse(i)
 }
 
-pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_c_f4(
+    msg: MsgCF4<'_>,
+    data: &mut Vec<u8>,
+    pos: usize,
+    f3: u8,
+    f2: ContentType,
+) -> (o: Result<usize, ()>)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_c_f4(msg@, f3@, f2@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg_d().serialize(msg, data, pos)
+    msg_c_f4(f3, f2).serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
@@ -1022,77 +1101,12 @@ pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
     msg_a().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
-    spec_content_type().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
-    spec_content_type().spec_serialize(msg)
-}
-
-pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
-{
-    content_type().parse(i)
-}
-
-pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    (),
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_content_type(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    content_type().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u8) -> Result<
-    (usize, SpecMsgCF4),
-    (),
-> {
-    spec_msg_c_f4(f2, f3).spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f2: SpecContentType, f3: u8) -> Result<
-    Seq<u8>,
-    (),
-> {
-    spec_msg_c_f4(f2, f3).spec_serialize(msg)
-}
-
-pub fn parse_msg_c_f4(i: &[u8], f2: ContentType, f3: u8) -> (o: Result<(usize, MsgCF4<'_>), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f2@, f3@) matches Ok(r_) && r@ == r_,
-{
-    msg_c_f4(f2, f3).parse(i)
-}
-
-pub fn serialize_msg_c_f4(
-    msg: MsgCF4<'_>,
-    data: &mut Vec<u8>,
-    pos: usize,
-    f2: ContentType,
-    f3: u8,
-) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_c_f4(msg@, f2@, f3@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_c_f4(f2, f3).serialize(msg, data, pos)
-}
-
 pub open spec fn parse_spec_msg_c(i: Seq<u8>) -> Result<(usize, SpecMsgC), ()> {
     let fst = (spec_content_type(), U8);
     let snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_parse(i)
 }
@@ -1102,7 +1116,7 @@ pub open spec fn serialize_spec_msg_c(msg: SpecMsgC) -> Result<Seq<u8>, ()> {
     let snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_serialize(msg)
 }
@@ -1114,7 +1128,7 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
     let ghost spec_snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     let fst = (content_type(), U8);
     let snd = |deps: (ContentType, u8)| -> (o: MsgCF4Combinator)
@@ -1122,7 +1136,7 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
             o@ == spec_snd(deps@),
         {
             let (f2, f3) = deps;
-            msg_c_f4(f2, f3)
+            msg_c_f4(f3, f2)
         };
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.parse(i)
 }
@@ -1137,7 +1151,7 @@ pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
     let ghost spec_snd = |deps|
         {
             let (f2, f3) = deps;
-            spec_msg_c_f4(f2, f3)
+            spec_msg_c_f4(f3, f2)
         };
     let fst = (content_type(), U8);
     let snd = |deps: (ContentType, u8)| -> (o: MsgCF4Combinator)
@@ -1145,7 +1159,7 @@ pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
             o@ == spec_snd(deps@),
         {
             let (f2, f3) = deps;
-            msg_c_f4(f2, f3)
+            msg_c_f4(f3, f2)
         };
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.serialize(
         msg,

--- a/vest/src/regular/depend.rs
+++ b/vest/src/regular/depend.rs
@@ -866,10 +866,7 @@ mod test {
     type TlvContentCombinator = AndThen<
         Bytes,
         Mapped<
-            OrdChoice<
-                OrdChoice<Cond<u8, u8, Msg1Combinator>, Cond<u8, u8, Msg2Combinator>>,
-                Cond<u8, u8, Msg3Combinator>,
-            >,
+            OrdChoice<OrdChoice<Cond<Msg1Combinator>, Cond<Msg2Combinator>>, Cond<Msg3Combinator>>,
             TlvContentMapper,
         >,
     >;
@@ -895,10 +892,10 @@ mod test {
             Mapped {
                 inner: OrdChoice(
                     OrdChoice(
-                        Cond { lhs: tag, rhs: 1, inner: spec_msg1() },
-                        Cond { lhs: tag, rhs: 2, inner: spec_msg2() },
+                        Cond { cond: tag == 1, inner: spec_msg1() },
+                        Cond { cond: tag == 2, inner: spec_msg2() },
                     ),
-                    Cond { lhs: tag, rhs: 3, inner: spec_msg3() },
+                    Cond { cond: tag == 3, inner: spec_msg3() },
                 ),
                 mapper: TlvContentMapper,
             },
@@ -945,10 +942,10 @@ mod test {
             Mapped {
                 inner: OrdChoice(
                     OrdChoice(
-                        Cond { lhs: tag, rhs: 1, inner: msg1() },
-                        Cond { lhs: tag, rhs: 2, inner: msg2() },
+                        Cond { cond: tag == 1, inner: msg1() },
+                        Cond { cond: tag == 2, inner: msg2() },
                     ),
-                    Cond { lhs: tag, rhs: 3, inner: msg3() },
+                    Cond { cond: tag == 3, inner: msg3() },
                 ),
                 mapper: TlvContentMapper,
             },

--- a/vest/src/regular/disjoint.rs
+++ b/vest/src/regular/disjoint.rs
@@ -2,7 +2,7 @@ use super::bytes::Bytes;
 use super::bytes_n::BytesN;
 use super::choice::OrdChoice;
 use super::cond::Cond;
-use super::map::{Iso, Mapped, SpecIso};
+use super::map::{Mapped, SpecIso};
 use super::preceded::Preceded;
 use super::tag::Tag;
 use super::uints::{U16, U32, U64, U8};
@@ -11,16 +11,16 @@ use vstd::prelude::*;
 
 verus! {
 
-/// Spec version of [`DisjointFrom`].
-pub trait SpecDisjointFrom<Other> where Self: SpecCombinator, Other: SpecCombinator {
+/// A helper trait for [`OrdChoice`] combinator.
+pub trait DisjointFrom<Other> where Self: SpecCombinator, Other: SpecCombinator {
     /// pre-condition that must be held for [`Self`] and [`Other`] to be disjoint
-    spec fn spec_disjoint_from(&self, other: &Other) -> bool;
+    spec fn disjoint_from(&self, other: &Other) -> bool;
 
     /// The combinator [`Self`] is disjoint from the combinator [`Other`] if the bytes `buf` can be
     /// parsed by [`Self`] but not by [`Other`]
-    proof fn spec_parse_disjoint_on(&self, other: &Other, buf: Seq<u8>)
+    proof fn parse_disjoint_on(&self, other: &Other, buf: Seq<u8>)
         requires
-            self.spec_disjoint_from(
+            self.disjoint_from(
                 other,
             ),
     // just one direction is enough for the proofs of `OrdChoice`
@@ -33,21 +33,25 @@ pub trait SpecDisjointFrom<Other> where Self: SpecCombinator, Other: SpecCombina
 macro_rules! impl_spec_disjoint_for_int_type {
     ($combinator:ty) => {
         ::builtin_macros::verus! {
-            impl SpecDisjointFrom<$combinator> for $combinator {
+            impl DisjointFrom<$combinator> for $combinator {
                 /// two `Tag(T, value)`s are disjoint if their bytes `value`s are different
-                open spec fn spec_disjoint_from(&self, other: &$combinator) -> bool {
+                open spec fn disjoint_from(&self, other: &$combinator) -> bool {
                     self.0.predicate.0 != other.0.predicate.0
                 }
 
-                proof fn spec_parse_disjoint_on(&self, other: &$combinator, buf: Seq<u8>) {
+                proof fn parse_disjoint_on(&self, other: &$combinator, buf: Seq<u8>) {
                 }
             }
         }
     };
 }
+
 impl_spec_disjoint_for_int_type!(Tag<U8, u8>);
+
 impl_spec_disjoint_for_int_type!(Tag<U16, u16>);
+
 impl_spec_disjoint_for_int_type!(Tag<U32, u32>);
+
 impl_spec_disjoint_for_int_type!(Tag<U64, u64>);
 
 // impl<T: FromToBytes> SpecDisjointFrom<Tag<Int<T>, T>> for Tag<Int<T>, T> where
@@ -59,111 +63,105 @@ impl_spec_disjoint_for_int_type!(Tag<U64, u64>);
 //     proof fn spec_parse_disjoint_on(&self, other: &Tag<Int<T>, T>, buf: Seq<u8>) {
 //     }
 // }
-
 /// two `Tag(T, value)`s are disjoint if their bytes `value`s are different
-impl<const N: usize> SpecDisjointFrom<Tag<BytesN<N>, Seq<u8>>> for Tag<BytesN<N>, Seq<u8>> {
-    open spec fn spec_disjoint_from(&self, other: &Tag<BytesN<N>, Seq<u8>>) -> bool {
+impl<const N: usize> DisjointFrom<Tag<BytesN<N>, Seq<u8>>> for Tag<BytesN<N>, Seq<u8>> {
+    open spec fn disjoint_from(&self, other: &Tag<BytesN<N>, Seq<u8>>) -> bool {
         self.0.predicate.0 != other.0.predicate.0
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &Tag<BytesN<N>, Seq<u8>>, buf: Seq<u8>) {
+    proof fn parse_disjoint_on(&self, other: &Tag<BytesN<N>, Seq<u8>>, buf: Seq<u8>) {
     }
 }
 
 /// two `Tag(T, value)`s are disjoint if their bytes `value`s are different
-impl SpecDisjointFrom<Tag<Bytes, Seq<u8>>> for Tag<Bytes, Seq<u8>>
-{
-    open spec fn spec_disjoint_from(&self, other: &Tag<Bytes, Seq<u8>>) -> bool {
+impl DisjointFrom<Tag<Bytes, Seq<u8>>> for Tag<Bytes, Seq<u8>> {
+    open spec fn disjoint_from(&self, other: &Tag<Bytes, Seq<u8>>) -> bool {
         // must also say that two `Bytes` combinators are of the same length
         self.0.predicate.0 != other.0.predicate.0 && self.0.inner.0 == other.0.inner.0
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &Tag<Bytes, Seq<u8>>, buf: Seq<u8>) {
+    proof fn parse_disjoint_on(&self, other: &Tag<Bytes, Seq<u8>>, buf: Seq<u8>) {
     }
 }
 
 // if `U1` and `U2` are disjoint, then `(U1, V1)` and `(U2, V2)` are disjoint
-impl<U1, U2, V1, V2> SpecDisjointFrom<(U2, V2)> for (U1, V1) where
-    U1: SpecDisjointFrom<U2>,
+impl<U1, U2, V1, V2> DisjointFrom<(U2, V2)> for (U1, V1) where
+    U1: DisjointFrom<U2>,
     U1: SecureSpecCombinator,
     U2: SecureSpecCombinator,
     V1: SpecCombinator,
     V2: SpecCombinator,
  {
-    open spec fn spec_disjoint_from(&self, other: &(U2, V2)) -> bool {
-        self.0.spec_disjoint_from(&other.0)
+    open spec fn disjoint_from(&self, other: &(U2, V2)) -> bool {
+        self.0.disjoint_from(&other.0)
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &(U2, V2), buf: Seq<u8>) {
-        self.0.spec_parse_disjoint_on(&other.0, buf)
+    proof fn parse_disjoint_on(&self, other: &(U2, V2), buf: Seq<u8>) {
+        self.0.parse_disjoint_on(&other.0, buf)
     }
 }
 
 // if `U1` and `U2` are disjoint, then `preceded(U1, V1)` and `preceded(U2, V2)` are disjoint
-impl<U1, U2, V1, V2> SpecDisjointFrom<Preceded<U2, V2>> for Preceded<U1, V1> where
-    U1: SpecDisjointFrom<U2>,
+impl<U1, U2, V1, V2> DisjointFrom<Preceded<U2, V2>> for Preceded<U1, V1> where
+    U1: DisjointFrom<U2>,
     U1: SecureSpecCombinator<SpecResult = ()>,
     U2: SecureSpecCombinator<SpecResult = ()>,
     V1: SpecCombinator,
     V2: SpecCombinator,
  {
-    open spec fn spec_disjoint_from(&self, other: &Preceded<U2, V2>) -> bool {
-        self.0.spec_disjoint_from(&other.0)
+    open spec fn disjoint_from(&self, other: &Preceded<U2, V2>) -> bool {
+        self.0.disjoint_from(&other.0)
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &Preceded<U2, V2>, buf: Seq<u8>) {
-        self.0.spec_parse_disjoint_on(&other.0, buf)
+    proof fn parse_disjoint_on(&self, other: &Preceded<U2, V2>, buf: Seq<u8>) {
+        self.0.parse_disjoint_on(&other.0, buf)
     }
 }
 
-/// if `S3` is disjoint from both `S1` and `S2`, then `S3` is disjoint from `OrdChoice<T1, T2, S1, S2>`,
+/// if `S3` is disjoint from both `S1` and `S2`, then `S3` is disjoint from `OrdChoice<S1, S2>`,
 /// where `S2` is disjoint from `S1`
 ///
 /// this allows composition of the form `OrdChoice(OrdChoice(OrcChoice(...), ...), ...)`
-impl<U1, U2, U3> SpecDisjointFrom<OrdChoice<U1, U2>> for U3 where
-    U2: SpecDisjointFrom<U1>,
-    U3: SpecDisjointFrom<U1> + SpecDisjointFrom<U2>,
+impl<U1, U2, U3> DisjointFrom<OrdChoice<U1, U2>> for U3 where
+    U2: DisjointFrom<U1>,
+    U3: DisjointFrom<U1> + DisjointFrom<U2>,
     U1: SpecCombinator,
  {
-    open spec fn spec_disjoint_from(&self, other: &OrdChoice<U1, U2>) -> bool {
-        self.spec_disjoint_from(&other.0) && self.spec_disjoint_from(&other.1)
+    open spec fn disjoint_from(&self, other: &OrdChoice<U1, U2>) -> bool {
+        self.disjoint_from(&other.0) && self.disjoint_from(&other.1)
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &OrdChoice<U1, U2>, buf: Seq<u8>) {
-        self.spec_parse_disjoint_on(&other.0, buf);
-        self.spec_parse_disjoint_on(&other.1, buf);
+    proof fn parse_disjoint_on(&self, other: &OrdChoice<U1, U2>, buf: Seq<u8>) {
+        self.parse_disjoint_on(&other.0, buf);
+        self.parse_disjoint_on(&other.1, buf);
     }
 }
 
 /*
     the following impl is very similar to the previous one, but it states things a bit differently:
-    if `S1` and `S2` are both disjoint from `S3`, then `OrdChoice<T1, T2, S1, S2>` is disjoint from `S3`
+    if `S1` and `S2` are both disjoint from `S3`, then `OrdChoice<S1, S2>` is disjoint from `S3`
     this allows composition of the form `OrdChoice(..., OrdChoice(..., OrdChoice(..., ...)))`
     unfortunately, this creates conflicting implementations with the previous one
     */
 
-// impl<T1, T2, T3, S1, S2, S3> DisjointFrom<Either<T1, T2>, T3, S3> for OrdChoice<T1, T2, S1, S2>
+// impl<S1, S2, S3> DisjointFrom<S3> for OrdChoiceS1, S2>
 // where
-//     T1: View,
-//     T2: View,
-//     T3: View,
-//     S1: SpecCombinator<T1> + DisjointFrom<T1, T3, S3>,
-//     S2: SpecCombinator<T2> + DisjointFrom<T2, T1, S1> + DisjointFrom<T2, T3, S3>,
-//     S3: SpecCombinator<T3>,
+//     S1: SpecCombinator + DisjointFrom<S3>,
+//     S2: SpecCombinator + DisjointFrom<S1> + DisjointFrom<S3>,
+//     S3: SpecCombinator,
 // {
-//     fn disjoint_from(&self, other : &S3) -> bool {
-//         self.0.disjoint_from(other) && self.1.disjoint_from(other)
-//     }
-//     open spec fn spec_disjoint_from(&self, other : &S3) -> bool {
-//         self.0.spec_disjoint_from(other) && self.1.spec_disjoint_from(other)
-//     }
-//     proof fn spec_parse_disjoint_on(&self, other : &S3, buf : Seq<u8>) {
-//         self.0.spec_parse_disjoint_on(other, buf);
-//         self.1.spec_parse_disjoint_on(other, buf);
-//     }
+//    open spec fn disjoint_from(&self, other: &S3) -> bool {
+//        self.disjoint_from(other.0) && self.disjoint_from(other.1)
+//    }
+//
+//    proof fn parse_disjoint_on(&self, other: &S3, buf: Seq<u8>) {
+//        self.parse_disjoint_on(other.0, buf);
+//        self.parse_disjoint_on(other.1, buf);
+//    }
+//
 // }
-impl<U1, U2, M1, M2> SpecDisjointFrom<Mapped<U2, M2>> for Mapped<U1, M1> where
-    U1: SpecDisjointFrom<U2>,
+impl<U1, U2, M1, M2> DisjointFrom<Mapped<U2, M2>> for Mapped<U1, M1> where
+    U1: DisjointFrom<U2>,
     U2: SpecCombinator,
     M1: SpecIso<Src = U1::SpecResult>,
     M2: SpecIso<Src = U2::SpecResult>,
@@ -172,165 +170,25 @@ impl<U1, U2, M1, M2> SpecDisjointFrom<Mapped<U2, M2>> for Mapped<U1, M1> where
     M1::Dst: SpecFrom<U1::SpecResult>,
     M2::Dst: SpecFrom<U2::SpecResult>,
  {
-    open spec fn spec_disjoint_from(&self, other: &Mapped<U2, M2>) -> bool {
-        self.inner.spec_disjoint_from(&other.inner)
+    open spec fn disjoint_from(&self, other: &Mapped<U2, M2>) -> bool {
+        self.inner.disjoint_from(&other.inner)
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &Mapped<U2, M2>, buf: Seq<u8>) {
-        self.inner.spec_parse_disjoint_on(&other.inner, buf)
+    proof fn parse_disjoint_on(&self, other: &Mapped<U2, M2>, buf: Seq<u8>) {
+        self.inner.parse_disjoint_on(&other.inner, buf)
     }
 }
 
-/// two `Cond` combinators are disjoint if one and *only one* of their operands are equal
-impl<T, Inner1, Inner2> SpecDisjointFrom<Cond<T, T, Inner2>> for Cond<T, T, Inner1> where
+// if `self.cond` implies `!other.cond`, then `self` is disjoint from `other`
+impl<Inner1, Inner2> DisjointFrom<Cond<Inner2>> for Cond<Inner1> where
     Inner1: SpecCombinator,
     Inner2: SpecCombinator,
  {
-    open spec fn spec_disjoint_from(&self, other: &Cond<T, T, Inner2>) -> bool {
-        ||| (self.lhs == other.lhs) && (self.rhs != other.rhs)
-        ||| (self.lhs != other.lhs) && (self.rhs == other.rhs)
+    open spec fn disjoint_from(&self, other: &Cond<Inner2>) -> bool {
+        self.cond ==> !other.cond
     }
 
-    proof fn spec_parse_disjoint_on(&self, other: &Cond<T, T, Inner2>, buf: Seq<u8>) {
-    }
-}
-
-/// A helper trait for [`OrdChoice`] combinator.
-pub trait DisjointFrom<Other> where
-    Self::V: SpecDisjointFrom<Other::V>,
-    Self: Combinator,
-    Other: Combinator,
-    Self::V: SecureSpecCombinator<SpecResult = <Self::Owned as View>::V>,
-    Other::V: SecureSpecCombinator<SpecResult = <Other::Owned as View>::V>,
- {
-    /// pre-condition that must be held for `Self` and `Other` to be disjoint
-    fn disjoint_from(&self, other: &Other) -> (res: bool)
-        ensures
-            res == self@.spec_disjoint_from(&other@),
-    ;
-}
-
-macro_rules! impl_disjoint_for_int_type {
-    ($combinator:ty) => {
-        ::builtin_macros::verus! {
-            impl DisjointFrom<$combinator> for $combinator {
-                fn disjoint_from(&self, other: &$combinator) -> bool {
-                    self.0.predicate.0 != other.0.predicate.0
-                }
-            }
-        }
-    };
-}
-impl_disjoint_for_int_type!(Tag<U8, u8>);
-impl_disjoint_for_int_type!(Tag<U16, u16>);
-impl_disjoint_for_int_type!(Tag<U32, u32>);
-impl_disjoint_for_int_type!(Tag<U64, u64>);
-
-// impl<T: FromToBytes> DisjointFrom<Tag<Int<T>, T>> for Tag<Int<T>, T> {
-//     fn disjoint_from(&self, other: &Tag<Int<T>, T>) -> bool {
-//         !self.0.predicate.0.eq(&other.0.predicate.0)
-//     }
-// }
-
-impl<const N: usize> DisjointFrom<Tag<BytesN<N>, [u8; N]>> for Tag<BytesN<N>, [u8; N]> {
-    fn disjoint_from(&self, other: &Tag<BytesN<N>, [u8; N]>) -> bool {
-        !compare_slice(self.0.predicate.0.as_slice(), other.0.predicate.0.as_slice())
-    }
-}
-
-impl<'a, 'b> DisjointFrom<Tag<Bytes, &'b [u8]>> for Tag<Bytes, &'a [u8]> {
-    fn disjoint_from(&self, other: &Tag<Bytes, &[u8]>) -> bool {
-        !compare_slice(self.0.predicate.0, other.0.predicate.0) && self.0.inner.0 == other.0.inner.0
-    }
-}
-
-impl<U1, U2, V1, V2> DisjointFrom<(U2, V2)> for (U1, V1) where
-    U1: DisjointFrom<U2>,
-    U1::V: SpecDisjointFrom<U2::V>,
-    U1: Combinator,
-    U2: Combinator,
-    V1: Combinator,
-    V2: Combinator,
-    U1::V: SecureSpecCombinator<SpecResult = <U1::Owned as View>::V>,
-    U2::V: SecureSpecCombinator<SpecResult = <U2::Owned as View>::V>,
-    V1::V: SecureSpecCombinator<SpecResult = <V1::Owned as View>::V>,
-    V2::V: SecureSpecCombinator<SpecResult = <V2::Owned as View>::V>,
- {
-    fn disjoint_from(&self, other: &(U2, V2)) -> bool {
-        self.0.disjoint_from(&other.0)
-    }
-}
-
-impl<U1, U2, V1, V2> DisjointFrom<Preceded<U2, V2>> for Preceded<U1, V1> where
-    U1: DisjointFrom<U2>,
-    U1::V: SpecDisjointFrom<U2::V>,
-    U1: for <'a>Combinator<Result<'a> = (), Owned = ()>,
-    U2: for <'a>Combinator<Result<'a> = (), Owned = ()>,
-    V1: Combinator,
-    V2: Combinator,
-    U1::V: SecureSpecCombinator<SpecResult = ()>,
-    U2::V: SecureSpecCombinator<SpecResult = ()>,
-    V1::V: SecureSpecCombinator<SpecResult = <V1::Owned as View>::V>,
-    V2::V: SecureSpecCombinator<SpecResult = <V2::Owned as View>::V>,
- {
-    fn disjoint_from(&self, other: &Preceded<U2, V2>) -> bool {
-        self.0.disjoint_from(&other.0)
-    }
-}
-
-impl<U1, U2, U3> DisjointFrom<OrdChoice<U1, U2>> for U3 where
-    U2: DisjointFrom<U1>,
-    U3: DisjointFrom<U1> + DisjointFrom<U2>,
-    U2::V: SpecDisjointFrom<U1::V>,
-    U3::V: SpecDisjointFrom<U1::V> + SpecDisjointFrom<U2::V>,
-    U1: Combinator,
-    U2: Combinator,
-    U3: Combinator,
-    U1::V: SecureSpecCombinator<SpecResult = <U1::Owned as View>::V>,
-    U2::V: SecureSpecCombinator<SpecResult = <U2::Owned as View>::V>,
-    U3::V: SecureSpecCombinator<SpecResult = <U3::Owned as View>::V>,
- {
-    fn disjoint_from(&self, other: &OrdChoice<U1, U2>) -> bool {
-        self.disjoint_from(&other.0) && self.disjoint_from(&other.1)
-    }
-}
-
-impl<U1, U2, M1, M2> DisjointFrom<Mapped<U2, M2>> for Mapped<U1, M1> where
-    U1: DisjointFrom<U2>,
-    U1::V: SpecDisjointFrom<U2::V>,
-    U1: Combinator,
-    U2: Combinator,
-    U1::V: SecureSpecCombinator<SpecResult = <U1::Owned as View>::V>,
-    U2::V: SecureSpecCombinator<SpecResult = <U2::Owned as View>::V>,
-    for <'a>M1: Iso<Src<'a> = U1::Result<'a>, SrcOwned = U1::Owned> + View,
-    for <'a>M2: Iso<Src<'a> = U2::Result<'a>, SrcOwned = U2::Owned> + View,
-    for <'a>U1::Result<'a>: View + From<M1::Dst<'a>>,
-    for <'a>U2::Result<'a>: View + From<M2::Dst<'a>>,
-    for <'a>M1::Dst<'a>: View + From<U1::Result<'a>>,
-    for <'a>M2::Dst<'a>: View + From<U2::Result<'a>>,
-    M1::V: SpecIso<Src = <U1::Owned as View>::V, Dst = <M1::DstOwned as View>::V>,
-    M2::V: SpecIso<Src = <U2::Owned as View>::V, Dst = <M2::DstOwned as View>::V>,
-    <U1::Owned as View>::V: SpecFrom<<M1::DstOwned as View>::V>,
-    <U2::Owned as View>::V: SpecFrom<<M2::DstOwned as View>::V>,
-    <M1::DstOwned as View>::V: SpecFrom<<U1::Owned as View>::V>,
-    <M2::DstOwned as View>::V: SpecFrom<<U2::Owned as View>::V>,
- {
-    fn disjoint_from(&self, other: &Mapped<U2, M2>) -> bool {
-        self.inner.disjoint_from(&other.inner)
-    }
-}
-
-impl<Lhs, Rhs, Inner1, Inner2> DisjointFrom<Cond<Lhs, Rhs, Inner2>> for Cond<Lhs, Rhs, Inner1> where
-    Lhs: Compare<Rhs> + Compare<Lhs> + View,
-    Rhs: Compare<Rhs> + View<V = Lhs::V>,
-    Inner1: Combinator,
-    Inner2: Combinator,
-    Inner1::V: SecureSpecCombinator<SpecResult = <Inner1::Owned as View>::V>,
-    Inner2::V: SecureSpecCombinator<SpecResult = <Inner2::Owned as View>::V>,
-{
-    fn disjoint_from(&self, other: &Cond<Lhs, Rhs, Inner2>) -> bool {
-        (self.lhs.compare(&other.lhs) && !self.rhs.compare(&other.rhs))
-        || (!self.lhs.compare(&other.lhs) && self.rhs.compare(&other.rhs))
+    proof fn parse_disjoint_on(&self, other: &Cond<Inner2>, buf: Seq<u8>) {
     }
 }
 

--- a/vest/src/regular/tag.rs
+++ b/vest/src/regular/tag.rs
@@ -325,7 +325,7 @@ mod test {
     {
         let tag1 = Tag::new(U8, 0x42);
         let tag2 = Tag::new(U8, 0x43);
-        let ord = OrdChoice::new(tag1, tag2);
+        let ord = OrdChoice(tag1, tag2);
         if let Ok((n, v)) = ord.parse(s) {
             let mut buf = Vec::new();
             buf.push(0);
@@ -340,7 +340,7 @@ mod test {
         let b2 = [1u8, 0, 0];
         let tag3 = Tag::new(Bytes(3), b1.as_slice());
         let tag4 = Tag::new(Bytes(3), b2.as_slice());
-        let ord2 = OrdChoice::new(tag3, tag4);
+        let ord2 = OrdChoice(tag3, tag4);
         if let Ok((n, v)) = ord2.parse(s) {
             let mut buf = Vec::new();
             buf.push(0);

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -28,7 +28,7 @@ pub broadcast proof fn size_of_facts()
 }
 
 /// Combinator for parsing and serializing unsigned u8 integers.
-/// 
+///
 /// > **Note**: Currently, little-endian byte order is used for serialization and parsing.
 pub struct U8;
 

--- a/vest/src/utils.rs
+++ b/vest/src/utils.rs
@@ -101,7 +101,6 @@ impl<T, U> SpecTryInto<U> for T where U: SpecTryFrom<T> {
 //         Ok(U::spec_into(value))
 //     }
 // }
-
 /// Vest equivalent of [`std::convert::TryFrom`].
 pub trait TryFrom<T> where T: View, Self: View + Sized, Self::V: SpecTryFrom<T::V> {
     type Error;
@@ -142,12 +141,11 @@ impl<T, U> TryInto<U> for T where T: View, U: View, U: TryFrom<T>, U::V: SpecTry
 
 // impl<T, U> TryFrom<U> for T where T: View, U: View, U: Into<T>, U::V: SpecInto<T::V> {
 //     type Error = Infallible;
-//         
+//
 //     fn ex_try_from(value: U) -> Result<T, Infallible> {
 //         Ok(U::ex_into(value))
 //     }
 // }
-
 /// A helper trait for two different types that can be compared.
 pub trait Compare<Other> where Self: View, Other: View<V = Self::V> {
     /// Compare a value of `Self` with a value of `Other`.
@@ -265,7 +263,7 @@ macro_rules! declare_identity_view_reflex {
                 proof fn reflex(&self) {}
             }
         }
-    };
+};
 }
 
 declare_identity_view_reflex!(());


### PR DESCRIPTION
## The problem

@zhengyao-lin wanted to express something like
```rust
Depend {
    fst: U8,
    snd: (|l| -> (o: _) {
        if l < 0x80 {
            C1
        } else {
            C2
        }
    }),
    ...
};
```
in Vest. The closest combinators we have for these kinds of formats were `OrdChoice` and `Cond`:
```rust
Depend {
    fst: U8,
    snd: (|l| -> (o: ??) {
        OrdChoice(Cond {lhs: l, rhs: 0x80, inner: C1}, 
                Cond {lhs: l, rhs: 0x70, inner: C1}
        )
    }),
    ...
};
```

However, currently our `Cond<Lhs, Rhs, Inner>` combinator only supports equality comparison and hence the example is not expressible.

The primary reason for `Cond` being defined this way was to ensure that there is an _easy_ and _deterministic_ way of checking disjointness of two `Cond` combinators (which is needed for the security proofs of `OrdChoice` combinator).

> Since `Cond<Lhs, Rhs, Inner>` is equality comparison between `Lhs` and `Rhs`, `Cond(lhs1, rhs1, c1)` and `Cond(lhs2, rhs2, c2)` are disjoint iff `(lhs1 == lhs2 && rhs1 != rhs2) || (lhs1 != lhs2 && rhs1 == rhs2)`.

The other reason was that `Cond` was motivated by the tag checks of enum formats, where equality checks would suffice.

## The solution

We _could_ make `Cond` more expressive, by introducing more operators and logic connectives at the type (combinator) level and provide disjointness conditions for each one of them. For example, we could introduce a `Cond<Lhs, Op, Rhs, Inner>` combinator that behaves differently based on the operator `Op`, as well as `And<Cond<...>, Cond<...>`, `Or<Cond<...>, Cond<...>`, and `Not<Cond<...>>` combinators. This would enable expressing arbitrary boolean expressions and the proof should scale well. However, it would also complicate the Vest codebase quite a bit and make Vest DSL compiler harder to implement.

An alternative approach would be to have a general `Cond` combinator:
```rust
struct Cond<Inner> {
  cond: bool,
  inner: Inner,
}
```

Now the disjointness condition for two `Cond`s would be `p1.cond ==> !p2.cond` (one direction of the implication is enough for the security proof).

The upside of this approach is that now the format @zhengyao-lin tried to express is simply:

```rust
Depend {
    fst: U8,
    snd: (|l| -> (o: _) {
        OrdChoice(Cond { cond: l < 0x80, inner: C1}, 
                Cond { cond: l >= 0x80, inner: C2}
        )
    }),
    ...
};
```

And the disjointness condition `l >= 0x80 ==> !(l < 0x80)` would be checked by Verus.

More complex expressions would also work:
```rust
// suppose a and b are some parsed ints
let c1 = Cond { cond: a == 0 && b == 1, inner: U8 };
let c2 = Cond { cond: 0 < a && a < 5 && b == 1, inner: U16 };
let c3 = Cond { cond: a >= 5 && b == 1, inner: U32 };

let choice = OrdChoice(OrdChoice(c1, c2), c3);
```

The downside is that the _library user_ now could provide arbitrary rust expressions typed `bool` and stress Verus' check of `p1.cond ==> !p2.cond`. In practice this shouldn't be an issue? Also the DSL won't generate complex expressions. Maybe @parno can confirm with this.

This would also greatly simplify our encoding of open enums, since the default case would now be expressible with conjunctions (as was discussed with @pratapsingh1729  and @gancherj ).