### PR TITLE
Error types

### DIFF
--- a/vest-dsl/test/src/codegen.rs
+++ b/vest-dsl/test/src/codegen.rs
@@ -117,6 +117,117 @@ impl TryFromInto for ATypeMapper {
     type DstOwned = AType;
 }
 
+pub struct SpecMsg2 {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+pub type SpecMsg2Inner = (u8, (u16, u32));
+
+impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
+    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
+        (m.a, (m.b, m.c))
+    }
+}
+
+impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
+    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
+        let (a, (b, c)) = m;
+        SpecMsg2 { a, b, c }
+    }
+}
+
+pub struct Msg2 {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+pub type Msg2Inner = (u8, (u16, u32));
+
+impl View for Msg2 {
+    type V = SpecMsg2;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
+    }
+}
+
+impl From<Msg2> for Msg2Inner {
+    fn ex_from(m: Msg2) -> Msg2Inner {
+        (m.a, (m.b, m.c))
+    }
+}
+
+impl From<Msg2Inner> for Msg2 {
+    fn ex_from(m: Msg2Inner) -> Msg2 {
+        let (a, (b, c)) = m;
+        Msg2 { a, b, c }
+    }
+}
+
+pub struct Msg2Mapper;
+
+impl View for Msg2Mapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for Msg2Mapper {
+    type Src = SpecMsg2Inner;
+
+    type Dst = SpecMsg2;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for Msg2Mapper {
+    type Src<'a> = Msg2Inner;
+
+    type Dst<'a> = Msg2;
+
+    type SrcOwned = Msg2OwnedInner;
+
+    type DstOwned = Msg2Owned;
+}
+
+pub struct Msg2Owned {
+    pub a: u8,
+    pub b: u16,
+    pub c: u32,
+}
+
+pub type Msg2OwnedInner = (u8, (u16, u32));
+
+impl View for Msg2Owned {
+    type V = SpecMsg2;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
+    }
+}
+
+impl From<Msg2Owned> for Msg2OwnedInner {
+    fn ex_from(m: Msg2Owned) -> Msg2OwnedInner {
+        (m.a, (m.b, m.c))
+    }
+}
+
+impl From<Msg2OwnedInner> for Msg2Owned {
+    fn ex_from(m: Msg2OwnedInner) -> Msg2Owned {
+        let (a, (b, c)) = m;
+        Msg2Owned { a, b, c }
+    }
+}
+
 pub struct SpecMsg1 {
     pub a: u8,
     pub b: u16,
@@ -124,17 +235,17 @@ pub struct SpecMsg1 {
     pub d: Seq<u8>,
 }
 
-pub type SpecMsg1Inner = (((u8, u16), Seq<u8>), Seq<u8>);
+pub type SpecMsg1Inner = (u8, (u16, (Seq<u8>, Seq<u8>)));
 
 impl SpecFrom<SpecMsg1> for SpecMsg1Inner {
     open spec fn spec_from(m: SpecMsg1) -> SpecMsg1Inner {
-        (((m.a, m.b), m.c), m.d)
+        (m.a, (m.b, (m.c, m.d)))
     }
 }
 
 impl SpecFrom<SpecMsg1Inner> for SpecMsg1 {
     open spec fn spec_from(m: SpecMsg1Inner) -> SpecMsg1 {
-        let (((a, b), c), d) = m;
+        let (a, (b, (c, d))) = m;
         SpecMsg1 { a, b, c, d }
     }
 }
@@ -146,7 +257,7 @@ pub struct Msg1<'a> {
     pub d: &'a [u8],
 }
 
-pub type Msg1Inner<'a> = (((u8, u16), &'a [u8]), &'a [u8]);
+pub type Msg1Inner<'a> = (u8, (u16, (&'a [u8], &'a [u8])));
 
 impl View for Msg1<'_> {
     type V = SpecMsg1;
@@ -158,13 +269,13 @@ impl View for Msg1<'_> {
 
 impl<'a> From<Msg1<'a>> for Msg1Inner<'a> {
     fn ex_from(m: Msg1<'a>) -> Msg1Inner<'a> {
-        (((m.a, m.b), m.c), m.d)
+        (m.a, (m.b, (m.c, m.d)))
     }
 }
 
 impl<'a> From<Msg1Inner<'a>> for Msg1<'a> {
     fn ex_from(m: Msg1Inner<'a>) -> Msg1<'a> {
-        let (((a, b), c), d) = m;
+        let (a, (b, (c, d))) = m;
         Msg1 { a, b, c, d }
     }
 }
@@ -208,7 +319,7 @@ pub struct Msg1Owned {
     pub d: Vec<u8>,
 }
 
