### PR TITLE
Add Combinator trait impls for references

### DIFF
--- a/vest/src/properties.rs
+++ b/vest/src/properties.rs
@@ -125,6 +125,41 @@ pub trait Combinator: View where
     ;
 }
 
+impl<C: Combinator> Combinator for &C where
+    C::V: SecureSpecCombinator<SpecResult = <C::Owned as View>::V>,
+{
+    type Result<'a> = C::Result<'a>;
+    type Owned = C::Owned;
+
+    open spec fn spec_length(&self) -> Option<usize> {
+        (*self).spec_length()
+    }
+
+    fn length(&self) -> Option<usize> {
+        (*self).length()
+    }
+
+    fn exec_is_prefix_secure() -> bool {
+        C::exec_is_prefix_secure()
+    }
+
+    open spec fn parse_requires(&self) -> bool {
+        (*self).parse_requires()
+    }
+
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
+        (*self).parse(s)
+    }
+
+    open spec fn serialize_requires(&self) -> bool {
+        (*self).serialize_requires()
+    }
+
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, ()>) {
+        (*self).serialize(v, data, pos)
+    }
+}
+
 // The following is an attempt to support `Fn`s as combinators.
 // I started implementing it because Verus doesn't support existential types (impl Trait) yet,
 // which is required to be able to put `Depend` combinator in the function's return type,

--- a/vest/src/regular/disjoint.rs
+++ b/vest/src/regular/disjoint.rs
@@ -334,4 +334,16 @@ impl<Lhs, Rhs, Inner1, Inner2> DisjointFrom<Cond<Lhs, Rhs, Inner2>> for Cond<Lhs
     }
 }
 
+impl<'a, T1, T2> DisjointFrom<&'a T1> for &'a T2 where
+    T1: Combinator,
+    T2: Combinator + DisjointFrom<T1>,
+    T1::V: SecureSpecCombinator<SpecResult = <T1::Owned as View>::V>,
+    T2::V: SecureSpecCombinator<SpecResult = <T2::Owned as View>::V>,
+    T2::V: SpecDisjointFrom<T1::V>,
+{
+    fn disjoint_from(&self, other: &&T1) -> bool {
+        (*self).disjoint_from(*other)
+    }
+}
+
 } // verus!


### PR DESCRIPTION
Hello! Can I add these trait impls so that references of combinators can also be used as combinators?

This is useful in situations when, for example, using `Depend` with a user provided combinator:
```
fn new_combinator<C>(c: C) -> Depend<U8, C, ...>
{
    Depend {
        fst: U8,
        snd: |i| &c, // otherwise we have to clone `c` here
        ...
    }
}
```