### PR TITLE
New combinator for parsing and serializing `u24`

### DIFF
--- a/vest-examples/src/depend.rs
+++ b/vest-examples/src/depend.rs
@@ -2,44 +2,45 @@ use vest::regular::bytes::*;
 use vest::regular::depend::SpecDepend;
 use vest::regular::depend::{Continuation, Depend};
 use vest::regular::uints::*;
+use vest::utils::*;
 use vstd::prelude::*;
 
 verus! {
 
-pub open spec fn msg1() -> SpecDepend<(U8, U16), (Bytes, Bytes)> {
+pub open spec fn msg1() -> SpecDepend<(U8, U24), (Bytes, Bytes)> {
     SpecDepend {
-        fst: (U8, U16),
+        fst: (U8, U24),
         snd: |deps| msg1_snd(deps),
     }
 }
 
-pub open spec fn msg1_snd(deps: (u8, u16)) -> (Bytes, Bytes)
+pub open spec fn msg1_snd(deps: (u8, u24)) -> (Bytes, Bytes)
 {
     let (x, y) = deps;
-    (Bytes(x as usize), Bytes(y as usize))
+    (Bytes(x.spec_into()), Bytes(y.spec_into()))
 }
 
 pub struct Msg1Snd;
 
-impl Continuation<(u8, u16)> for Msg1Snd {
+impl Continuation<(u8, u24)> for Msg1Snd {
     type Output = (Bytes, Bytes);
 
-    open spec fn requires(&self, i: (u8, u16)) -> bool {
+    open spec fn requires(&self, i: (u8, u24)) -> bool {
         true
     }
 
-    open spec fn ensures(&self, i: (u8, u16), o: (Bytes, Bytes)) -> bool {
+    open spec fn ensures(&self, i: (u8, u24), o: (Bytes, Bytes)) -> bool {
         o@ == msg1_snd(i@)
     }
 
-    fn apply(&self, deps: (u8, u16)) -> (Bytes, Bytes) {
+    fn apply(&self, deps: (u8, u24)) -> (Bytes, Bytes) {
         let (x, y) = deps;
-        (Bytes(x as usize), Bytes(y as usize))
+        (Bytes(x.ex_into()), Bytes(y.ex_into()))
     }
 }
 
 pub fn mk_msg1() -> (o: Depend<
-    (U8, U16),
+    (U8, U24),
     (Bytes, Bytes),
     Msg1Snd,
     >)
@@ -47,7 +48,7 @@ pub fn mk_msg1() -> (o: Depend<
         o@ == msg1(),
 {
     Depend {
-        fst: (U8, U16),
+        fst: (U8, U24),
         snd: Msg1Snd,
         spec_snd: Ghost(|deps| msg1_snd(deps)),
     }

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -4,7 +4,7 @@ use vstd::prelude::*;
 use vstd::seq_lib::*;
 use vstd::slice::*;
 
-use super::bytes::Bytes;
+use super::bytes_n::BytesN;
 
 verus! {
 
@@ -596,7 +596,7 @@ impl SpecCombinator for U24 {
     type SpecResult = u24;
     
     open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, u24), ()> {
-        match Bytes(3).spec_parse(s) {
+        match BytesN::<3>.spec_parse(s) {
             Ok((n, bytes)) => Ok((n, u24([bytes[0], bytes[1], bytes[2]]))),
             _ => Err(()),
         }
@@ -607,7 +607,7 @@ impl SpecCombinator for U24 {
 
     open spec fn spec_serialize(&self, v: u24) -> Result<Seq<u8>, ()> {
         let bytes = v.0;
-        Bytes(3).spec_serialize(bytes@)
+        BytesN::<3>.spec_serialize(bytes@)
     }
 }
 
@@ -617,14 +617,14 @@ impl SecureSpecCombinator for U24 {
     }
 
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>) {
-        Bytes(3).lemma_prefix_secure(s1, s2);
+        BytesN::<3>.lemma_prefix_secure(s1, s2);
     }
 
     proof fn theorem_serialize_parse_roundtrip(&self, v: u24) {
-        Bytes(3).theorem_serialize_parse_roundtrip(v.0@);
-        match Bytes(3).spec_serialize(v.0@) {
+        BytesN::<3>.theorem_serialize_parse_roundtrip(v.0@);
+        match BytesN::<3>.spec_serialize(v.0@) {
             Ok(buf) => {
-                match Bytes(3).spec_parse(buf) {
+                match BytesN::<3>.spec_parse(buf) {
                     Ok((n, bytes)) => {
                         bytes_eq_view_implies_eq([bytes[0], bytes[1], bytes[2]], v.0);
                     }
@@ -636,8 +636,8 @@ impl SecureSpecCombinator for U24 {
     }
 
     proof fn theorem_parse_serialize_roundtrip(&self, s: Seq<u8>) {
-        Bytes(3).theorem_parse_serialize_roundtrip(s);
-        match Bytes(3).spec_parse(s) {
+        BytesN::<3>.theorem_parse_serialize_roundtrip(s);
+        match BytesN::<3>.spec_parse(s) {
             Ok((n, bytes)) => {
                 assert([bytes[0], bytes[1], bytes[2]]@ == bytes);
             }
@@ -670,12 +670,12 @@ impl Combinator for U24 {
     }
 
     fn parse(&self, s: &[u8]) -> (res: Result<(usize, u24), ParseError>) {
-        let (n, bytes) = Bytes(3).parse(s)?;
+        let (n, bytes) = BytesN::<3>.parse(s)?;
         Ok((n, u24([bytes[0], bytes[1], bytes[2]])))
     }
 
     fn serialize(&self, v: u24, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
-        Bytes(3).serialize(v.0.as_slice(), data, pos)
+        BytesN::<3>.serialize(v.0.as_slice(), data, pos)
     }
 }
 


### PR DESCRIPTION
Rust doesn't support this primitive type `u24`, but TLS needs it.

I'm currently using a `[u8; 3]` to represent `u24` internally, with a trusted method to convert it to a `u32`.

For parsing and serialization, the new combinator `U24` is using `Bytes(3)` internally so the bitwise computation would really only happen when the user actually uses it (for example, by passing it to a `Depend` combinator).