-pub type Msg1OwnedInner = (((u8, u16), Vec<u8>), Vec<u8>);
+pub type Msg1OwnedInner = (u8, (u16, (Vec<u8>, Vec<u8>)));
 
 impl View for Msg1Owned {
     type V = SpecMsg1;
@@ -220,125 +331,14 @@ impl View for Msg1Owned {
 
 impl From<Msg1Owned> for Msg1OwnedInner {
     fn ex_from(m: Msg1Owned) -> Msg1OwnedInner {
-        (((m.a, m.b), m.c), m.d)
+        (m.a, (m.b, (m.c, m.d)))
     }
 }
 
 impl From<Msg1OwnedInner> for Msg1Owned {
     fn ex_from(m: Msg1OwnedInner) -> Msg1Owned {
-        let (((a, b), c), d) = m;
+        let (a, (b, (c, d))) = m;
         Msg1Owned { a, b, c, d }
-    }
-}
-
-pub struct SpecMsg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type SpecMsg2Inner = ((u8, u16), u32);
-
-impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
-    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
-        ((m.a, m.b), m.c)
-    }
-}
-
-impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
-    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
-        let ((a, b), c) = m;
-        SpecMsg2 { a, b, c }
-    }
-}
-
-pub struct Msg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type Msg2Inner = ((u8, u16), u32);
-
-impl View for Msg2 {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
-    }
-}
-
-impl From<Msg2> for Msg2Inner {
-    fn ex_from(m: Msg2) -> Msg2Inner {
-        ((m.a, m.b), m.c)
-    }
-}
-
-impl From<Msg2Inner> for Msg2 {
-    fn ex_from(m: Msg2Inner) -> Msg2 {
-        let ((a, b), c) = m;
-        Msg2 { a, b, c }
-    }
-}
-
-pub struct Msg2Mapper;
-
-impl View for Msg2Mapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for Msg2Mapper {
-    type Src = SpecMsg2Inner;
-
-    type Dst = SpecMsg2;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for Msg2Mapper {
-    type Src<'a> = Msg2Inner;
-
-    type Dst<'a> = Msg2;
-
-    type SrcOwned = Msg2OwnedInner;
-
-    type DstOwned = Msg2Owned;
-}
-
-pub struct Msg2Owned {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type Msg2OwnedInner = ((u8, u16), u32);
-
-impl View for Msg2Owned {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
-    }
-}
-
-impl From<Msg2Owned> for Msg2OwnedInner {
-    fn ex_from(m: Msg2Owned) -> Msg2OwnedInner {
-        ((m.a, m.b), m.c)
-    }
-}
-
-impl From<Msg2OwnedInner> for Msg2Owned {
-    fn ex_from(m: Msg2OwnedInner) -> Msg2Owned {
-        let ((a, b), c) = m;
-        Msg2Owned { a, b, c }
     }
 }
 
@@ -354,14 +354,14 @@ pub enum SpecMsg4V {
     C(SpecMsg3),
 }
 
-pub type SpecMsg4VInner = Either<Either<SpecMsg1, SpecMsg2>, SpecMsg3>;
+pub type SpecMsg4VInner = Either<SpecMsg1, Either<SpecMsg2, SpecMsg3>>;
 
 impl SpecFrom<SpecMsg4V> for SpecMsg4VInner {
     open spec fn spec_from(m: SpecMsg4V) -> SpecMsg4VInner {
         match m {
-            SpecMsg4V::A(m) => Either::Left(Either::Left(m)),
-            SpecMsg4V::B(m) => Either::Left(Either::Right(m)),
-            SpecMsg4V::C(m) => Either::Right(m),
+            SpecMsg4V::A(m) => Either::Left(m),
+            SpecMsg4V::B(m) => Either::Right(Either::Left(m)),
+            SpecMsg4V::C(m) => Either::Right(Either::Right(m)),
         }
     }
 }
@@ -369,9 +369,9 @@ impl SpecFrom<SpecMsg4V> for SpecMsg4VInner {
 impl SpecFrom<SpecMsg4VInner> for SpecMsg4V {
     open spec fn spec_from(m: SpecMsg4VInner) -> SpecMsg4V {
         match m {
-            Either::Left(Either::Left(m)) => SpecMsg4V::A(m),
-            Either::Left(Either::Right(m)) => SpecMsg4V::B(m),
-            Either::Right(m) => SpecMsg4V::C(m),
+            Either::Left(m) => SpecMsg4V::A(m),
+            Either::Right(Either::Left(m)) => SpecMsg4V::B(m),
+            Either::Right(Either::Right(m)) => SpecMsg4V::C(m),
         }
     }
 }
@@ -382,7 +382,7 @@ pub enum Msg4V<'a> {
     C(Msg3<'a>),
 }
 
-pub type Msg4VInner<'a> = Either<Either<Msg1<'a>, Msg2>, Msg3<'a>>;
+pub type Msg4VInner<'a> = Either<Msg1<'a>, Either<Msg2, Msg3<'a>>>;
 
 impl View for Msg4V<'_> {
     type V = SpecMsg4V;
@@ -399,9 +399,9 @@ impl View for Msg4V<'_> {
 impl<'a> From<Msg4V<'a>> for Msg4VInner<'a> {
     fn ex_from(m: Msg4V<'a>) -> Msg4VInner<'a> {
         match m {
-            Msg4V::A(m) => Either::Left(Either::Left(m)),
-            Msg4V::B(m) => Either::Left(Either::Right(m)),
-            Msg4V::C(m) => Either::Right(m),
+            Msg4V::A(m) => Either::Left(m),
+            Msg4V::B(m) => Either::Right(Either::Left(m)),
+            Msg4V::C(m) => Either::Right(Either::Right(m)),
         }
     }
 }
@@ -409,9 +409,9 @@ impl<'a> From<Msg4V<'a>> for Msg4VInner<'a> {
 impl<'a> From<Msg4VInner<'a>> for Msg4V<'a> {
     fn ex_from(m: Msg4VInner<'a>) -> Msg4V<'a> {
         match m {
-            Either::Left(Either::Left(m)) => Msg4V::A(m),
-            Either::Left(Either::Right(m)) => Msg4V::B(m),
-            Either::Right(m) => Msg4V::C(m),
+            Either::Left(m) => Msg4V::A(m),
+            Either::Right(Either::Left(m)) => Msg4V::B(m),
+            Either::Right(Either::Right(m)) => Msg4V::C(m),
         }
     }
 }
@@ -454,7 +454,7 @@ pub enum Msg4VOwned {
     C(Msg3Owned),
 }
 
-pub type Msg4VOwnedInner = Either<Either<Msg1Owned, Msg2Owned>, Msg3Owned>;
+pub type Msg4VOwnedInner = Either<Msg1Owned, Either<Msg2Owned, Msg3Owned>>;
 
 impl View for Msg4VOwned {
     type V = SpecMsg4V;
@@ -471,9 +471,9 @@ impl View for Msg4VOwned {
 impl From<Msg4VOwned> for Msg4VOwnedInner {
     fn ex_from(m: Msg4VOwned) -> Msg4VOwnedInner {
         match m {
-            Msg4VOwned::A(m) => Either::Left(Either::Left(m)),
-            Msg4VOwned::B(m) => Either::Left(Either::Right(m)),
-            Msg4VOwned::C(m) => Either::Right(m),
+            Msg4VOwned::A(m) => Either::Left(m),
+            Msg4VOwned::B(m) => Either::Right(Either::Left(m)),
+            Msg4VOwned::C(m) => Either::Right(Either::Right(m)),
         }
     }
 }
@@ -481,9 +481,9 @@ impl From<Msg4VOwned> for Msg4VOwnedInner {
 impl From<Msg4VOwnedInner> for Msg4VOwned {
     fn ex_from(m: Msg4VOwnedInner) -> Msg4VOwned {
         match m {
-            Either::Left(Either::Left(m)) => Msg4VOwned::A(m),
-            Either::Left(Either::Right(m)) => Msg4VOwned::B(m),
-            Either::Right(m) => Msg4VOwned::C(m),
+            Either::Left(m) => Msg4VOwned::A(m),
+            Either::Right(Either::Left(m)) => Msg4VOwned::B(m),
+            Either::Right(Either::Right(m)) => Msg4VOwned::C(m),
         }
     }
 }
@@ -598,6 +598,8 @@ impl From<Msg4OwnedInner> for Msg4Owned {
 
 pub type ATypeCombinator = TryMap<U8, ATypeMapper>;
 
+pub type Msg2Combinator = Mapped<(U8, (U16, U32)), Msg2Mapper>;
+
 pub struct Predicate5821512137558126895;
 
 impl View for Predicate5821512137558126895 {
@@ -637,16 +639,14 @@ impl Pred for Predicate5821512137558126895 {
 }
 
 pub type Msg1Combinator = Mapped<
-    (((Refined<U8, Predicate5821512137558126895>, U16), BytesN<3>), Tail),
+    (Refined<U8, Predicate5821512137558126895>, (U16, (BytesN<3>, Tail))),
     Msg1Mapper,
 >;
-
-pub type Msg2Combinator = Mapped<((U8, U16), U32), Msg2Mapper>;
 
 pub type Msg3Combinator = BytesN<6>;
 
 pub type Msg4VCombinator = Mapped<
-    OrdChoice<OrdChoice<Cond<Msg1Combinator>, Cond<Msg2Combinator>>, Cond<Msg3Combinator>>,
+    OrdChoice<Cond<Msg1Combinator>, OrdChoice<Cond<Msg2Combinator>, Cond<Msg3Combinator>>>,
     Msg4VMapper,
 >;
 
@@ -663,11 +663,22 @@ pub fn a_type() -> (o: ATypeCombinator)
     TryMap { inner: U8, mapper: ATypeMapper }
 }
 
+pub open spec fn spec_msg2() -> Msg2Combinator {
+    Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper }
+}
+
+pub fn msg2() -> (o: Msg2Combinator)
+    ensures
+        o@ == spec_msg2(),
+{
+    Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper }
+}
+
 pub open spec fn spec_msg1() -> Msg1Combinator {
     Mapped {
         inner: (
-            ((Refined { inner: U8, predicate: Predicate5821512137558126895 }, U16), BytesN::<3>),
-            Tail,
+            Refined { inner: U8, predicate: Predicate5821512137558126895 },
+            (U16, (BytesN::<3>, Tail)),
         ),
         mapper: Msg1Mapper,
     }
@@ -679,22 +690,11 @@ pub fn msg1() -> (o: Msg1Combinator)
 {
     Mapped {
         inner: (
-            ((Refined { inner: U8, predicate: Predicate5821512137558126895 }, U16), BytesN::<3>),
-            Tail,
+            Refined { inner: U8, predicate: Predicate5821512137558126895 },
+            (U16, (BytesN::<3>, Tail)),
         ),
         mapper: Msg1Mapper,
     }
-}
-
-pub open spec fn spec_msg2() -> Msg2Combinator {
-    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
-}
-
-pub fn msg2() -> (o: Msg2Combinator)
-    ensures
-        o@ == spec_msg2(),
-{
-    Mapped { inner: ((U8, U16), U32), mapper: Msg2Mapper }
 }
 
 pub open spec fn spec_msg3() -> Msg3Combinator {
@@ -711,11 +711,11 @@ pub fn msg3() -> (o: Msg3Combinator)
 pub open spec fn spec_msg4_v(t: SpecAType) -> Msg4VCombinator {
     Mapped {
         inner: OrdChoice(
+            Cond { cond: t == AType::A, inner: spec_msg1() },
             OrdChoice(
-                Cond { cond: t == AType::A, inner: spec_msg1() },
                 Cond { cond: t == AType::B, inner: spec_msg2() },
+                Cond { cond: t == AType::C, inner: spec_msg3() },
             ),
-            Cond { cond: t == AType::C, inner: spec_msg3() },
         ),
         mapper: Msg4VMapper,
     }
@@ -727,11 +727,11 @@ pub fn msg4_v<'a>(t: AType) -> (o: Msg4VCombinator)
 {
     Mapped {
         inner: OrdChoice(
+            Cond { cond: t == AType::A, inner: msg1() },
             OrdChoice(
-                Cond { cond: t == AType::A, inner: msg1() },
                 Cond { cond: t == AType::B, inner: msg2() },
+                Cond { cond: t == AType::C, inner: msg3() },
             ),
-            Cond { cond: t == AType::C, inner: msg3() },
         ),
         mapper: Msg4VMapper,
     }
@@ -745,14 +745,17 @@ pub open spec fn serialize_spec_a_type(msg: SpecAType) -> Result<Seq<u8>, ()> {
     spec_a_type().spec_serialize(msg)
 }
 
-pub fn parse_a_type(i: &[u8]) -> (o: Result<(usize, AType), ()>)
+pub fn parse_a_type(i: &[u8]) -> (o: Result<(usize, AType), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_a_type(i@) matches Ok(r_) && r@ == r_,
 {
     a_type().parse(i)
 }
 
-pub fn serialize_a_type(msg: AType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_a_type(msg: AType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_a_type(msg@) matches Ok(buf)
@@ -760,31 +763,6 @@ pub fn serialize_a_type(msg: AType, data: &mut Vec<u8>, pos: usize) -> (o: Resul
         },
 {
     a_type().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_msg1(i: Seq<u8>) -> Result<(usize, SpecMsg1), ()> {
-    spec_msg1().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg1(msg: SpecMsg1) -> Result<Seq<u8>, ()> {
-    spec_msg1().spec_serialize(msg)
-}
-
-pub fn parse_msg1(i: &[u8]) -> (o: Result<(usize, Msg1<'_>), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg1(i@) matches Ok(r_) && r@ == r_,
-{
-    msg1().parse(i)
-}
-
-pub fn serialize_msg1(msg: Msg1<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg1(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg1().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg2(i: Seq<u8>) -> Result<(usize, SpecMsg2), ()> {
@@ -795,14 +773,17 @@ pub open spec fn serialize_spec_msg2(msg: SpecMsg2) -> Result<Seq<u8>, ()> {
     spec_msg2().spec_serialize(msg)
 }
 
-pub fn parse_msg2(i: &[u8]) -> (o: Result<(usize, Msg2), ()>)
+pub fn parse_msg2(i: &[u8]) -> (o: Result<(usize, Msg2), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg2(i@) matches Ok(r_) && r@ == r_,
 {
     msg2().parse(i)
 }
 
-pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg2(msg@) matches Ok(buf)
@@ -810,6 +791,34 @@ pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<u
         },
 {
     msg2().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg1(i: Seq<u8>) -> Result<(usize, SpecMsg1), ()> {
+    spec_msg1().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg1(msg: SpecMsg1) -> Result<Seq<u8>, ()> {
+    spec_msg1().spec_serialize(msg)
+}
+
+pub fn parse_msg1(i: &[u8]) -> (o: Result<(usize, Msg1<'_>), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg1(i@) matches Ok(r_) && r@ == r_,
+{
+    msg1().parse(i)
+}
+
+pub fn serialize_msg1(msg: Msg1<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg1(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg1().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg3(i: Seq<u8>) -> Result<(usize, SpecMsg3), ()> {
@@ -820,14 +829,17 @@ pub open spec fn serialize_spec_msg3(msg: SpecMsg3) -> Result<Seq<u8>, ()> {
     spec_msg3().spec_serialize(msg)
 }
 
-pub fn parse_msg3(i: &[u8]) -> (o: Result<(usize, Msg3<'_>), ()>)
+pub fn parse_msg3(i: &[u8]) -> (o: Result<(usize, Msg3<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg3(i@) matches Ok(r_) && r@ == r_,
 {
     msg3().parse(i)
 }
 
-pub fn serialize_msg3(msg: Msg3<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg3(msg: Msg3<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg3(msg@) matches Ok(buf)
@@ -845,7 +857,7 @@ pub open spec fn serialize_spec_msg4_v(msg: SpecMsg4V, t: SpecAType) -> Result<S
     spec_msg4_v(t).spec_serialize(msg)
 }
 
-pub fn parse_msg4_v(i: &[u8], t: AType) -> (o: Result<(usize, Msg4V<'_>), ()>)
+pub fn parse_msg4_v(i: &[u8], t: AType) -> (o: Result<(usize, Msg4V<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg4_v(i@, t@) matches Ok(r_) && r@ == r_,
 {
@@ -854,7 +866,7 @@ pub fn parse_msg4_v(i: &[u8], t: AType) -> (o: Result<(usize, Msg4V<'_>), ()>)
 
 pub fn serialize_msg4_v(msg: Msg4V<'_>, data: &mut Vec<u8>, pos: usize, t: AType) -> (o: Result<
     usize,
-    (),
+    SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
@@ -885,7 +897,7 @@ pub open spec fn serialize_spec_msg4(msg: SpecMsg4) -> Result<Seq<u8>, ()> {
     Mapped { inner: SpecDepend { fst, snd }, mapper: Msg4Mapper }.spec_serialize(msg)
 }
 
-pub fn parse_msg4(i: &[u8]) -> (o: Result<(usize, Msg4<'_>), ()>)
+pub fn parse_msg4(i: &[u8]) -> (o: Result<(usize, Msg4<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg4(i@) matches Ok(r_) && r@ == r_,
 {
@@ -905,7 +917,10 @@ pub fn parse_msg4(i: &[u8]) -> (o: Result<(usize, Msg4<'_>), ()>)
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: Msg4Mapper }.parse(i)
 }
 
-pub fn serialize_msg4(msg: Msg4<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg4(msg: Msg4<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg4(msg@) matches Ok(buf)

--- a/vest-dsl/test/src/elab.rs
+++ b/vest-dsl/test/src/elab.rs
@@ -14,6 +14,163 @@ use vest::utils::*;
 use vstd::prelude::*;
 verus! {
 
+pub type SpecContent0 = Seq<u8>;
+
+pub type Content0<'a> = &'a [u8];
+
+pub type Content0Owned = Vec<u8>;
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecMsgCF4Inner = Either<SpecContent0, Either<u16, Either<u32, Seq<u8>>>>;
+
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
+        match m {
+            SpecMsgCF4::C0(m) => Either::Left(m),
+            SpecMsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            SpecMsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecMsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+}
+
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
+        match m {
+            Either::Left(m) => SpecMsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => SpecMsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecMsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecMsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
+    Unrecognized(&'a [u8]),
+}
+
+pub type MsgCF4Inner<'a> = Either<Content0<'a>, Either<u16, Either<u32, &'a [u8]>>>;
+
+impl View for MsgCF4<'_> {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
+        match m {
+            MsgCF4::C0(m) => Either::Left(m),
+            MsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
+        match m {
+            Either::Left(m) => MsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub struct MsgCF4Mapper;
+
+impl View for MsgCF4Mapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgCF4Mapper {
+    type Src = SpecMsgCF4Inner;
+
+    type Dst = SpecMsgCF4;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgCF4Mapper {
+    type Src<'a> = MsgCF4Inner<'a>;
+
+    type Dst<'a> = MsgCF4<'a>;
+
+    type SrcOwned = MsgCF4OwnedInner;
+
+    type DstOwned = MsgCF4Owned;
+}
+
+pub enum MsgCF4Owned {
+    C0(Content0Owned),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Vec<u8>),
+}
+
+pub type MsgCF4OwnedInner = Either<Content0Owned, Either<u16, Either<u32, Vec<u8>>>>;
+
+impl View for MsgCF4Owned {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl From<MsgCF4Owned> for MsgCF4OwnedInner {
+    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
+        match m {
+            MsgCF4Owned::C0(m) => Either::Left(m),
+            MsgCF4Owned::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4Owned::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4Owned::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+}
+
+impl From<MsgCF4OwnedInner> for MsgCF4Owned {
+    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
+        match m {
+            Either::Left(m) => MsgCF4Owned::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4Owned::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4Owned::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4Owned::Unrecognized(m),
+        }
+    }
+}
+
 pub struct SpecMsgD {
     pub f1: Seq<u8>,
     pub f2: u16,
@@ -119,169 +276,6 @@ impl From<MsgDOwnedInner> for MsgDOwned {
     fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
         let (f1, f2) = m;
         MsgDOwned { f1, f2 }
-    }
-}
-
-pub type SpecContentType = u8;
-
-pub type ContentType = u8;
-
-pub type ContentTypeOwned = u8;
-
-pub type SpecContent0 = Seq<u8>;
-
-pub type Content0<'a> = &'a [u8];
-
-pub type Content0Owned = Vec<u8>;
-
-pub enum SpecMsgCF4 {
-    C0(SpecContent0),
-    C1(u16),
-    C2(u32),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecMsgCF4Inner = Either<Either<Either<SpecContent0, u16>, u32>, Seq<u8>>;
-
-impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
-    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
-        match m {
-            SpecMsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
-            SpecMsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
-            SpecMsgCF4::C2(m) => Either::Left(Either::Right(m)),
-            SpecMsgCF4::Unrecognized(m) => Either::Right(m),
-        }
-    }
-}
-
-impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
-    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
-        match m {
-            Either::Left(Either::Left(Either::Left(m))) => SpecMsgCF4::C0(m),
-            Either::Left(Either::Left(Either::Right(m))) => SpecMsgCF4::C1(m),
-            Either::Left(Either::Right(m)) => SpecMsgCF4::C2(m),
-            Either::Right(m) => SpecMsgCF4::Unrecognized(m),
-        }
-    }
-}
-
-pub enum MsgCF4<'a> {
-    C0(Content0<'a>),
-    C1(u16),
-    C2(u32),
-    Unrecognized(&'a [u8]),
-}
-
-pub type MsgCF4Inner<'a> = Either<Either<Either<Content0<'a>, u16>, u32>, &'a [u8]>;
-
-impl View for MsgCF4<'_> {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
-            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
-    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
-        match m {
-            MsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
-            MsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
-            MsgCF4::C2(m) => Either::Left(Either::Right(m)),
-            MsgCF4::Unrecognized(m) => Either::Right(m),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
-    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
-        match m {
-            Either::Left(Either::Left(Either::Left(m))) => MsgCF4::C0(m),
-            Either::Left(Either::Left(Either::Right(m))) => MsgCF4::C1(m),
-            Either::Left(Either::Right(m)) => MsgCF4::C2(m),
-            Either::Right(m) => MsgCF4::Unrecognized(m),
-        }
-    }
-}
-
-pub struct MsgCF4Mapper;
-
-impl View for MsgCF4Mapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for MsgCF4Mapper {
-    type Src = SpecMsgCF4Inner;
-
-    type Dst = SpecMsgCF4;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for MsgCF4Mapper {
-    type Src<'a> = MsgCF4Inner<'a>;
-
-    type Dst<'a> = MsgCF4<'a>;
-
-    type SrcOwned = MsgCF4OwnedInner;
-
-    type DstOwned = MsgCF4Owned;
-}
-
-pub enum MsgCF4Owned {
-    C0(Content0Owned),
-    C1(u16),
-    C2(u32),
-    Unrecognized(Vec<u8>),
-}
-
-pub type MsgCF4OwnedInner = Either<Either<Either<Content0Owned, u16>, u32>, Vec<u8>>;
-
-impl View for MsgCF4Owned {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
-            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
-        }
-    }
-}
-
-impl From<MsgCF4Owned> for MsgCF4OwnedInner {
-    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
-        match m {
-            MsgCF4Owned::C0(m) => Either::Left(Either::Left(Either::Left(m))),
-            MsgCF4Owned::C1(m) => Either::Left(Either::Left(Either::Right(m))),
-            MsgCF4Owned::C2(m) => Either::Left(Either::Right(m)),
-            MsgCF4Owned::Unrecognized(m) => Either::Right(m),
-        }
-    }
-}
-
-impl From<MsgCF4OwnedInner> for MsgCF4Owned {
-    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
-        match m {
-            Either::Left(Either::Left(Either::Left(m))) => MsgCF4Owned::C0(m),
-            Either::Left(Either::Left(Either::Right(m))) => MsgCF4Owned::C1(m),
-            Either::Left(Either::Right(m)) => MsgCF4Owned::C2(m),
-            Either::Right(m) => MsgCF4Owned::Unrecognized(m),
-        }
     }
 }
 
@@ -498,6 +492,12 @@ impl From<MsgAOwnedInner> for MsgAOwned {
     }
 }
 
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
+
 pub struct SpecMsgC {
     pub f2: SpecContentType,
     pub f3: u8,
@@ -609,6 +609,16 @@ impl From<MsgCOwnedInner> for MsgCOwned {
     }
 }
 
+pub type Content0Combinator = Bytes;
+
+pub type MsgCF4Combinator = AndThen<
+    Bytes,
+    Mapped<
+        OrdChoice<Cond<Content0Combinator>, OrdChoice<Cond<U16>, OrdChoice<Cond<U32>, Cond<Tail>>>>,
+        MsgCF4Mapper,
+    >,
+>;
+
 pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
 
 pub exec const MSGD_F1: [u8; 4]
@@ -683,26 +693,68 @@ pub type MsgDCombinator = Mapped<
     MsgDMapper,
 >;
 
-pub type ContentTypeCombinator = U8;
-
-pub type Content0Combinator = Bytes;
-
-pub type MsgCF4Combinator = AndThen<
-    Bytes,
-    Mapped<
-        OrdChoice<OrdChoice<OrdChoice<Cond<Content0Combinator>, Cond<U16>>, Cond<U32>>, Cond<Tail>>,
-        MsgCF4Mapper,
-    >,
->;
-
 pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
 
 pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
+
+pub type ContentTypeCombinator = U8;
 
 pub type MsgCCombinator = Mapped<
     SpecDepend<(ContentTypeCombinator, U8), MsgCF4Combinator>,
     MsgCMapper,
 >;
+
+pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
+    Bytes(num as usize)
+}
+
+pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
+    ensures
+        o@ == spec_content_0(num@),
+{
+    Bytes(num as usize)
+}
+
+pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator {
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                Cond { cond: f2 == 0, inner: spec_content_0(f3) },
+                OrdChoice(
+                    Cond { cond: f2 == 1, inner: U16 },
+                    OrdChoice(
+                        Cond { cond: f2 == 2, inner: U32 },
+                        Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+                    ),
+                ),
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
+    ensures
+        o@ == spec_msg_c_f4(f3@, f2@),
+{
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                Cond { cond: f2 == 0, inner: content_0(f3) },
+                OrdChoice(
+                    Cond { cond: f2 == 1, inner: U16 },
+                    OrdChoice(
+                        Cond { cond: f2 == 2, inner: U32 },
+                        Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+                    ),
+                ),
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
 
 pub open spec fn spec_msg_d() -> MsgDCombinator {
     Mapped {
@@ -727,69 +779,6 @@ pub fn msg_d() -> (o: MsgDCombinator)
     }
 }
 
-pub open spec fn spec_content_type() -> ContentTypeCombinator {
-    U8
-}
-
-pub fn content_type() -> (o: ContentTypeCombinator)
-    ensures
-        o@ == spec_content_type(),
-{
-    U8
-}
-
-pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
-    Bytes(num as usize)
-}
-
-pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
-    ensures
-        o@ == spec_content_0(num@),
-{
-    Bytes(num as usize)
-}
-
-pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator {
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    OrdChoice(
-                        Cond { cond: f2 == 0, inner: spec_content_0(f3) },
-                        Cond { cond: f2 == 1, inner: U16 },
-                    ),
-                    Cond { cond: f2 == 2, inner: U32 },
-                ),
-                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
-pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
-    ensures
-        o@ == spec_msg_c_f4(f3@, f2@),
-{
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    OrdChoice(
-                        Cond { cond: f2 == 0, inner: content_0(f3) },
-                        Cond { cond: f2 == 1, inner: U16 },
-                    ),
-                    Cond { cond: f2 == 2, inner: U32 },
-                ),
-                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
 pub open spec fn spec_msg_b() -> MsgBCombinator {
     Mapped { inner: spec_msg_d(), mapper: MsgBMapper }
 }
@@ -812,57 +801,15 @@ pub fn msg_a() -> (o: MsgACombinator)
     Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
 }
 
-pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
-    spec_msg_d().spec_parse(i)
+pub open spec fn spec_content_type() -> ContentTypeCombinator {
+    U8
 }
 
-pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
-    spec_msg_d().spec_serialize(msg)
-}
-
-pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
+pub fn content_type() -> (o: ContentTypeCombinator)
     ensures
-        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+        o@ == spec_content_type(),
 {
-    msg_d().parse(i)
-}
-
-pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_d().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
-    spec_content_type().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
-    spec_content_type().spec_serialize(msg)
-}
-
-pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
-{
-    content_type().parse(i)
-}
-
-pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    (),
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_content_type(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    content_type().serialize(msg, data, pos)
+    U8
 }
 
 pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
@@ -873,7 +820,7 @@ pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u8) -> Result<
     spec_content_0(num).spec_serialize(msg)
 }
 
-pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ()>)
+pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
 {
@@ -881,7 +828,7 @@ pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), (
 }
 
 pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u8) -> (o:
-    Result<usize, ()>)
+    Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_content_0(msg@, num@) matches Ok(buf)
@@ -905,7 +852,10 @@ pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f3: u8, f2: SpecConten
     spec_msg_c_f4(f3, f2).spec_serialize(msg)
 }
 
-pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<(usize, MsgCF4<'_>), ()>)
+pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<
+    (usize, MsgCF4<'_>),
+    ParseError,
+>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f3@, f2@) matches Ok(r_) && r@ == r_,
 {
@@ -918,7 +868,7 @@ pub fn serialize_msg_c_f4(
     pos: usize,
     f3: u8,
     f2: ContentType,
-) -> (o: Result<usize, ()>)
+) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_c_f4(msg@, f3@, f2@) matches Ok(buf)
@@ -926,6 +876,34 @@ pub fn serialize_msg_c_f4(
         },
 {
     msg_c_f4(f3, f2).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
+}
+
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_d().parse(i)
+}
+
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_d().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
@@ -936,14 +914,17 @@ pub open spec fn serialize_spec_msg_b(msg: SpecMsgB) -> Result<Seq<u8>, ()> {
     spec_msg_b().spec_serialize(msg)
 }
 
-pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ()>)
+pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_b(i@) matches Ok(r_) && r@ == r_,
 {
     msg_b().parse(i)
 }
 
-pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_b(msg@) matches Ok(buf)
@@ -961,14 +942,17 @@ pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
     spec_msg_a().spec_serialize(msg)
 }
 
-pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ()>)
+pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
 {
     msg_a().parse(i)
 }
 
-pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_a(msg@) matches Ok(buf)
@@ -976,6 +960,34 @@ pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
         },
 {
     msg_a().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
+    spec_content_type().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
+    spec_content_type().spec_serialize(msg)
+}
+
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
+{
+    content_type().parse(i)
+}
+
+pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_content_type(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    content_type().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg_c(i: Seq<u8>) -> Result<(usize, SpecMsgC), ()> {
@@ -998,7 +1010,7 @@ pub open spec fn serialize_spec_msg_c(msg: SpecMsgC) -> Result<Seq<u8>, ()> {
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_serialize(msg)
 }
 
-pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
+pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_c(i@) matches Ok(r_) && r@ == r_,
 {
@@ -1018,7 +1030,10 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.parse(i)
 }
 
-pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_c(msg@) matches Ok(buf)

--- a/vest-dsl/test/src/struct.rs
+++ b/vest-dsl/test/src/struct.rs
@@ -64,7 +64,8 @@ pub type ParseResult<'a, Output> = Result<(Stream<'a>, usize, Output), ParseErro
 pub type SpecParseResult<Output> = Result<(SpecStream, nat, Output), ParseError>;
 
 pub type SerializeResult = Result<(usize, usize), SerializeError>;
-  // (new start position, number of bytes written)
+
+// (new start position, number of bytes written)
 pub type SpecSerializeResult = Result<(SpecStream, nat), SerializeError>;
 
 /// opaque type abstraction over raw bytes
@@ -4385,7 +4386,7 @@ pub exec fn sec_parse_pair<P1, P2, R1, R2>(
             res,
             spec_parse_pair(spec_parser1, spec_parser2),
         ),
-        // prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
+// prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
 
 {
     proof {

--- a/vest-dsl/test/src/test.rs
+++ b/vest-dsl/test/src/test.rs
@@ -20,14 +20,14 @@ pub enum SpecARegularChoose {
     C(u32),
 }
 
-pub type SpecARegularChooseInner = Either<Either<u8, u16>, u32>;
+pub type SpecARegularChooseInner = Either<u8, Either<u16, u32>>;
 
 impl SpecFrom<SpecARegularChoose> for SpecARegularChooseInner {
     open spec fn spec_from(m: SpecARegularChoose) -> SpecARegularChooseInner {
         match m {
-            SpecARegularChoose::A(m) => Either::Left(Either::Left(m)),
-            SpecARegularChoose::B(m) => Either::Left(Either::Right(m)),
-            SpecARegularChoose::C(m) => Either::Right(m),
+            SpecARegularChoose::A(m) => Either::Left(m),
+            SpecARegularChoose::B(m) => Either::Right(Either::Left(m)),
+            SpecARegularChoose::C(m) => Either::Right(Either::Right(m)),
         }
     }
 }
@@ -35,9 +35,9 @@ impl SpecFrom<SpecARegularChoose> for SpecARegularChooseInner {
 impl SpecFrom<SpecARegularChooseInner> for SpecARegularChoose {
     open spec fn spec_from(m: SpecARegularChooseInner) -> SpecARegularChoose {
         match m {
-            Either::Left(Either::Left(m)) => SpecARegularChoose::A(m),
-            Either::Left(Either::Right(m)) => SpecARegularChoose::B(m),
-            Either::Right(m) => SpecARegularChoose::C(m),
+            Either::Left(m) => SpecARegularChoose::A(m),
+            Either::Right(Either::Left(m)) => SpecARegularChoose::B(m),
+            Either::Right(Either::Right(m)) => SpecARegularChoose::C(m),
         }
     }
 }
@@ -48,7 +48,7 @@ pub enum ARegularChoose {
     C(u32),
 }
 
-pub type ARegularChooseInner = Either<Either<u8, u16>, u32>;
+pub type ARegularChooseInner = Either<u8, Either<u16, u32>>;
 
 impl View for ARegularChoose {
     type V = SpecARegularChoose;
@@ -65,9 +65,9 @@ impl View for ARegularChoose {
 impl From<ARegularChoose> for ARegularChooseInner {
     fn ex_from(m: ARegularChoose) -> ARegularChooseInner {
         match m {
-            ARegularChoose::A(m) => Either::Left(Either::Left(m)),
-            ARegularChoose::B(m) => Either::Left(Either::Right(m)),
-            ARegularChoose::C(m) => Either::Right(m),
+            ARegularChoose::A(m) => Either::Left(m),
+            ARegularChoose::B(m) => Either::Right(Either::Left(m)),
+            ARegularChoose::C(m) => Either::Right(Either::Right(m)),
         }
     }
 }
@@ -75,9 +75,9 @@ impl From<ARegularChoose> for ARegularChooseInner {
 impl From<ARegularChooseInner> for ARegularChoose {
     fn ex_from(m: ARegularChooseInner) -> ARegularChoose {
         match m {
-            Either::Left(Either::Left(m)) => ARegularChoose::A(m),
-            Either::Left(Either::Right(m)) => ARegularChoose::B(m),
-            Either::Right(m) => ARegularChoose::C(m),
+            Either::Left(m) => ARegularChoose::A(m),
+            Either::Right(Either::Left(m)) => ARegularChoose::B(m),
+            Either::Right(Either::Right(m)) => ARegularChoose::C(m),
         }
     }
 }
@@ -120,7 +120,7 @@ pub enum ARegularChooseOwned {
     C(u32),
 }
 
-pub type ARegularChooseOwnedInner = Either<Either<u8, u16>, u32>;
+pub type ARegularChooseOwnedInner = Either<u8, Either<u16, u32>>;
 
 impl View for ARegularChooseOwned {
     type V = SpecARegularChoose;
@@ -137,9 +137,9 @@ impl View for ARegularChooseOwned {
 impl From<ARegularChooseOwned> for ARegularChooseOwnedInner {
     fn ex_from(m: ARegularChooseOwned) -> ARegularChooseOwnedInner {
         match m {
-            ARegularChooseOwned::A(m) => Either::Left(Either::Left(m)),
-            ARegularChooseOwned::B(m) => Either::Left(Either::Right(m)),
-            ARegularChooseOwned::C(m) => Either::Right(m),
+            ARegularChooseOwned::A(m) => Either::Left(m),
+            ARegularChooseOwned::B(m) => Either::Right(Either::Left(m)),
+            ARegularChooseOwned::C(m) => Either::Right(Either::Right(m)),
         }
     }
 }
@@ -147,9 +147,9 @@ impl From<ARegularChooseOwned> for ARegularChooseOwnedInner {
 impl From<ARegularChooseOwnedInner> for ARegularChooseOwned {
     fn ex_from(m: ARegularChooseOwnedInner) -> ARegularChooseOwned {
         match m {
-            Either::Left(Either::Left(m)) => ARegularChooseOwned::A(m),
-            Either::Left(Either::Right(m)) => ARegularChooseOwned::B(m),
-            Either::Right(m) => ARegularChooseOwned::C(m),
+            Either::Left(m) => ARegularChooseOwned::A(m),
+            Either::Right(Either::Left(m)) => ARegularChooseOwned::B(m),
+            Either::Right(Either::Right(m)) => ARegularChooseOwned::C(m),
         }
     }
 }
@@ -257,12 +257,6 @@ impl TryFromInto for AClosedEnumMapper {
     type DstOwned = AClosedEnum;
 }
 
-pub type SpecAnOpenEnum = u8;
-
-pub type AnOpenEnum = u8;
-
-pub type AnOpenEnumOwned = u8;
-
 pub enum SpecAChooseWithDefault {
     A(u8),
     B(u16),
@@ -270,15 +264,17 @@ pub enum SpecAChooseWithDefault {
     Unrecognized(Seq<u8>),
 }
 
-pub type SpecAChooseWithDefaultInner = Either<Either<Either<u8, u16>, u32>, Seq<u8>>;
+pub type SpecAChooseWithDefaultInner = Either<u8, Either<u16, Either<u32, Seq<u8>>>>;
 
 impl SpecFrom<SpecAChooseWithDefault> for SpecAChooseWithDefaultInner {
     open spec fn spec_from(m: SpecAChooseWithDefault) -> SpecAChooseWithDefaultInner {
         match m {
-            SpecAChooseWithDefault::A(m) => Either::Left(Either::Left(Either::Left(m))),
-            SpecAChooseWithDefault::B(m) => Either::Left(Either::Left(Either::Right(m))),
-            SpecAChooseWithDefault::C(m) => Either::Left(Either::Right(m)),
-            SpecAChooseWithDefault::Unrecognized(m) => Either::Right(m),
+            SpecAChooseWithDefault::A(m) => Either::Left(m),
+            SpecAChooseWithDefault::B(m) => Either::Right(Either::Left(m)),
+            SpecAChooseWithDefault::C(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecAChooseWithDefault::Unrecognized(m) => Either::Right(
+                Either::Right(Either::Right(m)),
+            ),
         }
     }
 }
@@ -286,10 +282,12 @@ impl SpecFrom<SpecAChooseWithDefault> for SpecAChooseWithDefaultInner {
 impl SpecFrom<SpecAChooseWithDefaultInner> for SpecAChooseWithDefault {
     open spec fn spec_from(m: SpecAChooseWithDefaultInner) -> SpecAChooseWithDefault {
         match m {
-            Either::Left(Either::Left(Either::Left(m))) => SpecAChooseWithDefault::A(m),
-            Either::Left(Either::Left(Either::Right(m))) => SpecAChooseWithDefault::B(m),
-            Either::Left(Either::Right(m)) => SpecAChooseWithDefault::C(m),
-            Either::Right(m) => SpecAChooseWithDefault::Unrecognized(m),
+            Either::Left(m) => SpecAChooseWithDefault::A(m),
+            Either::Right(Either::Left(m)) => SpecAChooseWithDefault::B(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecAChooseWithDefault::C(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecAChooseWithDefault::Unrecognized(
+                m,
+            ),
         }
     }
 }
@@ -301,7 +299,7 @@ pub enum AChooseWithDefault<'a> {
     Unrecognized(&'a [u8]),
 }
 
-pub type AChooseWithDefaultInner<'a> = Either<Either<Either<u8, u16>, u32>, &'a [u8]>;
+pub type AChooseWithDefaultInner<'a> = Either<u8, Either<u16, Either<u32, &'a [u8]>>>;
 
 impl View for AChooseWithDefault<'_> {
     type V = SpecAChooseWithDefault;
@@ -319,10 +317,10 @@ impl View for AChooseWithDefault<'_> {
 impl<'a> From<AChooseWithDefault<'a>> for AChooseWithDefaultInner<'a> {
     fn ex_from(m: AChooseWithDefault<'a>) -> AChooseWithDefaultInner<'a> {
         match m {
-            AChooseWithDefault::A(m) => Either::Left(Either::Left(Either::Left(m))),
-            AChooseWithDefault::B(m) => Either::Left(Either::Left(Either::Right(m))),
-            AChooseWithDefault::C(m) => Either::Left(Either::Right(m)),
-            AChooseWithDefault::Unrecognized(m) => Either::Right(m),
+            AChooseWithDefault::A(m) => Either::Left(m),
+            AChooseWithDefault::B(m) => Either::Right(Either::Left(m)),
+            AChooseWithDefault::C(m) => Either::Right(Either::Right(Either::Left(m))),
+            AChooseWithDefault::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
         }
     }
 }
@@ -330,10 +328,10 @@ impl<'a> From<AChooseWithDefault<'a>> for AChooseWithDefaultInner<'a> {
 impl<'a> From<AChooseWithDefaultInner<'a>> for AChooseWithDefault<'a> {
     fn ex_from(m: AChooseWithDefaultInner<'a>) -> AChooseWithDefault<'a> {
         match m {
-            Either::Left(Either::Left(Either::Left(m))) => AChooseWithDefault::A(m),
-            Either::Left(Either::Left(Either::Right(m))) => AChooseWithDefault::B(m),
-            Either::Left(Either::Right(m)) => AChooseWithDefault::C(m),
-            Either::Right(m) => AChooseWithDefault::Unrecognized(m),
+            Either::Left(m) => AChooseWithDefault::A(m),
+            Either::Right(Either::Left(m)) => AChooseWithDefault::B(m),
+            Either::Right(Either::Right(Either::Left(m))) => AChooseWithDefault::C(m),
+            Either::Right(Either::Right(Either::Right(m))) => AChooseWithDefault::Unrecognized(m),
         }
     }
 }
@@ -377,7 +375,7 @@ pub enum AChooseWithDefaultOwned {
     Unrecognized(Vec<u8>),
 }
 
-pub type AChooseWithDefaultOwnedInner = Either<Either<Either<u8, u16>, u32>, Vec<u8>>;
+pub type AChooseWithDefaultOwnedInner = Either<u8, Either<u16, Either<u32, Vec<u8>>>>;
 
 impl View for AChooseWithDefaultOwned {
     type V = SpecAChooseWithDefault;
@@ -395,10 +393,12 @@ impl View for AChooseWithDefaultOwned {
 impl From<AChooseWithDefaultOwned> for AChooseWithDefaultOwnedInner {
     fn ex_from(m: AChooseWithDefaultOwned) -> AChooseWithDefaultOwnedInner {
         match m {
-            AChooseWithDefaultOwned::A(m) => Either::Left(Either::Left(Either::Left(m))),
-            AChooseWithDefaultOwned::B(m) => Either::Left(Either::Left(Either::Right(m))),
-            AChooseWithDefaultOwned::C(m) => Either::Left(Either::Right(m)),
-            AChooseWithDefaultOwned::Unrecognized(m) => Either::Right(m),
+            AChooseWithDefaultOwned::A(m) => Either::Left(m),
+            AChooseWithDefaultOwned::B(m) => Either::Right(Either::Left(m)),
+            AChooseWithDefaultOwned::C(m) => Either::Right(Either::Right(Either::Left(m))),
+            AChooseWithDefaultOwned::Unrecognized(m) => Either::Right(
+                Either::Right(Either::Right(m)),
+            ),
         }
     }
 }
@@ -406,36 +406,44 @@ impl From<AChooseWithDefaultOwned> for AChooseWithDefaultOwnedInner {
 impl From<AChooseWithDefaultOwnedInner> for AChooseWithDefaultOwned {
     fn ex_from(m: AChooseWithDefaultOwnedInner) -> AChooseWithDefaultOwned {
         match m {
-            Either::Left(Either::Left(Either::Left(m))) => AChooseWithDefaultOwned::A(m),
-            Either::Left(Either::Left(Either::Right(m))) => AChooseWithDefaultOwned::B(m),
-            Either::Left(Either::Right(m)) => AChooseWithDefaultOwned::C(m),
-            Either::Right(m) => AChooseWithDefaultOwned::Unrecognized(m),
+            Either::Left(m) => AChooseWithDefaultOwned::A(m),
+            Either::Right(Either::Left(m)) => AChooseWithDefaultOwned::B(m),
+            Either::Right(Either::Right(Either::Left(m))) => AChooseWithDefaultOwned::C(m),
+            Either::Right(Either::Right(Either::Right(m))) => AChooseWithDefaultOwned::Unrecognized(
+                m,
+            ),
         }
     }
 }
 
+pub type SpecAnOpenEnum = u8;
+
+pub type AnOpenEnum = u8;
+
+pub type AnOpenEnumOwned = u8;
+
 pub type ARegularChooseCombinator = Mapped<
-    OrdChoice<OrdChoice<Cond<U8>, Cond<U16>>, Cond<U32>>,
+    OrdChoice<Cond<U8>, OrdChoice<Cond<U16>, Cond<U32>>>,
     ARegularChooseMapper,
 >;
 
 pub type AClosedEnumCombinator = TryMap<U8, AClosedEnumMapper>;
 
-pub type AnOpenEnumCombinator = U8;
-
 pub type AChooseWithDefaultCombinator = Mapped<
-    OrdChoice<OrdChoice<OrdChoice<Cond<U8>, Cond<U16>>, Cond<U32>>, Cond<Tail>>,
+    OrdChoice<Cond<U8>, OrdChoice<Cond<U16>, OrdChoice<Cond<U32>, Cond<Tail>>>>,
     AChooseWithDefaultMapper,
 >;
+
+pub type AnOpenEnumCombinator = U8;
 
 pub open spec fn spec_a_regular_choose(e: SpecAClosedEnum) -> ARegularChooseCombinator {
     Mapped {
         inner: OrdChoice(
+            Cond { cond: e == AClosedEnum::A, inner: U8 },
             OrdChoice(
-                Cond { cond: e == AClosedEnum::A, inner: U8 },
                 Cond { cond: e == AClosedEnum::B, inner: U16 },
+                Cond { cond: e == AClosedEnum::C, inner: U32 },
             ),
-            Cond { cond: e == AClosedEnum::C, inner: U32 },
         ),
         mapper: ARegularChooseMapper,
     }
@@ -447,11 +455,11 @@ pub fn a_regular_choose(e: AClosedEnum) -> (o: ARegularChooseCombinator)
 {
     Mapped {
         inner: OrdChoice(
+            Cond { cond: e == AClosedEnum::A, inner: U8 },
             OrdChoice(
-                Cond { cond: e == AClosedEnum::A, inner: U8 },
                 Cond { cond: e == AClosedEnum::B, inner: U16 },
+                Cond { cond: e == AClosedEnum::C, inner: U32 },
             ),
-            Cond { cond: e == AClosedEnum::C, inner: U32 },
         ),
         mapper: ARegularChooseMapper,
     }
@@ -468,25 +476,17 @@ pub fn a_closed_enum() -> (o: AClosedEnumCombinator)
     TryMap { inner: U8, mapper: AClosedEnumMapper }
 }
 
-pub open spec fn spec_an_open_enum() -> AnOpenEnumCombinator {
-    U8
-}
-
-pub fn an_open_enum() -> (o: AnOpenEnumCombinator)
-    ensures
-        o@ == spec_an_open_enum(),
-{
-    U8
-}
-
 pub open spec fn spec_a_choose_with_default(e: SpecAnOpenEnum) -> AChooseWithDefaultCombinator {
     Mapped {
         inner: OrdChoice(
+            Cond { cond: e == 0, inner: U8 },
             OrdChoice(
-                OrdChoice(Cond { cond: e == 0, inner: U8 }, Cond { cond: e == 1, inner: U16 }),
-                Cond { cond: e == 2, inner: U32 },
+                Cond { cond: e == 1, inner: U16 },
+                OrdChoice(
+                    Cond { cond: e == 2, inner: U32 },
+                    Cond { cond: !(e == 0 || e == 1 || e == 2), inner: Tail },
+                ),
             ),
-            Cond { cond: !(e == 0 || e == 1 || e == 2), inner: Tail },
         ),
         mapper: AChooseWithDefaultMapper,
     }
@@ -498,14 +498,28 @@ pub fn a_choose_with_default<'a>(e: AnOpenEnum) -> (o: AChooseWithDefaultCombina
 {
     Mapped {
         inner: OrdChoice(
+            Cond { cond: e == 0, inner: U8 },
             OrdChoice(
-                OrdChoice(Cond { cond: e == 0, inner: U8 }, Cond { cond: e == 1, inner: U16 }),
-                Cond { cond: e == 2, inner: U32 },
+                Cond { cond: e == 1, inner: U16 },
+                OrdChoice(
+                    Cond { cond: e == 2, inner: U32 },
+                    Cond { cond: !(e == 0 || e == 1 || e == 2), inner: Tail },
+                ),
             ),
-            Cond { cond: !(e == 0 || e == 1 || e == 2), inner: Tail },
         ),
         mapper: AChooseWithDefaultMapper,
     }
+}
+
+pub open spec fn spec_an_open_enum() -> AnOpenEnumCombinator {
+    U8
+}
+
+pub fn an_open_enum() -> (o: AnOpenEnumCombinator)
+    ensures
+        o@ == spec_an_open_enum(),
+{
+    U8
 }
 
 pub open spec fn parse_spec_a_regular_choose(i: Seq<u8>, e: SpecAClosedEnum) -> Result<
@@ -522,7 +536,10 @@ pub open spec fn serialize_spec_a_regular_choose(
     spec_a_regular_choose(e).spec_serialize(msg)
 }
 
-pub fn parse_a_regular_choose(i: &[u8], e: AClosedEnum) -> (o: Result<(usize, ARegularChoose), ()>)
+pub fn parse_a_regular_choose(i: &[u8], e: AClosedEnum) -> (o: Result<
+    (usize, ARegularChoose),
+    ParseError,
+>)
     ensures
         o matches Ok(r) ==> parse_spec_a_regular_choose(i@, e@) matches Ok(r_) && r@ == r_,
 {
@@ -534,7 +551,7 @@ pub fn serialize_a_regular_choose(
     data: &mut Vec<u8>,
     pos: usize,
     e: AClosedEnum,
-) -> (o: Result<usize, ()>)
+) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_a_regular_choose(msg@, e@) matches Ok(buf)
@@ -552,7 +569,7 @@ pub open spec fn serialize_spec_a_closed_enum(msg: SpecAClosedEnum) -> Result<Se
     spec_a_closed_enum().spec_serialize(msg)
 }
 
-pub fn parse_a_closed_enum(i: &[u8]) -> (o: Result<(usize, AClosedEnum), ()>)
+pub fn parse_a_closed_enum(i: &[u8]) -> (o: Result<(usize, AClosedEnum), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_a_closed_enum(i@) matches Ok(r_) && r@ == r_,
 {
@@ -561,7 +578,7 @@ pub fn parse_a_closed_enum(i: &[u8]) -> (o: Result<(usize, AClosedEnum), ()>)
 
 pub fn serialize_a_closed_enum(msg: AClosedEnum, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
-    (),
+    SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
@@ -570,34 +587,6 @@ pub fn serialize_a_closed_enum(msg: AClosedEnum, data: &mut Vec<u8>, pos: usize)
         },
 {
     a_closed_enum().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_an_open_enum(i: Seq<u8>) -> Result<(usize, SpecAnOpenEnum), ()> {
-    spec_an_open_enum().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_an_open_enum(msg: SpecAnOpenEnum) -> Result<Seq<u8>, ()> {
-    spec_an_open_enum().spec_serialize(msg)
-}
-
-pub fn parse_an_open_enum(i: &[u8]) -> (o: Result<(usize, AnOpenEnum), ()>)
-    ensures
-        o matches Ok(r) ==> parse_spec_an_open_enum(i@) matches Ok(r_) && r@ == r_,
-{
-    an_open_enum().parse(i)
-}
-
-pub fn serialize_an_open_enum(msg: AnOpenEnum, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    (),
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_an_open_enum(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    an_open_enum().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_a_choose_with_default(i: Seq<u8>, e: SpecAnOpenEnum) -> Result<
@@ -616,7 +605,7 @@ pub open spec fn serialize_spec_a_choose_with_default(
 
 pub fn parse_a_choose_with_default(i: &[u8], e: AnOpenEnum) -> (o: Result<
     (usize, AChooseWithDefault<'_>),
-    (),
+    ParseError,
 >)
     ensures
         o matches Ok(r) ==> parse_spec_a_choose_with_default(i@, e@) matches Ok(r_) && r@ == r_,
@@ -629,7 +618,7 @@ pub fn serialize_a_choose_with_default(
     data: &mut Vec<u8>,
     pos: usize,
     e: AnOpenEnum,
-) -> (o: Result<usize, ()>)
+) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_a_choose_with_default(msg@, e@) matches Ok(buf)
@@ -637,6 +626,34 @@ pub fn serialize_a_choose_with_default(
         },
 {
     a_choose_with_default(e).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_an_open_enum(i: Seq<u8>) -> Result<(usize, SpecAnOpenEnum), ()> {
+    spec_an_open_enum().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_an_open_enum(msg: SpecAnOpenEnum) -> Result<Seq<u8>, ()> {
+    spec_an_open_enum().spec_serialize(msg)
+}
+
+pub fn parse_an_open_enum(i: &[u8]) -> (o: Result<(usize, AnOpenEnum), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_an_open_enum(i@) matches Ok(r_) && r@ == r_,
+{
+    an_open_enum().parse(i)
+}
+
+pub fn serialize_an_open_enum(msg: AnOpenEnum, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_an_open_enum(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    an_open_enum().serialize(msg, data, pos)
 }
 
 } // verus!

--- a/vest-dsl/test/src/wireguard.rs
+++ b/vest-dsl/test/src/wireguard.rs
@@ -64,7 +64,8 @@ pub type ParseResult<'a, Output> = Result<(Stream<'a>, usize, Output), ParseErro
 pub type SpecParseResult<Output> = Result<(SpecStream, nat, Output), ParseError>;
 
 pub type SerializeResult = Result<(usize, usize), SerializeError>;
-  // (new start position, number of bytes written)
+
+// (new start position, number of bytes written)
 pub type SpecSerializeResult = Result<(SpecStream, nat), SerializeError>;
 
 /// opaque type abstraction over raw bytes
@@ -4385,7 +4386,7 @@ pub exec fn sec_parse_pair<P1, P2, R1, R2>(
             res,
             spec_parse_pair(spec_parser1, spec_parser2),
         ),
-        // prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
+// prop_parse_exec_spec_equiv(parse_pair(exec_parser1, exec_parser2, spec_parser1, spec_parser2), spec_parse_pair(spec_parser1, spec_parser2))
 
 {
     proof {

--- a/vest-examples/src/choice.rs
+++ b/vest-examples/src/choice.rs
@@ -20,7 +20,7 @@ exec fn disjoint_examples(a: u32, b: u8) -> Result<(), Error> {
     let c2 = Cond { cond: 0 < a && a < 5 && b == 2, inner: U16 };
     let c3 = Cond { cond: a >= 5 && b == 2, inner: U32 };
 
-    let choice = OrdChoice(OrdChoice(c1, c2), c3);
+    let choice = ord_choice!(c1, c2, c3);
 
     let mut data = my_vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     let mut s = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -42,8 +42,10 @@ exec fn choice_parse_serialize() -> Result<(), Error> {
     let g2 = (U32, (U16, U8));
     let g3 = (Tag::new(U8, 10), U32);
     let g4 = (BytesN::<12>, (U16, (U8, U8)));
-    let ord_choice1 = OrdChoice(
-        OrdChoice(OrdChoice((c1, g1), (c2, g2)), (c3, g3)),
+    let ord_choice1 = ord_choice!(
+        (c1, g1),
+        (c2, g2),
+        (c3, g3),
         (c4, g4),
     );
     let mut data1 =
@@ -112,13 +114,15 @@ exec fn choice_serialize_parse() -> Result<(), Error> {
     let g2 = (U32, (U16, U8));
     let g3 = (Tag::new(U8, 10), U32);
     let g4 = (BytesN::<12>, (U16, (U8, U8)));
-    let ord_choice1 = OrdChoice(
-        OrdChoice(OrdChoice((c1, g1), (c2, g2)), (c3, g3)),
+    let ord_choice1 = ord_choice!(
+        (c1, g1),
+        (c2, g2),
+        (c3, g3),
         (c4, g4),
     );
     let vec1 = my_vec![0x10u8, 0x11u8, 0x12u8, 0x13u8];
     let vec2 = my_vec![0x14u8, 0x15u8, 0x16u8, 0x17u8, 0x18u8];
-    let val1 = Either::Left(Either::Left(Either::Left(((), (vec1.as_slice(), vec2.as_slice())))));
+    let val1 = inj_ord_choice_result!(((), (vec1.as_slice(), vec2.as_slice())), *, *, *);
     let mut s1 = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     let len1 = ord_choice1.serialize(val1, &mut s1, 0)?;
     let (n1, val1_) = ord_choice1.parse(slice_subrange(s1.as_slice(), 0, len1))?;
@@ -136,7 +140,7 @@ exec fn choice_serialize_parse() -> Result<(), Error> {
         // }
     }
     let vec3 = my_vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-    let val2 = Either::Right(((), (vec3.as_slice(), (32000u16, (0u8, 0u8)))));
+    let val2 = inj_ord_choice_result!(*, *, *, ((), (vec3.as_slice(), (32000u16, (0u8, 0u8)))));
     let mut s2 = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
     let len2 = ord_choice1.serialize(val2, &mut s2, 0)?;
     let (n2, val2_) = ord_choice1.parse(slice_subrange(s2.as_slice(), 0, len2))?;

--- a/vest-examples/src/choice.rs
+++ b/vest-examples/src/choice.rs
@@ -15,7 +15,7 @@ verus! {
 
 broadcast use vest::regular::uints::size_of_facts;
 
-exec fn disjoint_examples(a: u32, b: u8) -> Result<(), ()> {
+exec fn disjoint_examples(a: u32, b: u8) -> Result<(), Error> {
     let c1 = Cond { cond: a == 0 && b == 1, inner: U8 };
     let c2 = Cond { cond: 0 < a && a < 5 && b == 2, inner: U16 };
     let c3 = Cond { cond: a >= 5 && b == 2, inner: U32 };
@@ -33,7 +33,7 @@ exec fn disjoint_examples(a: u32, b: u8) -> Result<(), ()> {
 //////////////////////////////////////
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
-exec fn choice_parse_serialize() -> Result<(), ()> {
+exec fn choice_parse_serialize() -> Result<(), Error> {
     let c1 = Tag::new(U8, 1);
     let c2 = Tag::new(U8, 2);
     let c3 = Tag::new(U8, 3);
@@ -103,7 +103,7 @@ exec fn choice_parse_serialize() -> Result<(), ()> {
 //////////////////////////////////////
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
-exec fn choice_serialize_parse() -> Result<(), ()> {
+exec fn choice_serialize_parse() -> Result<(), Error> {
     let c1 = Tag::new(U8, 1);
     let c2 = Tag::new(U8, 2);
     let c3 = Tag::new(U8, 3);

--- a/vest-examples/src/depend.rs
+++ b/vest-examples/src/depend.rs
@@ -57,7 +57,7 @@ pub open spec fn spec_parse_msg1(data: Seq<u8>) -> Result<
     }.spec_parse(data)
 }
 
-pub fn parse_msg1<'a>(data: &'a [u8]) -> (o: Result<(usize, ((u8, u16), (&'a [u8], &'a [u8]))), ()>)
+pub fn parse_msg1<'a>(data: &'a [u8]) -> (o: Result<(usize, ((u8, u16), (&'a [u8], &'a [u8]))), ParseError>)
     ensures
         o is Ok ==> o.unwrap()@ == spec_parse_msg1(data@).unwrap(),
         o is Err ==> spec_parse_msg1(data@) is Err,
@@ -93,7 +93,7 @@ pub open spec fn spec_serialize_msg1(v: ((u8, u16), (Seq<u8>, Seq<u8>))) -> Resu
 
 pub fn serialize_msg1(v: ((u8, u16), (&[u8], &[u8])), data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
-    (),
+    SerializeError,
 >)
     ensures
         o is Ok ==> o.unwrap() == spec_serialize_msg1(v@).unwrap().len() && data@ == seq_splice(

--- a/vest-examples/src/enums.rs
+++ b/vest-examples/src/enums.rs
@@ -45,12 +45,12 @@ spec fn spec_parse(x: Seq<u8>) -> Option<MyEnum> {
     let case1 = (tag1, payload1);
     let case2 = (tag2, payload2);
     let case3 = (tag3, payload3);
-    let comb = OrdChoice(OrdChoice(case1, case2), case3);
+    let comb = ord_choice!(case1, case2, case3);
     if let Ok((_, eithers)) = comb.spec_parse(x) {
         match eithers {
-            Either::Left(Either::Left((_, x))) => Some(MyEnum::A(x)),
-            Either::Left(Either::Right((_, x))) => Some(MyEnum::B(x)),
-            Either::Right(_) => Some(MyEnum::C()),
+            inj_ord_choice_pat!((_, x), *, *) => Some(MyEnum::A(x)),
+            inj_ord_choice_pat!(*, (_, x), *) => Some(MyEnum::B(x)),
+            inj_ord_choice_pat!(*, *, (_, x)) => Some(MyEnum::C()),
         }
     } else {
         None
@@ -71,12 +71,12 @@ fn exec_parse<'a>(x: &'a [u8]) -> (res: Option<MyEnumExec<'a>>)
     let case1 = (tag1, payload1);
     let case2 = (tag2, payload2);
     let case3 = (tag3, payload3);
-    let comb = OrdChoice(OrdChoice(case1, case2), case3);
+    let comb = ord_choice!(case1, case2, case3);
     if let Ok((_, eithers)) = comb.parse(x) {
         match eithers {
-            Either::Left(Either::Left((_, x))) => Some(MyEnumExec::A(x)),
-            Either::Left(Either::Right((_, x))) => Some(MyEnumExec::B(x)),
-            Either::Right(_) => Some(MyEnumExec::C()),
+            inj_ord_choice_pat!((_, x), *, *) => Some(MyEnumExec::A(x)),
+            inj_ord_choice_pat!(*, (_, x), *) => Some(MyEnumExec::B(x)),
+            inj_ord_choice_pat!(*, *, _) => Some(MyEnumExec::C()),
         }
     } else {
         None

--- a/vest-examples/src/map.rs
+++ b/vest-examples/src/map.rs
@@ -148,7 +148,7 @@ impl Iso for Msg1Mapper {
 //////////////////////////////////////
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
-fn parse_serialize() -> Result<(), ()> {
+fn parse_serialize() -> Result<(), Error> {
     let msg_inner = (U8, (U16, (Bytes(3), Tail)));
     let msg = Mapped { inner: msg_inner, mapper: Msg1Mapper };
     let mut data = my_vec![1u8, 123u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
@@ -166,7 +166,7 @@ fn parse_serialize() -> Result<(), ()> {
 //////////////////////////////////////
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
-fn serialize_parse() -> Result<(), ()> {
+fn serialize_parse() -> Result<(), Error> {
     let msg_inner = (U8, (U16, (Bytes(3), Tail)));
     let msg = Mapped { inner: msg_inner, mapper: Msg1Mapper };
     let bytes1: [u8; 3] = [0u8, 0u8, 1u8];
@@ -263,7 +263,7 @@ impl Iso for Msg2Mapper {
 //////////////////////////////////////
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
-fn parse_serialize2() -> Result<(), ()> {
+fn parse_serialize2() -> Result<(), Error> {
     let msg_inner = (U8, (U16, U32));
     let msg = Mapped { inner: msg_inner, mapper: Msg2Mapper };
     let mut data = my_vec![1u8, 123u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
@@ -281,7 +281,7 @@ fn parse_serialize2() -> Result<(), ()> {
 //////////////////////////////////////
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
-fn serialize_parse2() -> Result<(), ()> {
+fn serialize_parse2() -> Result<(), Error> {
     let msg_inner = (U8, (U16, U32));
     let msg = Mapped { inner: msg_inner, mapper: Msg2Mapper };
     let val = Msg2 { a: 1, b: 123, c: 1 };
@@ -404,7 +404,7 @@ impl Iso for Msg3Mapper {
 //////////////////////////////////////
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
-fn parse_serialize3() -> Result<(), ()> {
+fn parse_serialize3() -> Result<(), Error> {
     let msg_inner = BytesN::<6>;
     let msg = Mapped { inner: msg_inner, mapper: Msg3Mapper };
     let mut data = my_vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8];
@@ -423,7 +423,7 @@ fn parse_serialize3() -> Result<(), ()> {
 //////////////////////////////////////
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
-fn serialize_parse3() -> Result<(), ()> {
+fn serialize_parse3() -> Result<(), Error> {
     let msg_inner = BytesN::<6>;
     let msg = Mapped { inner: msg_inner, mapper: Msg3Mapper };
     let bytes: [u8; 6] = [1, 2, 3, 4, 5, 6];
@@ -585,7 +585,7 @@ impl Iso for Msg4Mapper {
 //////////////////////////////////////
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
-fn parse_serialize4() -> Result<(), ()> {
+fn parse_serialize4() -> Result<(), Error> {
     let tag1 = Tag::new(U8, 1);
     let tag2 = Tag::new(U8, 2);
     let tag3 = Tag::new(U8, 3);
@@ -618,7 +618,7 @@ fn parse_serialize4() -> Result<(), ()> {
 //////////////////////////////////////
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
-fn serialize_parse4() -> Result<(), ()> {
+fn serialize_parse4() -> Result<(), Error> {
     let tag1 = Tag::new(U8, 1);
     let tag2 = Tag::new(U8, 2);
     let tag3 = Tag::new(U8, 3);

--- a/vest-examples/src/map.rs
+++ b/vest-examples/src/map.rs
@@ -2,7 +2,6 @@ use crate::my_vec;
 use vest::properties::*;
 use vest::regular::bytes::*;
 use vest::regular::bytes_n::*;
-use vest::regular::choice::OrdChoice;
 use vest::regular::choice::*;
 use vest::regular::map::*;
 use vest::regular::preceded::*;
@@ -448,7 +447,7 @@ pub enum SpecMsg4 {
     M3(SpecMsg3),
 }
 
-pub type SpecMsg4Inner = Either<Either<SpecMsg1, Msg2>, SpecMsg3>;
+pub type SpecMsg4Inner = ord_choice_result!(SpecMsg1, Msg2, SpecMsg3);
 
 pub enum Msg4<'a> {
     M1(Msg1<'a>),
@@ -462,9 +461,8 @@ pub enum Msg4Owned {
     M3(Msg3Owned),
 }
 
-pub type Msg4Inner<'a> = Either<Either<Msg1<'a>, Msg2>, Msg3<'a>>;
-
-pub type Msg4InnerOwned = Either<Either<Msg1Owned, Msg2>, Msg3Owned>;
+pub type Msg4Inner<'a> = ord_choice_result!(Msg1<'a>, Msg2, Msg3<'a>);
+pub type Msg4InnerOwned = ord_choice_result!(Msg1Owned, Msg2, Msg3Owned);
 
 impl View for Msg4<'_> {
     type V = SpecMsg4;
@@ -493,9 +491,9 @@ impl View for Msg4Owned {
 impl SpecFrom<SpecMsg4> for SpecMsg4Inner {
     open spec fn spec_from(e: SpecMsg4) -> SpecMsg4Inner {
         match e {
-            SpecMsg4::M1(m) => Either::Left(Either::Left(m)),
-            SpecMsg4::M2(m) => Either::Left(Either::Right(m)),
-            SpecMsg4::M3(m) => Either::Right(m),
+            SpecMsg4::M1(m) => inj_ord_choice_result!(m, *, *),
+            SpecMsg4::M2(m) => inj_ord_choice_result!(*, m, *),
+            SpecMsg4::M3(m) => inj_ord_choice_result!(*, *, m),
         }
     }
 }
@@ -503,9 +501,9 @@ impl SpecFrom<SpecMsg4> for SpecMsg4Inner {
 impl SpecFrom<SpecMsg4Inner> for SpecMsg4 {
     open spec fn spec_from(e: SpecMsg4Inner) -> SpecMsg4 {
         match e {
-            Either::Left(Either::Left(m)) => SpecMsg4::M1(m),
-            Either::Left(Either::Right(m)) => SpecMsg4::M2(m),
-            Either::Right(m) => SpecMsg4::M3(m),
+            inj_ord_choice_pat!(m, *, *) => SpecMsg4::M1(m),
+            inj_ord_choice_pat!(*, m, *) => SpecMsg4::M2(m),
+            inj_ord_choice_pat!(*, *, m) => SpecMsg4::M3(m),
         }
     }
 }
@@ -513,9 +511,9 @@ impl SpecFrom<SpecMsg4Inner> for SpecMsg4 {
 impl<'a> From<Msg4<'a>> for Msg4Inner<'a> {
     fn ex_from(e: Msg4) -> (res: Msg4Inner) {
         match e {
-            Msg4::M1(m) => Either::Left(Either::Left(m)),
-            Msg4::M2(m) => Either::Left(Either::Right(m)),
-            Msg4::M3(m) => Either::Right(m),
+            Msg4::M1(m) => inj_ord_choice_result!(m, *, *),
+            Msg4::M2(m) => inj_ord_choice_result!(*, m, *),
+            Msg4::M3(m) => inj_ord_choice_result!(*, *, m),
         }
     }
 }
@@ -523,9 +521,9 @@ impl<'a> From<Msg4<'a>> for Msg4Inner<'a> {
 impl<'a> From<Msg4Inner<'a>> for Msg4<'a> {
     fn ex_from(e: Msg4Inner) -> (res: Msg4) {
         match e {
-            Either::Left(Either::Left(m)) => Msg4::M1(m),
-            Either::Left(Either::Right(m)) => Msg4::M2(m),
-            Either::Right(m) => Msg4::M3(m),
+            inj_ord_choice_pat!(m, *, *) => Msg4::M1(m),
+            inj_ord_choice_pat!(*, m, *) => Msg4::M2(m),
+            inj_ord_choice_pat!(*, *, m) => Msg4::M3(m),
         }
     }
 }
@@ -533,9 +531,9 @@ impl<'a> From<Msg4Inner<'a>> for Msg4<'a> {
 impl From<Msg4Owned> for Msg4InnerOwned {
     fn ex_from(e: Msg4Owned) -> (res: Msg4InnerOwned) {
         match e {
-            Msg4Owned::M1(m) => Either::Left(Either::Left(m)),
-            Msg4Owned::M2(m) => Either::Left(Either::Right(m)),
-            Msg4Owned::M3(m) => Either::Right(m),
+            Msg4Owned::M1(m) => inj_ord_choice_result!(m, *, *),
+            Msg4Owned::M2(m) => inj_ord_choice_result!(*, m, *),
+            Msg4Owned::M3(m) => inj_ord_choice_result!(*, *, m),
         }
     }
 }
@@ -543,9 +541,9 @@ impl From<Msg4Owned> for Msg4InnerOwned {
 impl From<Msg4InnerOwned> for Msg4Owned {
     fn ex_from(e: Msg4InnerOwned) -> (res: Msg4Owned) {
         match e {
-            Either::Left(Either::Left(m)) => Msg4Owned::M1(m),
-            Either::Left(Either::Right(m)) => Msg4Owned::M2(m),
-            Either::Right(m) => Msg4Owned::M3(m),
+            inj_ord_choice_pat!(m, *, *) => Msg4Owned::M1(m),
+            inj_ord_choice_pat!(*, m, *) => Msg4Owned::M2(m),
+            inj_ord_choice_pat!(*, *, m) => Msg4Owned::M3(m),
         }
     }
 }
@@ -592,7 +590,7 @@ fn parse_serialize4() -> Result<(), Error> {
     let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16, (Bytes(3), Tail))), mapper: Msg1Mapper });
     let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper });
     let msg3 = Preceded(tag3, Mapped { inner: BytesN::<6>, mapper: Msg3Mapper });
-    let msg_inner = OrdChoice(OrdChoice(msg1, msg2), msg3);
+    let msg_inner = ord_choice!(msg1, msg2, msg3);
     let msg = Mapped { inner: msg_inner, mapper: Msg4Mapper };
     let mut data = my_vec![1u8, 123u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
     let mut s = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -625,7 +623,7 @@ fn serialize_parse4() -> Result<(), Error> {
     let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16, (Bytes(3), Tail))), mapper: Msg1Mapper });
     let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper });
     let msg3 = Preceded(tag3, Mapped { inner: BytesN::<6>, mapper: Msg3Mapper });
-    let msg_inner = OrdChoice(OrdChoice(msg1, msg2), msg3);
+    let msg_inner = ord_choice!(msg1, msg2, msg3);
     let msg = Mapped { inner: msg_inner, mapper: Msg4Mapper };
     let bytes1: [u8; 3] = [0u8, 0u8, 1u8];
     let bytes2: [u8; 3] = [0u8, 0u8, 2u8];

--- a/vest-examples/src/pair.rs
+++ b/vest-examples/src/pair.rs
@@ -11,7 +11,7 @@ verus! {
 //////////////////////////////////////
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
-exec fn parse_serialize() -> Result<(), ()> {
+exec fn parse_serialize() -> Result<(), Error> {
     let msg1 = ((Tag::new(U8, 1), U32), Bytes(3));
     let mut data1 = my_vec![1u8, 0x40u8, 0xE2u8, 0x01u8, 0x00u8, 0u8, 0u8, 1u8, 0u8, 0u8, 0u8, 0u8];
     let mut s1 = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -37,7 +37,7 @@ exec fn parse_serialize() -> Result<(), ()> {
 //////////////////////////////////////
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
-exec fn serialize_parse() -> Result<(), ()> {
+exec fn serialize_parse() -> Result<(), Error> {
     let msg1 = ((Tag::new(U8, 1), U32), Bytes(3));
     let mut bytes = my_vec![0u8, 0u8, 1u8];
     let val1 = (((), 123456u32), bytes.as_slice());

--- a/vest/src/errors.rs
+++ b/vest/src/errors.rs
@@ -6,6 +6,7 @@ verus! {
 
 /// Parser errors
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub enum ParseError {
     /// The second combinator of AndThen did not consume all bytes
     AndThenUnusedBytes,
@@ -25,6 +26,7 @@ pub enum ParseError {
 
 /// Serializer errors
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub enum SerializeError {
     InsufficientBuffer,
     AndThenUnusedBytes,

--- a/vest/src/errors.rs
+++ b/vest/src/errors.rs
@@ -39,9 +39,13 @@ pub enum SerializeError {
     Other(String),
 }
 
+/// Sum of both parse and serialize errors
 #[derive(Debug)]
 pub enum Error {
+    /// Parser error
     Parse(ParseError),
+
+    /// Serializer error
     Serialize(SerializeError),
 }
 

--- a/vest/src/errors.rs
+++ b/vest/src/errors.rs
@@ -36,7 +36,7 @@ pub enum SerializeError {
     TryMapFailed,
     RefinedPredicateFailed,
     RepeatEmptyElement,
-	Other(String),
+    Other(String),
 }
 
 }

--- a/vest/src/errors.rs
+++ b/vest/src/errors.rs
@@ -39,4 +39,24 @@ pub enum SerializeError {
     Other(String),
 }
 
+#[derive(Debug)]
+pub enum Error {
+    Parse(ParseError),
+    Serialize(SerializeError),
 }
+
+impl std::convert::From<ParseError> for Error {
+    fn from(e: ParseError) -> Self {
+        Error::Parse(e)
+    }
+}
+
+impl std::convert::From<SerializeError> for Error {
+    fn from(e: SerializeError) -> Self {
+        Error::Serialize(e)
+    }
+}
+
+}
+
+

--- a/vest/src/errors.rs
+++ b/vest/src/errors.rs
@@ -1,0 +1,42 @@
+pub use crate::utils::*;
+use vstd::prelude::*;
+use vstd::*;
+
+verus! {
+
+/// Parser errors
+#[derive(Debug)]
+pub enum ParseError {
+    /// The second combinator of AndThen did not consume all bytes
+    AndThenUnusedBytes,
+    BuilderError,
+    UnexpectedEndOfInput,
+    OrdChoiceNoMatch,
+    CondFailed,
+    DependFstNotPrefixSecure,
+    PairFstNotPrefixSecure,
+    PrecededFstNotPrefixSecure,
+    SizeOverflow,
+    TryMapFailed,
+    RefinedPredicateFailed,
+    RepeatEmptyElement,
+    Other(String),
+}
+
+/// Serializer errors
+#[derive(Debug)]
+pub enum SerializeError {
+    InsufficientBuffer,
+    AndThenUnusedBytes,
+    CondFailed,
+    DependFstNotPrefixSecure,
+    PairFstNotPrefixSecure,
+    PrecededFstNotPrefixSecure,
+    SizeOverflow,
+    TryMapFailed,
+    RefinedPredicateFailed,
+    RepeatEmptyElement,
+	Other(String),
+}
+
+}

--- a/vest/src/lib.rs
+++ b/vest/src/lib.rs
@@ -97,3 +97,5 @@ pub mod regular;
 pub mod utils;
 //// Constant-time parser and serializer combinators.
 // mod secret;
+/// Error types
+pub mod errors;

--- a/vest/src/properties.rs
+++ b/vest/src/properties.rs
@@ -4,6 +4,39 @@ use vstd::*;
 
 verus! {
 
+/// Parser errors
+pub enum ParseError {
+    /// The second combinator of AndThen did not consume all bytes
+    AndThenUnusedBytes,
+    BuilderError,
+    UnexpectedEndOfInput,
+    OrdChoiceNoMatch,
+    CondFailed,
+    DependFstNotPrefixSecure,
+    PairFstNotPrefixSecure,
+    PrecededFstNotPrefixSecure,
+    SizeOverflow,
+    TryMapFailed,
+    RefinedPredicateFailed,
+    RepeatEmptyElement,
+    Other(String),
+}
+
+/// Serializer errors
+pub enum SerializeError {
+    InsufficientBuffer,
+    AndThenUnusedBytes,
+    CondFailed,
+    DependFstNotPrefixSecure,
+    PairFstNotPrefixSecure,
+    PrecededFstNotPrefixSecure,
+    SizeOverflow,
+    TryMapFailed,
+    RefinedPredicateFailed,
+    RepeatEmptyElement,
+	Other(String),
+}
+
 /// Specification for parser and serializer [`Combinator`]s. All Vest combinators must implement this
 /// trait.
 pub trait SpecCombinator {
@@ -92,7 +125,7 @@ pub trait Combinator: View where
     }
 
     /// The parsing function.
-    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>)
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>)
         requires
             self.parse_requires(),
         ensures
@@ -111,7 +144,7 @@ pub trait Combinator: View where
     /// The serialization function.
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
         usize,
-        (),
+        SerializeError,
     >)
         requires
             self.serialize_requires(),
@@ -182,7 +215,7 @@ impl<C: Combinator> Combinator for &C where
         (*self).parse_requires()
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
         (*self).parse(s)
     }
 
@@ -190,7 +223,7 @@ impl<C: Combinator> Combinator for &C where
         (*self).serialize_requires()
     }
 
-    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, ()>) {
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         (*self).serialize(v, data, pos)
     }
 }

--- a/vest/src/properties.rs
+++ b/vest/src/properties.rs
@@ -1,41 +1,9 @@
 pub use crate::utils::*;
+pub use crate::errors::*;
 use vstd::prelude::*;
 use vstd::*;
 
 verus! {
-
-/// Parser errors
-pub enum ParseError {
-    /// The second combinator of AndThen did not consume all bytes
-    AndThenUnusedBytes,
-    BuilderError,
-    UnexpectedEndOfInput,
-    OrdChoiceNoMatch,
-    CondFailed,
-    DependFstNotPrefixSecure,
-    PairFstNotPrefixSecure,
-    PrecededFstNotPrefixSecure,
-    SizeOverflow,
-    TryMapFailed,
-    RefinedPredicateFailed,
-    RepeatEmptyElement,
-    Other(String),
-}
-
-/// Serializer errors
-pub enum SerializeError {
-    InsufficientBuffer,
-    AndThenUnusedBytes,
-    CondFailed,
-    DependFstNotPrefixSecure,
-    PairFstNotPrefixSecure,
-    PrecededFstNotPrefixSecure,
-    SizeOverflow,
-    TryMapFailed,
-    RefinedPredicateFailed,
-    RepeatEmptyElement,
-	Other(String),
-}
 
 /// Specification for parser and serializer [`Combinator`]s. All Vest combinators must implement this
 /// trait.

--- a/vest/src/regular/and_then.rs
+++ b/vest/src/regular/and_then.rs
@@ -109,13 +109,13 @@ impl<Next: Combinator> Combinator for AndThen<Bytes, Next> where
         self.1.parse_requires()
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> Result<(usize, Self::Result<'a>), ()> {
+    fn parse<'a>(&self, s: &'a [u8]) -> Result<(usize, Self::Result<'a>), ParseError> {
         let (n, v1) = self.0.parse(s)?;
         let (m, v2) = self.1.parse(v1)?;
         if m == n {
             Ok((n, v2))
         } else {
-            Err(())
+            Err(ParseError::AndThenUnusedBytes)
         }
     }
 
@@ -123,12 +123,12 @@ impl<Next: Combinator> Combinator for AndThen<Bytes, Next> where
         self.1.serialize_requires()
     }
 
-    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, ()> {
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, SerializeError> {
         let n = self.1.serialize(v, data, pos)?;
         if n == self.0.0 {
             Ok(n)
         } else {
-            Err(())
+            Err(SerializeError::AndThenUnusedBytes)
         }
     }
 }

--- a/vest/src/regular/builder.rs
+++ b/vest/src/regular/builder.rs
@@ -107,7 +107,7 @@ impl<T> Combinator for BuilderCombinator<T> where T: Builder + View, T::V: Build
         false
     }
 
-    fn parse(&self, s: &[u8]) -> (res: Result<(usize, ()), ()>) {
+    fn parse(&self, s: &[u8]) -> (res: Result<(usize, ()), ParseError>) {
         let v = self.0.into_vec();
         proof {
             self.0.value_wf();
@@ -115,11 +115,11 @@ impl<T> Combinator for BuilderCombinator<T> where T: Builder + View, T::V: Build
         if compare_slice(s, v.as_slice()) {
             Ok((s.len(), ()))
         } else {
-            Err(())
+            Err(ParseError::BuilderError)
         }
     }
 
-    fn serialize(&self, v: (), data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, ()>) {
+    fn serialize(&self, v: (), data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         if self.0.length() <= data.len() && pos <= data.len() - self.0.length() {
             self.0.into_mut_vec(data, pos);
             assert(pos + self.0.value().len() <= data@.len());
@@ -127,7 +127,7 @@ impl<T> Combinator for BuilderCombinator<T> where T: Builder + View, T::V: Build
             assert(data@.subrange(pos as int, pos + self.0.value().len() as int) == self.0.value());
             Ok(self.0.length())
         } else {
-            Err(())
+            Err(SerializeError::InsufficientBuffer)
         }
     }
 }

--- a/vest/src/regular/bytes.rs
+++ b/vest/src/regular/bytes.rs
@@ -97,18 +97,18 @@ impl Combinator for Bytes {
         true
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
         if self.0 <= s.len() {
             let s_ = slice_subrange(s, 0, self.0);
             Ok((self.0, s_))
         } else {
-            Err(())
+            Err(ParseError::UnexpectedEndOfInput)
         }
     }
 
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
         usize,
-        (),
+        SerializeError,
     >) {
         if v.len() <= data.len() && v.len() == self.0 && pos <= data.len() - v.len() {
             set_range(data, pos, v);
@@ -117,7 +117,7 @@ impl Combinator for Bytes {
             ).unwrap());
             Ok(self.0)
         } else {
-            Err(())
+            Err(SerializeError::InsufficientBuffer)
         }
     }
 }

--- a/vest/src/regular/bytes_n.rs
+++ b/vest/src/regular/bytes_n.rs
@@ -78,25 +78,25 @@ impl<const N: usize> Combinator for BytesN<N> {
         true
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
         if N <= s.len() {
             let s_ = slice_subrange(s, 0, N);
             Ok((N, s_))
         } else {
-            Err(())
+            Err(ParseError::UnexpectedEndOfInput)
         }
     }
 
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
         usize,
-        (),
+        SerializeError,
     >) {
         if v.len() <= data.len() && v.len() == N && pos < data.len() - v.len() {
             set_range(data, pos, v);
             assert(data@.subrange(pos as int, pos + N as int) == self@.spec_serialize(v@).unwrap());
             Ok(N)
         } else {
-            Err(())
+            Err(SerializeError::InsufficientBuffer)
         }
     }
 }

--- a/vest/src/regular/choice.rs
+++ b/vest/src/regular/choice.rs
@@ -148,14 +148,14 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
         self.0.parse_requires() && self.1.parse_requires() && self@.1.disjoint_from(&self@.0)
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
         if let Ok((n, v)) = self.0.parse(s) {
             Ok((n, Either::Left(v)))
         } else {
             if let Ok((n, v)) = self.1.parse(s) {
                 Ok((n, Either::Right(v)))
             } else {
-                Err(())
+                Err(ParseError::OrdChoiceNoMatch)
             }
         }
     }
@@ -168,7 +168,7 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
 
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
         usize,
-        (),
+        SerializeError,
     >) {
         match v {
             Either::Left(v) => {
@@ -176,7 +176,7 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
                 if n <= usize::MAX - pos && n + pos <= data.len() {
                     Ok(n)
                 } else {
-                    Err(())
+                    Err(SerializeError::InsufficientBuffer)
                 }
             },
             Either::Right(v) => {
@@ -184,7 +184,7 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
                 if n <= usize::MAX - pos && n + pos <= data.len() {
                     Ok(n)
                 } else {
-                    Err(())
+                    Err(SerializeError::InsufficientBuffer)
                 }
             },
         }

--- a/vest/src/regular/choice.rs
+++ b/vest/src/regular/choice.rs
@@ -194,6 +194,7 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
 /// This macro constructs a nested OrdChoice combinator
 /// in the form of OrdChoice(..., OrdChoice(..., OrdChoice(..., ...)))
 #[allow(unused_macros)]
+#[macro_export]
 macro_rules! ord_choice {
     ($c:expr $(,)?) => {
         $c
@@ -203,10 +204,11 @@ macro_rules! ord_choice {
         OrdChoice($c, ord_choice!($($rest),*))
     };
 }
-pub(crate) use ord_choice;
+pub use ord_choice;
 
 /// Build a type for the `ord_choice!` macro
 #[allow(unused_macros)]
+#[macro_export]
 macro_rules! ord_choice_type {
     ($c:ty $(,)?) => {
         $c
@@ -216,10 +218,11 @@ macro_rules! ord_choice_type {
         OrdChoice<$c, ord_choice_type!($($rest),*)>
     };
 }
-pub(crate) use ord_choice_type;
+pub use ord_choice_type;
 
 /// Build a type for the result of `ord_choice!`
 #[allow(unused_macros)]
+#[macro_export]
 macro_rules! ord_choice_result {
     ($c:ty $(,)?) => {
         $c
@@ -229,24 +232,43 @@ macro_rules! ord_choice_result {
         Either<$c, ord_choice_result!($($rest),*)>
     };
 }
-pub(crate) use ord_choice_result;
+pub use ord_choice_result;
 
 /// Maps x:Ti to ord_choice_result!(T1, ..., Tn)
 #[allow(unused_macros)]
+#[macro_export]
 macro_rules! inj_ord_choice_result {
     (*, $($rest:tt),* $(,)?) => {
         Either::Right(inj_ord_choice_result!($($rest),*))
     };
 
-    ($x:ident $(,)?) => {
+    ($x:expr $(,)?) => {
         $x
     };
 
-    ($x:ident, $(*),* $(,)?) => {
+    ($x:expr, $(*),* $(,)?) => {
         Either::Left($x)
     };
 }
-pub(crate) use inj_ord_choice_result;
+pub use inj_ord_choice_result;
+
+/// Same as above but for patterns
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! inj_ord_choice_pat {
+    (*, $($rest:tt),* $(,)?) => {
+        Either::Right(inj_ord_choice_pat!($($rest),*))
+    };
+
+    ($x:pat $(,)?) => {
+        $x
+    };
+
+    ($x:pat, $(*),* $(,)?) => {
+        Either::Left($x)
+    };
+}
+pub use inj_ord_choice_pat;
 
 // what would it look like if we manually implemented the match combinator?
 //

--- a/vest/src/regular/choice.rs
+++ b/vest/src/regular/choice.rs
@@ -191,6 +191,63 @@ impl<Fst, Snd> Combinator for OrdChoice<Fst, Snd> where
     }
 }
 
+/// This macro constructs a nested OrdChoice combinator
+/// in the form of OrdChoice(..., OrdChoice(..., OrdChoice(..., ...)))
+#[allow(unused_macros)]
+macro_rules! ord_choice {
+    ($c:expr $(,)?) => {
+        $c
+    };
+
+    ($c:expr, $($rest:expr),* $(,)?) => {
+        OrdChoice($c, ord_choice!($($rest),*))
+    };
+}
+pub(crate) use ord_choice;
+
+/// Build a type for the `ord_choice!` macro
+#[allow(unused_macros)]
+macro_rules! ord_choice_type {
+    ($c:ty $(,)?) => {
+        $c
+    };
+
+    ($c:ty, $($rest:ty),* $(,)?) => {
+        OrdChoice<$c, ord_choice_type!($($rest),*)>
+    };
+}
+pub(crate) use ord_choice_type;
+
+/// Build a type for the result of `ord_choice!`
+#[allow(unused_macros)]
+macro_rules! ord_choice_result {
+    ($c:ty $(,)?) => {
+        $c
+    };
+
+    ($c:ty, $($rest:ty),* $(,)?) => {
+        Either<$c, ord_choice_result!($($rest),*)>
+    };
+}
+pub(crate) use ord_choice_result;
+
+/// Maps x:Ti to ord_choice_result!(T1, ..., Tn)
+#[allow(unused_macros)]
+macro_rules! inj_ord_choice_result {
+    (*, $($rest:tt),* $(,)?) => {
+        Either::Right(inj_ord_choice_result!($($rest),*))
+    };
+
+    ($x:ident $(,)?) => {
+        $x
+    };
+
+    ($x:ident, $(*),* $(,)?) => {
+        Either::Left($x)
+    };
+}
+pub(crate) use inj_ord_choice_result;
+
 // what would it look like if we manually implemented the match combinator?
 //
 // use super::uints::*;

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -98,11 +98,11 @@ impl<Inner: Combinator> Combinator for Cond<Inner> where
         self.inner.parse_requires()
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> Result<(usize, Self::Result<'a>), ()> {
+    fn parse<'a>(&self, s: &'a [u8]) -> Result<(usize, Self::Result<'a>), ParseError> {
         if self.cond {
             self.inner.parse(s)
         } else {
-            Err(())
+            Err(ParseError::CondFailed)
         }
     }
 
@@ -110,11 +110,11 @@ impl<Inner: Combinator> Combinator for Cond<Inner> where
         self.inner.serialize_requires()
     }
 
-    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, ()> {
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, SerializeError> {
         if self.cond {
             self.inner.serialize(v, data, pos)
         } else {
-            Err(())
+            Err(SerializeError::CondFailed)
         }
     }
 }
@@ -943,14 +943,14 @@ pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
     spec_msg_d().spec_serialize(msg)
 }
 
-pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ()>)
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
 {
     msg_d().parse(i)
 }
 
-pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_d(msg@) matches Ok(buf)
@@ -968,7 +968,7 @@ pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq
     spec_content_type().spec_serialize(msg)
 }
 
-pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
 {
@@ -977,7 +977,7 @@ pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ()>)
 
 pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
-    (),
+    SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
@@ -996,7 +996,7 @@ pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u8) -> Result<
     spec_content_0(num).spec_serialize(msg)
 }
 
-pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ()>)
+pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
 {
@@ -1004,7 +1004,7 @@ pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), (
 }
 
 pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u8) -> (o:
-    Result<usize, ()>)
+    Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_content_0(msg@, num@) matches Ok(buf)
@@ -1028,7 +1028,7 @@ pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f3: u8, f2: SpecConten
     spec_msg_c_f4(f3, f2).spec_serialize(msg)
 }
 
-pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<(usize, MsgCF4<'_>), ()>)
+pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<(usize, MsgCF4<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f3@, f2@) matches Ok(r_) && r@ == r_,
 {
@@ -1041,7 +1041,7 @@ pub fn serialize_msg_c_f4(
     pos: usize,
     f3: u8,
     f2: ContentType,
-) -> (o: Result<usize, ()>)
+) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_c_f4(msg@, f3@, f2@) matches Ok(buf)
@@ -1059,14 +1059,14 @@ pub open spec fn serialize_spec_msg_b(msg: SpecMsgB) -> Result<Seq<u8>, ()> {
     spec_msg_b().spec_serialize(msg)
 }
 
-pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ()>)
+pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_b(i@) matches Ok(r_) && r@ == r_,
 {
     msg_b().parse(i)
 }
 
-pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_b(msg@) matches Ok(buf)
@@ -1084,14 +1084,14 @@ pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
     spec_msg_a().spec_serialize(msg)
 }
 
-pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ()>)
+pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
 {
     msg_a().parse(i)
 }
 
-pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_a(msg@) matches Ok(buf)
@@ -1121,7 +1121,7 @@ pub open spec fn serialize_spec_msg_c(msg: SpecMsgC) -> Result<Seq<u8>, ()> {
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }.spec_serialize(msg)
 }
 
-pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
+pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_c(i@) matches Ok(r_) && r@ == r_,
 {
@@ -1141,7 +1141,7 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ()>)
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.parse(i)
 }
 
-pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, ()>)
+pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_c(msg@) matches Ok(buf)

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -137,6 +137,164 @@ use crate::utils::*;
 use vstd::prelude::*;
 verus! {
 
+
+pub type SpecContent0 = Seq<u8>;
+
+pub type Content0<'a> = &'a [u8];
+
+pub type Content0Owned = Vec<u8>;
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecMsgCF4Inner = Either<SpecContent0, Either<u16, Either<u32, Seq<u8>>>>;
+
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
+        match m {
+            SpecMsgCF4::C0(m) => Either::Left(m),
+            SpecMsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            SpecMsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecMsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+}
+
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
+        match m {
+            Either::Left(m) => SpecMsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => SpecMsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecMsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecMsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
+    Unrecognized(&'a [u8]),
+}
+
+pub type MsgCF4Inner<'a> = Either<Content0<'a>, Either<u16, Either<u32, &'a [u8]>>>;
+
+impl View for MsgCF4<'_> {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
+        match m {
+            MsgCF4::C0(m) => Either::Left(m),
+            MsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+}
+
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
+        match m {
+            Either::Left(m) => MsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4::Unrecognized(m),
+        }
+    }
+}
+
+pub struct MsgCF4Mapper;
+
+impl View for MsgCF4Mapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgCF4Mapper {
+    type Src = SpecMsgCF4Inner;
+
+    type Dst = SpecMsgCF4;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgCF4Mapper {
+    type Src<'a> = MsgCF4Inner<'a>;
+
+    type Dst<'a> = MsgCF4<'a>;
+
+    type SrcOwned = MsgCF4OwnedInner;
+
+    type DstOwned = MsgCF4Owned;
+}
+
+pub enum MsgCF4Owned {
+    C0(Content0Owned),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Vec<u8>),
+}
+
+pub type MsgCF4OwnedInner = Either<Content0Owned, Either<u16, Either<u32, Vec<u8>>>>;
+
+impl View for MsgCF4Owned {
+    type V = SpecMsgCF4;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+impl From<MsgCF4Owned> for MsgCF4OwnedInner {
+    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
+        match m {
+            MsgCF4Owned::C0(m) => Either::Left(m),
+            MsgCF4Owned::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4Owned::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4Owned::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+}
+
+impl From<MsgCF4OwnedInner> for MsgCF4Owned {
+    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
+        match m {
+            Either::Left(m) => MsgCF4Owned::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4Owned::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4Owned::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4Owned::Unrecognized(m),
+        }
+    }
+}
+
 pub struct SpecMsgD {
     pub f1: Seq<u8>,
     pub f2: u16,
@@ -242,169 +400,6 @@ impl From<MsgDOwnedInner> for MsgDOwned {
     fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
         let (f1, f2) = m;
         MsgDOwned { f1, f2 }
-    }
-}
-
-pub type SpecContentType = u8;
-
-pub type ContentType = u8;
-
-pub type ContentTypeOwned = u8;
-
-pub type SpecContent0 = Seq<u8>;
-
-pub type Content0<'a> = &'a [u8];
-
-pub type Content0Owned = Vec<u8>;
-
-pub enum SpecMsgCF4 {
-    C0(SpecContent0),
-    C1(u16),
-    C2(u32),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecMsgCF4Inner = ord_choice_result!(SpecContent0, u16, u32, Seq<u8>);
-
-impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
-    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
-        match m {
-            SpecMsgCF4::C0(m) => inj_ord_choice_result!(m, *, *, *),
-            SpecMsgCF4::C1(m) => inj_ord_choice_result!(*, m, *, *),
-            SpecMsgCF4::C2(m) => inj_ord_choice_result!(*, *, m, *),
-            SpecMsgCF4::Unrecognized(m) => inj_ord_choice_result!(*, *, *, m),
-        }
-    }
-}
-
-impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
-    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
-        match m {
-            inj_ord_choice_pat!(m, *, *, *) => SpecMsgCF4::C0(m),
-            inj_ord_choice_pat!(*, m, *, *) => SpecMsgCF4::C1(m),
-            inj_ord_choice_pat!(*, *, m, *) => SpecMsgCF4::C2(m),
-            inj_ord_choice_pat!(*, *, *, m) => SpecMsgCF4::Unrecognized(m),
-        }
-    }
-}
-
-pub enum MsgCF4<'a> {
-    C0(Content0<'a>),
-    C1(u16),
-    C2(u32),
-    Unrecognized(&'a [u8]),
-}
-
-pub type MsgCF4Inner<'a> = ord_choice_result!(Content0<'a>, u16, u32, &'a [u8]);
-
-impl View for MsgCF4<'_> {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
-            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
-    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
-        match m {
-            MsgCF4::C0(m) => inj_ord_choice_result!(m, *, *, *),
-            MsgCF4::C1(m) => inj_ord_choice_result!(*, m, *, *),
-            MsgCF4::C2(m) => inj_ord_choice_result!(*, *, m, *),
-            MsgCF4::Unrecognized(m) => inj_ord_choice_result!(*, *, *, m),
-        }
-    }
-}
-
-impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
-    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
-        match m {
-            inj_ord_choice_pat!(m, *, *, *) => MsgCF4::C0(m),
-            inj_ord_choice_pat!(*, m, *, *) => MsgCF4::C1(m),
-            inj_ord_choice_pat!(*, *, m, *) => MsgCF4::C2(m),
-            inj_ord_choice_pat!(*, *, *, m) => MsgCF4::Unrecognized(m),
-        }
-    }
-}
-
-pub struct MsgCF4Mapper;
-
-impl View for MsgCF4Mapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for MsgCF4Mapper {
-    type Src = SpecMsgCF4Inner;
-
-    type Dst = SpecMsgCF4;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for MsgCF4Mapper {
-    type Src<'a> = MsgCF4Inner<'a>;
-
-    type Dst<'a> = MsgCF4<'a>;
-
-    type SrcOwned = MsgCF4OwnedInner;
-
-    type DstOwned = MsgCF4Owned;
-}
-
-pub enum MsgCF4Owned {
-    C0(Content0Owned),
-    C1(u16),
-    C2(u32),
-    Unrecognized(Vec<u8>),
-}
-
-pub type MsgCF4OwnedInner = ord_choice_result!(Content0Owned, u16, u32, Vec<u8>);
-
-impl View for MsgCF4Owned {
-    type V = SpecMsgCF4;
-
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
-            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
-        }
-    }
-}
-
-impl From<MsgCF4Owned> for MsgCF4OwnedInner {
-    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
-        match m {
-            MsgCF4Owned::C0(m) => inj_ord_choice_result!(m, *, *, *),
-            MsgCF4Owned::C1(m) => inj_ord_choice_result!(*, m, *, *),
-            MsgCF4Owned::C2(m) => inj_ord_choice_result!(*, *, m, *),
-            MsgCF4Owned::Unrecognized(m) => inj_ord_choice_result!(*, *, *, m),
-        }
-    }
-}
-
-impl From<MsgCF4OwnedInner> for MsgCF4Owned {
-    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
-        match m {
-            inj_ord_choice_pat!(m, *, *, *) => MsgCF4Owned::C0(m),
-            inj_ord_choice_pat!(*, m, *, *) => MsgCF4Owned::C1(m),
-            inj_ord_choice_pat!(*, *, m, *) => MsgCF4Owned::C2(m),
-            inj_ord_choice_pat!(*, *, *, m) => MsgCF4Owned::Unrecognized(m),
-        }
     }
 }
 
@@ -621,6 +616,12 @@ impl From<MsgAOwnedInner> for MsgAOwned {
     }
 }
 
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
+
 pub struct SpecMsgC {
     pub f2: SpecContentType,
     pub f3: u8,
@@ -732,6 +733,16 @@ impl From<MsgCOwnedInner> for MsgCOwned {
     }
 }
 
+pub type Content0Combinator = Bytes;
+
+pub type MsgCF4Combinator = AndThen<
+    Bytes,
+    Mapped<
+        OrdChoice<Cond<Content0Combinator>, OrdChoice<Cond<U16>, OrdChoice<Cond<U32>, Cond<Tail>>>>,
+        MsgCF4Mapper,
+    >,
+>;
+
 pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
 
 pub exec const MSGD_F1: [u8; 4]
@@ -806,26 +817,68 @@ pub type MsgDCombinator = Mapped<
     MsgDMapper,
 >;
 
-pub type ContentTypeCombinator = U8;
-
-pub type Content0Combinator = Bytes;
-
-pub type MsgCF4Combinator = AndThen<
-    Bytes,
-    Mapped<
-        ord_choice_type!(Cond<Content0Combinator>, Cond<U16>, Cond<U32>, Cond<Tail>),
-        MsgCF4Mapper,
-    >,
->;
-
 pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
 
 pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
+
+pub type ContentTypeCombinator = U8;
 
 pub type MsgCCombinator = Mapped<
     SpecDepend<(ContentTypeCombinator, U8), MsgCF4Combinator>,
     MsgCMapper,
 >;
+
+pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
+    Bytes(num as usize)
+}
+
+pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
+    ensures
+        o@ == spec_content_0(num@),
+{
+    Bytes(num as usize)
+}
+
+pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator {
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                Cond { cond: f2 == 0, inner: spec_content_0(f3) },
+                OrdChoice(
+                    Cond { cond: f2 == 1, inner: U16 },
+                    OrdChoice(
+                        Cond { cond: f2 == 2, inner: U32 },
+                        Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+                    ),
+                ),
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
+    ensures
+        o@ == spec_msg_c_f4(f3@, f2@),
+{
+    AndThen(
+        Bytes(f3 as usize),
+        Mapped {
+            inner: OrdChoice(
+                Cond { cond: f2 == 0, inner: content_0(f3) },
+                OrdChoice(
+                    Cond { cond: f2 == 1, inner: U16 },
+                    OrdChoice(
+                        Cond { cond: f2 == 2, inner: U32 },
+                        Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+                    ),
+                ),
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
 
 pub open spec fn spec_msg_d() -> MsgDCombinator {
     Mapped {
@@ -850,61 +903,6 @@ pub fn msg_d() -> (o: MsgDCombinator)
     }
 }
 
-pub open spec fn spec_content_type() -> ContentTypeCombinator {
-    U8
-}
-
-pub fn content_type() -> (o: ContentTypeCombinator)
-    ensures
-        o@ == spec_content_type(),
-{
-    U8
-}
-
-pub open spec fn spec_content_0(num: u8) -> Content0Combinator {
-    Bytes(num as usize)
-}
-
-pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
-    ensures
-        o@ == spec_content_0(num@),
-{
-    Bytes(num as usize)
-}
-
-pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator {
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: ord_choice!(
-                Cond { cond: f2 == 0, inner: spec_content_0(f3) },
-                Cond { cond: f2 == 1, inner: U16 },
-                Cond { cond: f2 == 2, inner: U32 },
-                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
-pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
-    ensures
-        o@ == spec_msg_c_f4(f3@, f2@),
-{
-    AndThen(
-        Bytes(f3 as usize),
-        Mapped {
-            inner: ord_choice!(
-                Cond { cond: f2 == 0, inner: content_0(f3) },
-                Cond { cond: f2 == 1, inner: U16 },
-                Cond { cond: f2 == 2, inner: U32 },
-                Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
-            ),
-            mapper: MsgCF4Mapper,
-        },
-    )
-}
-
 pub open spec fn spec_msg_b() -> MsgBCombinator {
     Mapped { inner: spec_msg_d(), mapper: MsgBMapper }
 }
@@ -927,57 +925,15 @@ pub fn msg_a() -> (o: MsgACombinator)
     Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
 }
 
-pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
-    spec_msg_d().spec_parse(i)
+pub open spec fn spec_content_type() -> ContentTypeCombinator {
+    U8
 }
 
-pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
-    spec_msg_d().spec_serialize(msg)
-}
-
-pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ParseError>)
+pub fn content_type() -> (o: ContentTypeCombinator)
     ensures
-        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+        o@ == spec_content_type(),
 {
-    msg_d().parse(i)
-}
-
-pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_d().serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
-    spec_content_type().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
-    spec_content_type().spec_serialize(msg)
-}
-
-pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ParseError>)
-    ensures
-        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
-{
-    content_type().parse(i)
-}
-
-pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    SerializeError,
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_content_type(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    content_type().serialize(msg, data, pos)
+    U8
 }
 
 pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
@@ -1020,7 +976,10 @@ pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f3: u8, f2: SpecConten
     spec_msg_c_f4(f3, f2).spec_serialize(msg)
 }
 
-pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<(usize, MsgCF4<'_>), ParseError>)
+pub fn parse_msg_c_f4(i: &[u8], f3: u8, f2: ContentType) -> (o: Result<
+    (usize, MsgCF4<'_>),
+    ParseError,
+>)
     ensures
         o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f3@, f2@) matches Ok(r_) && r@ == r_,
 {
@@ -1043,6 +1002,34 @@ pub fn serialize_msg_c_f4(
     msg_c_f4(f3, f2).serialize(msg, data, pos)
 }
 
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
+}
+
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_d().parse(i)
+}
+
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_d().serialize(msg, data, pos)
+}
+
 pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
     spec_msg_b().spec_parse(i)
 }
@@ -1058,7 +1045,10 @@ pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ParseError>)
     msg_b().parse(i)
 }
 
-pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_b(msg@) matches Ok(buf)
@@ -1083,7 +1073,10 @@ pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ParseError>)
     msg_a().parse(i)
 }
 
-pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_a(msg@) matches Ok(buf)
@@ -1091,6 +1084,34 @@ pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
         },
 {
     msg_a().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
+    spec_content_type().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
+    spec_content_type().spec_serialize(msg)
+}
+
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
+{
+    content_type().parse(i)
+}
+
+pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_content_type(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    content_type().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_msg_c(i: Seq<u8>) -> Result<(usize, SpecMsgC), ()> {
@@ -1133,7 +1154,10 @@ pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ParseError>)
     Mapped { inner: Depend { fst, snd, spec_snd: Ghost(spec_snd) }, mapper: MsgCMapper }.parse(i)
 }
 
-pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
     ensures
         o matches Ok(n) ==> {
             &&& serialize_spec_msg_c(msg@) matches Ok(buf)

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -280,10 +280,10 @@ impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
 impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
     open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
         match m {
-            inj_ord_choice_result!(m, *, *, *) => SpecMsgCF4::C0(m),
-            inj_ord_choice_result!(*, m, *, *) => SpecMsgCF4::C1(m),
-            inj_ord_choice_result!(*, *, m, *) => SpecMsgCF4::C2(m),
-            inj_ord_choice_result!(*, *, *, m) => SpecMsgCF4::Unrecognized(m),
+            inj_ord_choice_pat!(m, *, *, *) => SpecMsgCF4::C0(m),
+            inj_ord_choice_pat!(*, m, *, *) => SpecMsgCF4::C1(m),
+            inj_ord_choice_pat!(*, *, m, *) => SpecMsgCF4::C2(m),
+            inj_ord_choice_pat!(*, *, *, m) => SpecMsgCF4::Unrecognized(m),
         }
     }
 }
@@ -324,10 +324,10 @@ impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
 impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
     fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
         match m {
-            inj_ord_choice_result!(m, *, *, *) => MsgCF4::C0(m),
-            inj_ord_choice_result!(*, m, *, *) => MsgCF4::C1(m),
-            inj_ord_choice_result!(*, *, m, *) => MsgCF4::C2(m),
-            inj_ord_choice_result!(*, *, *, m) => MsgCF4::Unrecognized(m),
+            inj_ord_choice_pat!(m, *, *, *) => MsgCF4::C0(m),
+            inj_ord_choice_pat!(*, m, *, *) => MsgCF4::C1(m),
+            inj_ord_choice_pat!(*, *, m, *) => MsgCF4::C2(m),
+            inj_ord_choice_pat!(*, *, *, m) => MsgCF4::Unrecognized(m),
         }
     }
 }
@@ -400,10 +400,10 @@ impl From<MsgCF4Owned> for MsgCF4OwnedInner {
 impl From<MsgCF4OwnedInner> for MsgCF4Owned {
     fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
         match m {
-            inj_ord_choice_result!(m, *, *, *) => MsgCF4Owned::C0(m),
-            inj_ord_choice_result!(*, m, *, *) => MsgCF4Owned::C1(m),
-            inj_ord_choice_result!(*, *, m, *) => MsgCF4Owned::C2(m),
-            inj_ord_choice_result!(*, *, *, m) => MsgCF4Owned::Unrecognized(m),
+            inj_ord_choice_pat!(m, *, *, *) => MsgCF4Owned::C0(m),
+            inj_ord_choice_pat!(*, m, *, *) => MsgCF4Owned::C1(m),
+            inj_ord_choice_pat!(*, *, m, *) => MsgCF4Owned::C2(m),
+            inj_ord_choice_pat!(*, *, *, m) => MsgCF4Owned::Unrecognized(m),
         }
     }
 }

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -264,15 +264,15 @@ pub enum SpecMsgCF4 {
     Unrecognized(Seq<u8>),
 }
 
-pub type SpecMsgCF4Inner = Either<Either<Either<SpecContent0, u16>, u32>, Seq<u8>>;
+pub type SpecMsgCF4Inner = ord_choice_result!(SpecContent0, u16, u32, Seq<u8>);
 
 impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
     open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
         match m {
-            SpecMsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
-            SpecMsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
-            SpecMsgCF4::C2(m) => Either::Left(Either::Right(m)),
-            SpecMsgCF4::Unrecognized(m) => Either::Right(m),
+            SpecMsgCF4::C0(m) => inj_ord_choice_result!(m, *, *, *),
+            SpecMsgCF4::C1(m) => inj_ord_choice_result!(*, m, *, *),
+            SpecMsgCF4::C2(m) => inj_ord_choice_result!(*, *, m, *),
+            SpecMsgCF4::Unrecognized(m) => inj_ord_choice_result!(*, *, *, m),
         }
     }
 }
@@ -280,10 +280,10 @@ impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
 impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
     open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
         match m {
-            Either::Left(Either::Left(Either::Left(m))) => SpecMsgCF4::C0(m),
-            Either::Left(Either::Left(Either::Right(m))) => SpecMsgCF4::C1(m),
-            Either::Left(Either::Right(m)) => SpecMsgCF4::C2(m),
-            Either::Right(m) => SpecMsgCF4::Unrecognized(m),
+            inj_ord_choice_result!(m, *, *, *) => SpecMsgCF4::C0(m),
+            inj_ord_choice_result!(*, m, *, *) => SpecMsgCF4::C1(m),
+            inj_ord_choice_result!(*, *, m, *) => SpecMsgCF4::C2(m),
+            inj_ord_choice_result!(*, *, *, m) => SpecMsgCF4::Unrecognized(m),
         }
     }
 }
@@ -295,7 +295,7 @@ pub enum MsgCF4<'a> {
     Unrecognized(&'a [u8]),
 }
 
-pub type MsgCF4Inner<'a> = Either<Either<Either<Content0<'a>, u16>, u32>, &'a [u8]>;
+pub type MsgCF4Inner<'a> = ord_choice_result!(Content0<'a>, u16, u32, &'a [u8]);
 
 impl View for MsgCF4<'_> {
     type V = SpecMsgCF4;
@@ -313,10 +313,10 @@ impl View for MsgCF4<'_> {
 impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
     fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
         match m {
-            MsgCF4::C0(m) => Either::Left(Either::Left(Either::Left(m))),
-            MsgCF4::C1(m) => Either::Left(Either::Left(Either::Right(m))),
-            MsgCF4::C2(m) => Either::Left(Either::Right(m)),
-            MsgCF4::Unrecognized(m) => Either::Right(m),
+            MsgCF4::C0(m) => inj_ord_choice_result!(m, *, *, *),
+            MsgCF4::C1(m) => inj_ord_choice_result!(*, m, *, *),
+            MsgCF4::C2(m) => inj_ord_choice_result!(*, *, m, *),
+            MsgCF4::Unrecognized(m) => inj_ord_choice_result!(*, *, *, m),
         }
     }
 }
@@ -324,10 +324,10 @@ impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
 impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
     fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
         match m {
-            Either::Left(Either::Left(Either::Left(m))) => MsgCF4::C0(m),
-            Either::Left(Either::Left(Either::Right(m))) => MsgCF4::C1(m),
-            Either::Left(Either::Right(m)) => MsgCF4::C2(m),
-            Either::Right(m) => MsgCF4::Unrecognized(m),
+            inj_ord_choice_result!(m, *, *, *) => MsgCF4::C0(m),
+            inj_ord_choice_result!(*, m, *, *) => MsgCF4::C1(m),
+            inj_ord_choice_result!(*, *, m, *) => MsgCF4::C2(m),
+            inj_ord_choice_result!(*, *, *, m) => MsgCF4::Unrecognized(m),
         }
     }
 }
@@ -371,7 +371,7 @@ pub enum MsgCF4Owned {
     Unrecognized(Vec<u8>),
 }
 
-pub type MsgCF4OwnedInner = Either<Either<Either<Content0Owned, u16>, u32>, Vec<u8>>;
+pub type MsgCF4OwnedInner = ord_choice_result!(Content0Owned, u16, u32, Vec<u8>);
 
 impl View for MsgCF4Owned {
     type V = SpecMsgCF4;
@@ -389,10 +389,10 @@ impl View for MsgCF4Owned {
 impl From<MsgCF4Owned> for MsgCF4OwnedInner {
     fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
         match m {
-            MsgCF4Owned::C0(m) => Either::Left(Either::Left(Either::Left(m))),
-            MsgCF4Owned::C1(m) => Either::Left(Either::Left(Either::Right(m))),
-            MsgCF4Owned::C2(m) => Either::Left(Either::Right(m)),
-            MsgCF4Owned::Unrecognized(m) => Either::Right(m),
+            MsgCF4Owned::C0(m) => inj_ord_choice_result!(m, *, *, *),
+            MsgCF4Owned::C1(m) => inj_ord_choice_result!(*, m, *, *),
+            MsgCF4Owned::C2(m) => inj_ord_choice_result!(*, *, m, *),
+            MsgCF4Owned::Unrecognized(m) => inj_ord_choice_result!(*, *, *, m),
         }
     }
 }
@@ -400,10 +400,10 @@ impl From<MsgCF4Owned> for MsgCF4OwnedInner {
 impl From<MsgCF4OwnedInner> for MsgCF4Owned {
     fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
         match m {
-            Either::Left(Either::Left(Either::Left(m))) => MsgCF4Owned::C0(m),
-            Either::Left(Either::Left(Either::Right(m))) => MsgCF4Owned::C1(m),
-            Either::Left(Either::Right(m)) => MsgCF4Owned::C2(m),
-            Either::Right(m) => MsgCF4Owned::Unrecognized(m),
+            inj_ord_choice_result!(m, *, *, *) => MsgCF4Owned::C0(m),
+            inj_ord_choice_result!(*, m, *, *) => MsgCF4Owned::C1(m),
+            inj_ord_choice_result!(*, *, m, *) => MsgCF4Owned::C2(m),
+            inj_ord_choice_result!(*, *, *, m) => MsgCF4Owned::Unrecognized(m),
         }
     }
 }
@@ -813,7 +813,7 @@ pub type Content0Combinator = Bytes;
 pub type MsgCF4Combinator = AndThen<
     Bytes,
     Mapped<
-        OrdChoice<OrdChoice<OrdChoice<Cond<Content0Combinator>, Cond<U16>>, Cond<U32>>, Cond<Tail>>,
+        ord_choice_type!(Cond<Content0Combinator>, Cond<U16>, Cond<U32>, Cond<Tail>),
         MsgCF4Mapper,
     >,
 >;
@@ -876,14 +876,10 @@ pub open spec fn spec_msg_c_f4(f3: u8, f2: SpecContentType) -> MsgCF4Combinator 
     AndThen(
         Bytes(f3 as usize),
         Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    OrdChoice(
-                        Cond { cond: f2 == 0, inner: spec_content_0(f3) },
-                        Cond { cond: f2 == 1, inner: U16 },
-                    ),
-                    Cond { cond: f2 == 2, inner: U32 },
-                ),
+            inner: ord_choice!(
+                Cond { cond: f2 == 0, inner: spec_content_0(f3) },
+                Cond { cond: f2 == 1, inner: U16 },
+                Cond { cond: f2 == 2, inner: U32 },
                 Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
             ),
             mapper: MsgCF4Mapper,
@@ -898,14 +894,10 @@ pub fn msg_c_f4<'a>(f3: u8, f2: ContentType) -> (o: MsgCF4Combinator)
     AndThen(
         Bytes(f3 as usize),
         Mapped {
-            inner: OrdChoice(
-                OrdChoice(
-                    OrdChoice(
-                        Cond { cond: f2 == 0, inner: content_0(f3) },
-                        Cond { cond: f2 == 1, inner: U16 },
-                    ),
-                    Cond { cond: f2 == 2, inner: U32 },
-                ),
+            inner: ord_choice!(
+                Cond { cond: f2 == 0, inner: content_0(f3) },
+                Cond { cond: f2 == 1, inner: U16 },
+                Cond { cond: f2 == 2, inner: U32 },
                 Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
             ),
             mapper: MsgCF4Mapper,

--- a/vest/src/regular/depend.rs
+++ b/vest/src/regular/depend.rs
@@ -262,7 +262,7 @@ mod test {
         and_then::AndThen,
         bytes::Bytes,
         bytes_n::BytesN,
-        choice::{Either, OrdChoice},
+        choice::*,
         cond::Cond,
         depend::{Depend, SpecDepend},
         map::*,
@@ -608,7 +608,7 @@ mod test {
         M3(SpecMsg3),
     }
 
-    pub type SpecTlvContentInner = Either<Either<SpecMsg1, Msg2>, SpecMsg3>;
+    pub type SpecTlvContentInner = ord_choice_result!(SpecMsg1, Msg2, SpecMsg3);
 
     pub enum TlvContent<'a> {
         M1(Msg1<'a>),
@@ -622,9 +622,8 @@ mod test {
         M3(Msg3Owned),
     }
 
-    pub type TlvContentInner<'a> = Either<Either<Msg1<'a>, Msg2>, Msg3<'a>>;
-
-    pub type TlvContentOwnedInner = Either<Either<Msg1Owned, Msg2>, Msg3Owned>;
+    pub type TlvContentInner<'a> = ord_choice_result!(Msg1<'a>, Msg2, Msg3<'a>);
+    pub type TlvContentOwnedInner = ord_choice_result!(Msg1Owned, Msg2, Msg3Owned);
 
     impl View for TlvContent<'_> {
         type V = SpecTlvContent;
@@ -653,9 +652,9 @@ mod test {
     impl SpecFrom<SpecTlvContent> for SpecTlvContentInner {
         open spec fn spec_from(e: SpecTlvContent) -> SpecTlvContentInner {
             match e {
-                SpecTlvContent::M1(m) => Either::Left(Either::Left(m)),
-                SpecTlvContent::M2(m) => Either::Left(Either::Right(m)),
-                SpecTlvContent::M3(m) => Either::Right(m),
+                SpecTlvContent::M1(m) => inj_ord_choice_result!(m, *, *),
+                SpecTlvContent::M2(m) => inj_ord_choice_result!(*, m, *),
+                SpecTlvContent::M3(m) => inj_ord_choice_result!(*, *, m),
             }
         }
     }
@@ -663,9 +662,9 @@ mod test {
     impl SpecFrom<SpecTlvContentInner> for SpecTlvContent {
         open spec fn spec_from(e: SpecTlvContentInner) -> SpecTlvContent {
             match e {
-                Either::Left(Either::Left(m)) => SpecTlvContent::M1(m),
-                Either::Left(Either::Right(m)) => SpecTlvContent::M2(m),
-                Either::Right(m) => SpecTlvContent::M3(m),
+                inj_ord_choice_result!(m, *, *) => SpecTlvContent::M1(m),
+                inj_ord_choice_result!(*, m, *) => SpecTlvContent::M2(m),
+                inj_ord_choice_result!(*, *, m) => SpecTlvContent::M3(m),
             }
         }
     }
@@ -673,9 +672,9 @@ mod test {
     impl<'a> From<TlvContent<'a>> for TlvContentInner<'a> {
         fn ex_from(e: TlvContent) -> (res: TlvContentInner) {
             match e {
-                TlvContent::M1(m) => Either::Left(Either::Left(m)),
-                TlvContent::M2(m) => Either::Left(Either::Right(m)),
-                TlvContent::M3(m) => Either::Right(m),
+                TlvContent::M1(m) => inj_ord_choice_result!(m, *, *),
+                TlvContent::M2(m) => inj_ord_choice_result!(*, m, *),
+                TlvContent::M3(m) => inj_ord_choice_result!(*, *, m),
             }
         }
     }
@@ -683,9 +682,9 @@ mod test {
     impl<'a> From<TlvContentInner<'a>> for TlvContent<'a> {
         fn ex_from(e: TlvContentInner) -> (res: TlvContent) {
             match e {
-                Either::Left(Either::Left(m)) => TlvContent::M1(m),
-                Either::Left(Either::Right(m)) => TlvContent::M2(m),
-                Either::Right(m) => TlvContent::M3(m),
+                inj_ord_choice_result!(m, *, *) => TlvContent::M1(m),
+                inj_ord_choice_result!(*, m, *) => TlvContent::M2(m),
+                inj_ord_choice_result!(*, *, m) => TlvContent::M3(m),
             }
         }
     }
@@ -693,9 +692,9 @@ mod test {
     impl From<TlvContentOwned> for TlvContentOwnedInner {
         fn ex_from(e: TlvContentOwned) -> (res: TlvContentOwnedInner) {
             match e {
-                TlvContentOwned::M1(m) => Either::Left(Either::Left(m)),
-                TlvContentOwned::M2(m) => Either::Left(Either::Right(m)),
-                TlvContentOwned::M3(m) => Either::Right(m),
+                TlvContentOwned::M1(m) => inj_ord_choice_result!(m, *, *),
+                TlvContentOwned::M2(m) => inj_ord_choice_result!(*, m, *),
+                TlvContentOwned::M3(m) => inj_ord_choice_result!(*, *, m),
             }
         }
     }
@@ -703,9 +702,9 @@ mod test {
     impl From<TlvContentOwnedInner> for TlvContentOwned {
         fn ex_from(e: TlvContentOwnedInner) -> (res: TlvContentOwned) {
             match e {
-                Either::Left(Either::Left(m)) => TlvContentOwned::M1(m),
-                Either::Left(Either::Right(m)) => TlvContentOwned::M2(m),
-                Either::Right(m) => TlvContentOwned::M3(m),
+                inj_ord_choice_result!(m, *, *) => TlvContentOwned::M1(m),
+                inj_ord_choice_result!(*, m, *) => TlvContentOwned::M2(m),
+                inj_ord_choice_result!(*, *, m) => TlvContentOwned::M3(m),
             }
         }
     }
@@ -866,7 +865,7 @@ mod test {
     type TlvContentCombinator = AndThen<
         Bytes,
         Mapped<
-            OrdChoice<OrdChoice<Cond<Msg1Combinator>, Cond<Msg2Combinator>>, Cond<Msg3Combinator>>,
+            ord_choice_type!(Cond<Msg1Combinator>, Cond<Msg2Combinator>, Cond<Msg3Combinator>),
             TlvContentMapper,
         >,
     >;
@@ -890,11 +889,9 @@ mod test {
         AndThen(
             Bytes(len as usize),
             Mapped {
-                inner: OrdChoice(
-                    OrdChoice(
-                        Cond { cond: tag == 1, inner: spec_msg1() },
-                        Cond { cond: tag == 2, inner: spec_msg2() },
-                    ),
+                inner: ord_choice!(
+                    Cond { cond: tag == 1, inner: spec_msg1() },
+                    Cond { cond: tag == 2, inner: spec_msg2() },
                     Cond { cond: tag == 3, inner: spec_msg3() },
                 ),
                 mapper: TlvContentMapper,
@@ -940,11 +937,9 @@ mod test {
         AndThen(
             Bytes(len as usize),
             Mapped {
-                inner: OrdChoice(
-                    OrdChoice(
-                        Cond { cond: tag == 1, inner: msg1() },
-                        Cond { cond: tag == 2, inner: msg2() },
-                    ),
+                inner: ord_choice!(
+                    Cond { cond: tag == 1, inner: msg1() },
+                    Cond { cond: tag == 2, inner: msg2() },
                     Cond { cond: tag == 3, inner: msg3() },
                 ),
                 mapper: TlvContentMapper,

--- a/vest/src/regular/depend.rs
+++ b/vest/src/regular/depend.rs
@@ -662,9 +662,9 @@ mod test {
     impl SpecFrom<SpecTlvContentInner> for SpecTlvContent {
         open spec fn spec_from(e: SpecTlvContentInner) -> SpecTlvContent {
             match e {
-                inj_ord_choice_result!(m, *, *) => SpecTlvContent::M1(m),
-                inj_ord_choice_result!(*, m, *) => SpecTlvContent::M2(m),
-                inj_ord_choice_result!(*, *, m) => SpecTlvContent::M3(m),
+                inj_ord_choice_pat!(m, *, *) => SpecTlvContent::M1(m),
+                inj_ord_choice_pat!(*, m, *) => SpecTlvContent::M2(m),
+                inj_ord_choice_pat!(*, *, m) => SpecTlvContent::M3(m),
             }
         }
     }
@@ -682,9 +682,9 @@ mod test {
     impl<'a> From<TlvContentInner<'a>> for TlvContent<'a> {
         fn ex_from(e: TlvContentInner) -> (res: TlvContent) {
             match e {
-                inj_ord_choice_result!(m, *, *) => TlvContent::M1(m),
-                inj_ord_choice_result!(*, m, *) => TlvContent::M2(m),
-                inj_ord_choice_result!(*, *, m) => TlvContent::M3(m),
+                inj_ord_choice_pat!(m, *, *) => TlvContent::M1(m),
+                inj_ord_choice_pat!(*, m, *) => TlvContent::M2(m),
+                inj_ord_choice_pat!(*, *, m) => TlvContent::M3(m),
             }
         }
     }
@@ -702,9 +702,9 @@ mod test {
     impl From<TlvContentOwnedInner> for TlvContentOwned {
         fn ex_from(e: TlvContentOwnedInner) -> (res: TlvContentOwned) {
             match e {
-                inj_ord_choice_result!(m, *, *) => TlvContentOwned::M1(m),
-                inj_ord_choice_result!(*, m, *) => TlvContentOwned::M2(m),
-                inj_ord_choice_result!(*, *, m) => TlvContentOwned::M3(m),
+                inj_ord_choice_pat!(m, *, *) => TlvContentOwned::M1(m),
+                inj_ord_choice_pat!(*, m, *) => TlvContentOwned::M2(m),
+                inj_ord_choice_pat!(*, *, m) => TlvContentOwned::M3(m),
             }
         }
     }

--- a/vest/src/regular/disjoint.rs
+++ b/vest/src/regular/disjoint.rs
@@ -1,6 +1,7 @@
 use super::bytes::Bytes;
 use super::bytes_n::BytesN;
 use super::choice::OrdChoice;
+use super::error::CustomError;
 use super::cond::Cond;
 use super::map::{Mapped, SpecIso};
 use super::preceded::Preceded;
@@ -173,11 +174,6 @@ impl<Inner1, Inner2> DisjointFrom<Cond<Inner2>> for Cond<Inner1> where
 impl<'a, T1, T2> DisjointFrom<&'a T1> for &'a T2 where
     T1: SpecCombinator,
     T2: SpecCombinator + DisjointFrom<T1>,
-    // T1: Combinator,
-    // T2: Combinator + DisjointFrom<T1>,
-    // T1::V: SecureSpecCombinator<SpecResult = <T1::Owned as View>::V>,
-    // T2::V: SecureSpecCombinator<SpecResult = <T2::Owned as View>::V>,
-    // T2::V: SpecDisjointFrom<T1::V>,
 {
     open spec fn disjoint_from(&self, other: &&T1) -> bool {
         (*self).disjoint_from(*other)
@@ -186,6 +182,16 @@ impl<'a, T1, T2> DisjointFrom<&'a T1> for &'a T2 where
     proof fn parse_disjoint_on(&self, other: &&T1, buf: Seq<u8>) {
         (*self).parse_disjoint_on(*other, buf)
     }
+}
+
+impl<T> DisjointFrom<T> for CustomError where
+    T: SpecCombinator,
+{
+    open spec fn disjoint_from(&self, c: &T) -> bool {
+        true
+    }
+
+    proof fn parse_disjoint_on(&self, c: &T, buf: Seq<u8>) {}
 }
 
 } // verus!

--- a/vest/src/regular/disjoint.rs
+++ b/vest/src/regular/disjoint.rs
@@ -1,7 +1,7 @@
 use super::bytes::Bytes;
 use super::bytes_n::BytesN;
 use super::choice::OrdChoice;
-use super::error::CustomError;
+use super::fail::Fail;
 use super::cond::Cond;
 use super::map::{Mapped, SpecIso};
 use super::preceded::Preceded;
@@ -184,7 +184,7 @@ impl<'a, T1, T2> DisjointFrom<&'a T1> for &'a T2 where
     }
 }
 
-impl<T> DisjointFrom<T> for CustomError where
+impl<T> DisjointFrom<T> for Fail where
     T: SpecCombinator,
 {
     open spec fn disjoint_from(&self, c: &T) -> bool {

--- a/vest/src/regular/error.rs
+++ b/vest/src/regular/error.rs
@@ -1,0 +1,69 @@
+use crate::properties::*;
+use vstd::prelude::*;
+
+verus! {
+
+/// Combinator used for custom error message
+pub struct CustomError(pub String);
+
+impl View for CustomError {
+    type V = CustomError;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecCombinator for CustomError {
+    type SpecResult = ();
+
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::SpecResult), ()> {
+        Err(())
+    }
+
+    open spec fn spec_serialize(&self, v: Self::SpecResult) -> Result<Seq<u8>, ()> {
+        Err(())
+    }
+
+    proof fn spec_parse_wf(&self, s: Seq<u8>) {}
+}
+
+impl SecureSpecCombinator for CustomError {
+    open spec fn spec_is_prefix_secure() -> bool {
+        true
+    }
+
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>) {}
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::SpecResult) {}
+    proof fn theorem_parse_serialize_roundtrip(&self, s: Seq<u8>) {}
+}
+
+impl Combinator for CustomError {
+    type Result<'a> = ();
+    type Owned = ();
+
+    open spec fn spec_length(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    fn length(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    fn exec_is_prefix_secure() -> bool {
+        true
+    }
+
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
+        Err(ParseError::Other(self.0.clone()))
+    }
+
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
+        usize,
+        SerializeError,
+    >) {
+        Err(SerializeError::Other(self.0.clone()))
+    }
+}
+
+}

--- a/vest/src/regular/fail.rs
+++ b/vest/src/regular/fail.rs
@@ -4,17 +4,17 @@ use vstd::prelude::*;
 verus! {
 
 /// Combinator used for custom error message
-pub struct CustomError(pub String);
+pub struct Fail(pub String);
 
-impl View for CustomError {
-    type V = CustomError;
+impl View for Fail {
+    type V = Fail;
 
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
 
-impl SpecCombinator for CustomError {
+impl SpecCombinator for Fail {
     type SpecResult = ();
 
     open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::SpecResult), ()> {
@@ -28,7 +28,7 @@ impl SpecCombinator for CustomError {
     proof fn spec_parse_wf(&self, s: Seq<u8>) {}
 }
 
-impl SecureSpecCombinator for CustomError {
+impl SecureSpecCombinator for Fail {
     open spec fn spec_is_prefix_secure() -> bool {
         true
     }
@@ -38,7 +38,7 @@ impl SecureSpecCombinator for CustomError {
     proof fn theorem_parse_serialize_roundtrip(&self, s: Seq<u8>) {}
 }
 
-impl Combinator for CustomError {
+impl Combinator for Fail {
     type Result<'a> = ();
     type Owned = ();
 

--- a/vest/src/regular/mod.rs
+++ b/vest/src/regular/mod.rs
@@ -37,4 +37,4 @@ pub mod uints;
 /// Repeat combinator
 pub mod repeat;
 /// Error combinator
-pub mod error;
+pub mod fail;

--- a/vest/src/regular/mod.rs
+++ b/vest/src/regular/mod.rs
@@ -36,3 +36,5 @@ pub mod tail;
 pub mod uints;
 /// Repeat combinator
 pub mod repeat;
+/// Error combinator
+pub mod error;

--- a/vest/src/regular/tag.rs
+++ b/vest/src/regular/tag.rs
@@ -149,19 +149,16 @@ Inner::V: SecureSpecCombinator<SpecResult = T::V>, T: FromToBytes {
         self.0.parse_requires()
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> Result<(usize, Self::Result<'a>), ()> {
-        if let Ok((n, _)) = self.0.parse(s) {
-            Ok((n, ()))
-        } else {
-            Err(())
-        }
+    fn parse<'a>(&self, s: &'a [u8]) -> Result<(usize, Self::Result<'a>), ParseError> {
+        let (n, _) = self.0.parse(s)?;
+        Ok((n, ()))
     }
 
     open spec fn serialize_requires(&self) -> bool {
         self.0.serialize_requires()
     }
 
-    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, ()> {
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, SerializeError> {
         self.0.serialize(self.0.predicate.0, data, pos)
     }
 }
@@ -192,19 +189,16 @@ Inner::V: SecureSpecCombinator<SpecResult = Seq<u8>> {
         self.0.parse_requires()
     }
 
-    fn parse<'b>(&self, s: &'b [u8]) -> Result<(usize, Self::Result<'b>), ()> {
-        if let Ok((n, _)) = self.0.parse(s) {
-            Ok((n, ()))
-        } else {
-            Err(())
-        }
+    fn parse<'b>(&self, s: &'b [u8]) -> Result<(usize, Self::Result<'b>), ParseError> {
+        let (n, _) = self.0.parse(s)?;
+        Ok((n, ()))
     }
 
     open spec fn serialize_requires(&self) -> bool {
         self.0.serialize_requires()
     }
 
-    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, ()> {
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, SerializeError> {
         self.0.serialize(self.0.predicate.0.as_slice(), data, pos)
     }
 }
@@ -235,19 +229,16 @@ Inner::V: SecureSpecCombinator<SpecResult = Seq<u8>> {
         self.0.parse_requires()
     }
 
-    fn parse<'b>(&self, s: &'b [u8]) -> Result<(usize, Self::Result<'b>), ()> {
-        if let Ok((n, _)) = self.0.parse(s) {
-            Ok((n, ()))
-        } else {
-            Err(())
-        }
+    fn parse<'b>(&self, s: &'b [u8]) -> Result<(usize, Self::Result<'b>), ParseError> {
+        let (n, _) = self.0.parse(s)?;
+        Ok((n, ()))
     }
 
     open spec fn serialize_requires(&self) -> bool {
         self.0.serialize_requires()
     }
 
-    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, ()> {
+    fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> Result<usize, SerializeError> {
         self.0.serialize(self.0.predicate.0, data, pos)
     }
 }

--- a/vest/src/regular/tail.rs
+++ b/vest/src/regular/tail.rs
@@ -70,17 +70,17 @@ impl Combinator for Tail {
         false
     }
 
-    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ()>) {
+    fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
         if s.len() <= usize::MAX {
             Ok(((s.len()), s))
         } else {
-            Err(())
+            Err(ParseError::SizeOverflow)
         }
     }
 
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
         usize,
-        (),
+        SerializeError,
     >) {
         if pos <= data.len() {
             if v.len() <= data.len() - pos {
@@ -90,10 +90,10 @@ impl Combinator for Tail {
                 ).unwrap());
                 Ok(v.len())
             } else {
-                Err(())
+                Err(SerializeError::InsufficientBuffer)
             }
         } else {
-            Err(())
+            Err(SerializeError::InsufficientBuffer)
         }
     }
 }

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -143,7 +143,7 @@ macro_rules! impl_combinator_for_int_type {
                     true
                 }
 
-                fn parse(&self, s: &[u8]) -> (res: Result<(usize, $int_type), ()>) {
+                fn parse(&self, s: &[u8]) -> (res: Result<(usize, $int_type), ParseError>) {
                     if s.len() >= size_of::<$int_type>() {
                         let s_ = slice_subrange(s, 0, size_of::<$int_type>());
                         let v = $int_type::ex_from_le_bytes(s_);
@@ -157,11 +157,11 @@ macro_rules! impl_combinator_for_int_type {
                         }
                         Ok((size_of::<$int_type>(), v))
                     } else {
-                        Err(())
+                        Err(ParseError::UnexpectedEndOfInput)
                     }
                 }
 
-                fn serialize(&self, v: $int_type, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, ()>) {
+                fn serialize(&self, v: $int_type, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
                     if pos <= data.len() {
                         if size_of::<$int_type>() <= data.len() - pos {
                             $int_type::ex_to_le_bytes(&v, data, pos);
@@ -172,10 +172,10 @@ macro_rules! impl_combinator_for_int_type {
                             }
                             Ok(size_of::<$int_type>())
                         } else {
-                            Err(())
+                            Err(SerializeError::InsufficientBuffer)
                         }
                     } else {
-                        Err(())
+                        Err(SerializeError::InsufficientBuffer)
                     }
                 }
             }


### PR DESCRIPTION
Adding error types `ParseError` and `SerializeError` for debugging larger combinators.

This is WIP, but would appreciate some feedback.

TODO:
 - [x] Add an error combinator that always fails but produces a custom error message (e.g. `OrdChoice(OrdChoice(...), Error("Failed all choices"))`)
 - [ ] ~Record position of the error?~
 - [x] Change `vest-dsl` to work with right-associative OrdChoice