### PR TITLE
Endianness support

### DIFF
--- a/vest-dsl/src/ast.rs
+++ b/vest-dsl/src/ast.rs
@@ -27,7 +27,7 @@ pub enum Definition {
     Endianess(Endianess),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Endianess {
     Little,
     Big,

--- a/vest-dsl/src/elab.rs
+++ b/vest-dsl/src/elab.rs
@@ -16,14 +16,19 @@ pub fn elaborate(ast: &mut Vec<Definition>) {
         .map(|sorted| {
             // reorder the definitions
             ast.sort_by_cached_key(|defn| {
-                sorted
-                    .iter()
-                    .position(|name_| match defn {
-                        Definition::Combinator { name, .. } => name == name_,
-                        Definition::ConstCombinator { name, .. } => name == name_,
-                        _ => false,
-                    })
-                    .unwrap()
+                // skip the endianness definition
+                if let Definition::Endianess(_) = defn {
+                    0
+                } else {
+                    sorted
+                        .iter()
+                        .position(|name_| match defn {
+                            Definition::Combinator { name, .. } => name == name_,
+                            Definition::ConstCombinator { name, .. } => name == name_,
+                            _ => false,
+                        })
+                        .unwrap()
+                }
             });
         })
         .unwrap_or_else(|_| {

--- a/vest-dsl/src/type_check.rs
+++ b/vest-dsl/src/type_check.rs
@@ -64,6 +64,7 @@ pub fn check(ast: &[Definition]) -> GlobalCtx {
             Definition::ConstCombinator { name, .. } => {
                 global_ctx.const_combinators.insert(name);
             }
+            Definition::Endianess(_) => {}
             _ => unimplemented!(),
         }
     }
@@ -89,6 +90,7 @@ fn check_defn(defn: &Definition, local_ctx: &mut LocalCtx, global_ctx: &GlobalCt
         } => {
             check_const_combinator(const_combinator, local_ctx, global_ctx);
         }
+        Definition::Endianess(_) => {}
         _ => unimplemented!(),
     }
 }
@@ -264,7 +266,7 @@ fn check_const_int_combinator(combinator: &IntCombinator, value: &i128) {
                 panic!("Value {} is out of range for u64", value);
             }
         }
-        _ => panic!("Unsupported int combinator"),
+        _ => panic!("Unsupported const int combinator"),
     }
 }
 

--- a/vest-dsl/test/src/elab.rs
+++ b/vest-dsl/test/src/elab.rs
@@ -234,114 +234,6 @@ pub type Content0<'a> = &'a [u8];
 
 pub type Content0Owned = Vec<u8>;
 
-pub struct SpecMsgA {
-    pub f1: SpecMsgB,
-    pub f2: Seq<u8>,
-}
-
-pub type SpecMsgAInner = (SpecMsgB, Seq<u8>);
-
-impl SpecFrom<SpecMsgA> for SpecMsgAInner {
-    open spec fn spec_from(m: SpecMsgA) -> SpecMsgAInner {
-        (m.f1, m.f2)
-    }
-}
-
-impl SpecFrom<SpecMsgAInner> for SpecMsgA {
-    open spec fn spec_from(m: SpecMsgAInner) -> SpecMsgA {
-        let (f1, f2) = m;
-        SpecMsgA { f1, f2 }
-    }
-}
-
-pub struct MsgA<'a> {
-    pub f1: MsgB<'a>,
-    pub f2: &'a [u8],
-}
-
-pub type MsgAInner<'a> = (MsgB<'a>, &'a [u8]);
-
-impl View for MsgA<'_> {
-    type V = SpecMsgA;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgA { f1: self.f1@, f2: self.f2@ }
-    }
-}
-
-impl<'a> From<MsgA<'a>> for MsgAInner<'a> {
-    fn ex_from(m: MsgA<'a>) -> MsgAInner<'a> {
-        (m.f1, m.f2)
-    }
-}
-
-impl<'a> From<MsgAInner<'a>> for MsgA<'a> {
-    fn ex_from(m: MsgAInner<'a>) -> MsgA<'a> {
-        let (f1, f2) = m;
-        MsgA { f1, f2 }
-    }
-}
-
-pub struct MsgAMapper;
-
-impl View for MsgAMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for MsgAMapper {
-    type Src = SpecMsgAInner;
-
-    type Dst = SpecMsgA;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for MsgAMapper {
-    type Src<'a> = MsgAInner<'a>;
-
-    type Dst<'a> = MsgA<'a>;
-
-    type SrcOwned = MsgAOwnedInner;
-
-    type DstOwned = MsgAOwned;
-}
-
-pub struct MsgAOwned {
-    pub f1: MsgBOwned,
-    pub f2: Vec<u8>,
-}
-
-pub type MsgAOwnedInner = (MsgBOwned, Vec<u8>);
-
-impl View for MsgAOwned {
-    type V = SpecMsgA;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgA { f1: self.f1@, f2: self.f2@ }
-    }
-}
-
-impl From<MsgAOwned> for MsgAOwnedInner {
-    fn ex_from(m: MsgAOwned) -> MsgAOwnedInner {
-        (m.f1, m.f2)
-    }
-}
-
-impl From<MsgAOwnedInner> for MsgAOwned {
-    fn ex_from(m: MsgAOwnedInner) -> MsgAOwned {
-        let (f1, f2) = m;
-        MsgAOwned { f1, f2 }
-    }
-}
-
 pub type SpecContentType = u8;
 
 pub type ContentType = u8;
@@ -501,11 +393,11 @@ impl From<MsgCF4OwnedInner> for MsgCF4Owned {
 
 pub struct SpecMsgC {
     pub f2: SpecContentType,
-    pub f3: u8,
+    pub f3: u24,
     pub f4: SpecMsgCF4,
 }
 
-pub type SpecMsgCInner = ((SpecContentType, u8), SpecMsgCF4);
+pub type SpecMsgCInner = ((SpecContentType, u24), SpecMsgCF4);
 
 impl SpecFrom<SpecMsgC> for SpecMsgCInner {
     open spec fn spec_from(m: SpecMsgC) -> SpecMsgCInner {
@@ -522,11 +414,11 @@ impl SpecFrom<SpecMsgCInner> for SpecMsgC {
 
 pub struct MsgC<'a> {
     pub f2: ContentType,
-    pub f3: u8,
+    pub f3: u24,
     pub f4: MsgCF4<'a>,
 }
 
-pub type MsgCInner<'a> = ((ContentType, u8), MsgCF4<'a>);
+pub type MsgCInner<'a> = ((ContentType, u24), MsgCF4<'a>);
 
 impl View for MsgC<'_> {
     type V = SpecMsgC;
@@ -583,11 +475,11 @@ impl Iso for MsgCMapper {
 
 pub struct MsgCOwned {
     pub f2: ContentTypeOwned,
-    pub f3: u8,
+    pub f3: u24,
     pub f4: MsgCF4Owned,
 }
 
-pub type MsgCOwnedInner = ((ContentTypeOwned, u8), MsgCF4Owned);
+pub type MsgCOwnedInner = ((ContentTypeOwned, u24), MsgCF4Owned);
 
 impl View for MsgCOwned {
     type V = SpecMsgC;
@@ -610,12 +502,120 @@ impl From<MsgCOwnedInner> for MsgCOwned {
     }
 }
 
+pub struct SpecMsgA {
+    pub f1: SpecMsgB,
+    pub f2: Seq<u8>,
+}
+
+pub type SpecMsgAInner = (SpecMsgB, Seq<u8>);
+
+impl SpecFrom<SpecMsgA> for SpecMsgAInner {
+    open spec fn spec_from(m: SpecMsgA) -> SpecMsgAInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl SpecFrom<SpecMsgAInner> for SpecMsgA {
+    open spec fn spec_from(m: SpecMsgAInner) -> SpecMsgA {
+        let (f1, f2) = m;
+        SpecMsgA { f1, f2 }
+    }
+}
+
+pub struct MsgA<'a> {
+    pub f1: MsgB<'a>,
+    pub f2: &'a [u8],
+}
+
+pub type MsgAInner<'a> = (MsgB<'a>, &'a [u8]);
+
+impl View for MsgA<'_> {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl<'a> From<MsgA<'a>> for MsgAInner<'a> {
+    fn ex_from(m: MsgA<'a>) -> MsgAInner<'a> {
+        (m.f1, m.f2)
+    }
+}
+
+impl<'a> From<MsgAInner<'a>> for MsgA<'a> {
+    fn ex_from(m: MsgAInner<'a>) -> MsgA<'a> {
+        let (f1, f2) = m;
+        MsgA { f1, f2 }
+    }
+}
+
+pub struct MsgAMapper;
+
+impl View for MsgAMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgAMapper {
+    type Src = SpecMsgAInner;
+
+    type Dst = SpecMsgA;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgAMapper {
+    type Src<'a> = MsgAInner<'a>;
+
+    type Dst<'a> = MsgA<'a>;
+
+    type SrcOwned = MsgAOwnedInner;
+
+    type DstOwned = MsgAOwned;
+}
+
+pub struct MsgAOwned {
+    pub f1: MsgBOwned,
+    pub f2: Vec<u8>,
+}
+
+pub type MsgAOwnedInner = (MsgBOwned, Vec<u8>);
+
+impl View for MsgAOwned {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl From<MsgAOwned> for MsgAOwnedInner {
+    fn ex_from(m: MsgAOwned) -> MsgAOwnedInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl From<MsgAOwnedInner> for MsgAOwned {
+    fn ex_from(m: MsgAOwnedInner) -> MsgAOwned {
+        let (f1, f2) = m;
+        MsgAOwned { f1, f2 }
+    }
+}
+
 pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
 
 pub const MSGD_F2: u16 = 4660;
 
 pub type SpecMsgDCombinator = Mapped<
-    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16, TagPred<u16>>),
+    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16Be, TagPred<u16>>),
     MsgDMapper,
 >;
 
@@ -657,7 +657,7 @@ impl Pred for BytesPredicate16235736133663645624 {
 }
 
 pub type MsgDCombinator = Mapped<
-    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16, TagPred<u16>>),
+    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16Be, TagPred<u16>>),
     MsgDMapper,
 >;
 
@@ -669,10 +669,6 @@ pub type SpecContent0Combinator = Bytes;
 
 pub type Content0Combinator = Bytes;
 
-pub type SpecMsgACombinator = Mapped<(SpecMsgBCombinator, Tail), MsgAMapper>;
-
-pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
-
 pub type SpecContentTypeCombinator = U8;
 
 pub type ContentTypeCombinator = U8;
@@ -682,7 +678,7 @@ pub type SpecMsgCF4Combinator = AndThen<
     Mapped<
         OrdChoice<
             Cond<SpecContent0Combinator>,
-            OrdChoice<Cond<U16>, OrdChoice<Cond<U32>, Cond<Tail>>>,
+            OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>,
         >,
         MsgCF4Mapper,
     >,
@@ -691,28 +687,35 @@ pub type SpecMsgCF4Combinator = AndThen<
 pub type MsgCF4Combinator = AndThen<
     Bytes,
     Mapped<
-        OrdChoice<Cond<Content0Combinator>, OrdChoice<Cond<U16>, OrdChoice<Cond<U32>, Cond<Tail>>>>,
+        OrdChoice<
+            Cond<Content0Combinator>,
+            OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>,
+        >,
         MsgCF4Mapper,
     >,
 >;
 
 pub type SpecMsgCCombinator = Mapped<
-    SpecDepend<(SpecContentTypeCombinator, U8), SpecMsgCF4Combinator>,
+    SpecDepend<(SpecContentTypeCombinator, U24Be), SpecMsgCF4Combinator>,
     MsgCMapper,
 >;
 
 pub struct MsgCCont;
 
 pub type MsgCCombinator = Mapped<
-    Depend<(ContentTypeCombinator, U8), MsgCF4Combinator, MsgCCont>,
+    Depend<(ContentTypeCombinator, U24Be), MsgCF4Combinator, MsgCCont>,
     MsgCMapper,
 >;
+
+pub type SpecMsgACombinator = Mapped<(SpecMsgBCombinator, Tail), MsgAMapper>;
+
+pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
 
 pub open spec fn spec_msg_d() -> SpecMsgDCombinator {
     Mapped {
         inner: (
             Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
-            Refined { inner: U16, predicate: TagPred(MSGD_F2) },
+            Refined { inner: U16Be, predicate: TagPred(MSGD_F2) },
         ),
         mapper: MsgDMapper,
     }
@@ -725,7 +728,7 @@ pub fn msg_d() -> (o: MsgDCombinator)
     Mapped {
         inner: (
             Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
-            Refined { inner: U16, predicate: TagPred(MSGD_F2) },
+            Refined { inner: U16Be, predicate: TagPred(MSGD_F2) },
         ),
         mapper: MsgDMapper,
     }
@@ -742,26 +745,15 @@ pub fn msg_b() -> (o: MsgBCombinator)
     Mapped { inner: msg_d(), mapper: MsgBMapper }
 }
 
-pub open spec fn spec_content_0(num: u8) -> SpecContent0Combinator {
-    Bytes(num as usize)
+pub open spec fn spec_content_0(num: u24) -> SpecContent0Combinator {
+    Bytes(num.spec_into())
 }
 
-pub fn content_0<'a>(num: u8) -> (o: Content0Combinator)
+pub fn content_0<'a>(num: u24) -> (o: Content0Combinator)
     ensures
         o@ == spec_content_0(num@),
 {
-    Bytes(num as usize)
-}
-
-pub open spec fn spec_msg_a() -> SpecMsgACombinator {
-    Mapped { inner: (spec_msg_b(), Tail), mapper: MsgAMapper }
-}
-
-pub fn msg_a() -> (o: MsgACombinator)
-    ensures
-        o@ == spec_msg_a(),
-{
-    Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
+    Bytes(num.ex_into())
 }
 
 pub open spec fn spec_content_type() -> SpecContentTypeCombinator {
@@ -775,16 +767,16 @@ pub fn content_type() -> (o: ContentTypeCombinator)
     U8
 }
 
-pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> SpecMsgCF4Combinator {
+pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u24) -> SpecMsgCF4Combinator {
     AndThen(
-        Bytes(f3 as usize),
+        Bytes(f3.spec_into()),
         Mapped {
             inner: OrdChoice(
                 Cond { cond: f2 == 0, inner: spec_content_0(f3) },
                 OrdChoice(
-                    Cond { cond: f2 == 1, inner: U16 },
+                    Cond { cond: f2 == 1, inner: U16Be },
                     OrdChoice(
-                        Cond { cond: f2 == 2, inner: U32 },
+                        Cond { cond: f2 == 2, inner: U32Be },
                         Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
                     ),
                 ),
@@ -794,19 +786,19 @@ pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u8) -> SpecMsgCF4Combina
     )
 }
 
-pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
+pub fn msg_c_f4<'a>(f2: ContentType, f3: u24) -> (o: MsgCF4Combinator)
     ensures
         o@ == spec_msg_c_f4(f2@, f3@),
 {
     AndThen(
-        Bytes(f3 as usize),
+        Bytes(f3.ex_into()),
         Mapped {
             inner: OrdChoice(
                 Cond { cond: f2 == 0, inner: content_0(f3) },
                 OrdChoice(
-                    Cond { cond: f2 == 1, inner: U16 },
+                    Cond { cond: f2 == 1, inner: U16Be },
                     OrdChoice(
-                        Cond { cond: f2 == 2, inner: U32 },
+                        Cond { cond: f2 == 2, inner: U32Be },
                         Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
                     ),
                 ),
@@ -817,12 +809,12 @@ pub fn msg_c_f4<'a>(f2: ContentType, f3: u8) -> (o: MsgCF4Combinator)
 }
 
 pub open spec fn spec_msg_c() -> SpecMsgCCombinator {
-    let fst = (spec_content_type(), U8);
+    let fst = (spec_content_type(), U24Be);
     let snd = |deps| spec_msg_c_cont(deps);
     Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }
 }
 
-pub open spec fn spec_msg_c_cont(deps: (SpecContentType, u8)) -> SpecMsgCF4Combinator {
+pub open spec fn spec_msg_c_cont(deps: (SpecContentType, u24)) -> SpecMsgCF4Combinator {
     let (f2, f3) = deps;
     spec_msg_c_f4(f2, f3)
 }
@@ -831,27 +823,38 @@ pub fn msg_c() -> (o: MsgCCombinator)
     ensures
         o@ == spec_msg_c(),
 {
-    let fst = (content_type(), U8);
+    let fst = (content_type(), U24Be);
     let snd = MsgCCont;
     let spec_snd = Ghost(|deps| spec_msg_c_cont(deps));
     Mapped { inner: Depend { fst, snd, spec_snd }, mapper: MsgCMapper }
 }
 
-impl Continuation<(ContentType, u8)> for MsgCCont {
+impl Continuation<(ContentType, u24)> for MsgCCont {
     type Output = MsgCF4Combinator;
 
-    open spec fn requires(&self, deps: (ContentType, u8)) -> bool {
+    open spec fn requires(&self, deps: (ContentType, u24)) -> bool {
         true
     }
 
-    open spec fn ensures(&self, deps: (ContentType, u8), o: Self::Output) -> bool {
+    open spec fn ensures(&self, deps: (ContentType, u24), o: Self::Output) -> bool {
         o@ == spec_msg_c_cont(deps@)
     }
 
-    fn apply(&self, deps: (ContentType, u8)) -> Self::Output {
+    fn apply(&self, deps: (ContentType, u24)) -> Self::Output {
         let (f2, f3) = deps;
         msg_c_f4(f2, f3)
     }
+}
+
+pub open spec fn spec_msg_a() -> SpecMsgACombinator {
+    Mapped { inner: (spec_msg_b(), Tail), mapper: MsgAMapper }
+}
+
+pub fn msg_a() -> (o: MsgACombinator)
+    ensures
+        o@ == spec_msg_a(),
+{
+    Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
 }
 
 pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
@@ -910,22 +913,22 @@ pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
     msg_b().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u8) -> Result<(usize, SpecContent0), ()> {
+pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u24) -> Result<(usize, SpecContent0), ()> {
     spec_content_0(num).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u8) -> Result<Seq<u8>, ()> {
+pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u24) -> Result<Seq<u8>, ()> {
     spec_content_0(num).spec_serialize(msg)
 }
 
-pub fn parse_content_0(i: &[u8], num: u8) -> (o: Result<(usize, Content0<'_>), ParseError>)
+pub fn parse_content_0(i: &[u8], num: u24) -> (o: Result<(usize, Content0<'_>), ParseError>)
     ensures
         o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
 {
     content_0(num).parse(i)
 }
 
-pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u8) -> (o:
+pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u24) -> (o:
     Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
@@ -934,34 +937,6 @@ pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, nu
         },
 {
     content_0(num).serialize(msg, data, pos)
-}
-
-pub open spec fn parse_spec_msg_a(i: Seq<u8>) -> Result<(usize, SpecMsgA), ()> {
-    spec_msg_a().spec_parse(i)
-}
-
-pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
-    spec_msg_a().spec_serialize(msg)
-}
-
-pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ParseError>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
-{
-    msg_a().parse(i)
-}
-
-pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    SerializeError,
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg_a(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg_a().serialize(msg, data, pos)
 }
 
 pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
@@ -992,21 +967,21 @@ pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) 
     content_type().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u8) -> Result<
+pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u24) -> Result<
     (usize, SpecMsgCF4),
     (),
 > {
     spec_msg_c_f4(f2, f3).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f2: SpecContentType, f3: u8) -> Result<
+pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f2: SpecContentType, f3: u24) -> Result<
     Seq<u8>,
     (),
 > {
     spec_msg_c_f4(f2, f3).spec_serialize(msg)
 }
 
-pub fn parse_msg_c_f4(i: &[u8], f2: ContentType, f3: u8) -> (o: Result<
+pub fn parse_msg_c_f4(i: &[u8], f2: ContentType, f3: u24) -> (o: Result<
     (usize, MsgCF4<'_>),
     ParseError,
 >)
@@ -1021,7 +996,7 @@ pub fn serialize_msg_c_f4(
     data: &mut Vec<u8>,
     pos: usize,
     f2: ContentType,
-    f3: u8,
+    f3: u24,
 ) -> (o: Result<usize, SerializeError>)
     ensures
         o matches Ok(n) ==> {
@@ -1058,6 +1033,34 @@ pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Res
         },
 {
     msg_c().serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_a(i: Seq<u8>) -> Result<(usize, SpecMsgA), ()> {
+    spec_msg_a().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
+    spec_msg_a().spec_serialize(msg)
+}
+
+pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_a().parse(i)
+}
+
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+    usize,
+    SerializeError,
+>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_a(msg@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_a().serialize(msg, data, pos)
 }
 
 } // verus!

--- a/vest-dsl/test/src/elab.vest
+++ b/vest-dsl/test/src/elab.vest
@@ -1,3 +1,5 @@
+!BIG_ENDIAN
+
 msg_d = {
   const f1: [u8; 4] = [1; 4],
   const f2: u16 = 0x1234,
@@ -21,7 +23,7 @@ content_type = enum {
 
 msg_c = {
   @f2: content_type,
-  @f3: u8,
+  @f3: u24,
   f4: [u8; @f3] >>= choose(@f2) {
     C0 => content_0(@f3),
     C1 => u16,
@@ -30,4 +32,4 @@ msg_c = {
   },
 }
 
-content_0(@num: u8) = [u8; @num]
+content_0(@num: u24) = [u8; @num]

--- a/vest-examples/src/choice.rs
+++ b/vest-examples/src/choice.rs
@@ -17,8 +17,8 @@ broadcast use vest::regular::uints::size_of_facts;
 
 exec fn disjoint_examples(a: u32, b: u8) -> Result<(), Error> {
     let c1 = Cond { cond: a == 0 && b == 1, inner: U8 };
-    let c2 = Cond { cond: 0 < a && a < 5 && b == 2, inner: U16 };
-    let c3 = Cond { cond: a >= 5 && b == 2, inner: U32 };
+    let c2 = Cond { cond: 0 < a && a < 5 && b == 2, inner: U16Le };
+    let c3 = Cond { cond: a >= 5 && b == 2, inner: U32Le };
 
     let choice = ord_choice!(c1, c2, c3);
 
@@ -39,9 +39,9 @@ exec fn choice_parse_serialize() -> Result<(), Error> {
     let c3 = Tag::new(U8, 3);
     let c4 = Tag::new(U8, 4);
     let g1 = (Bytes(4), Tail);
-    let g2 = (U32, (U16, U8));
-    let g3 = (Tag::new(U8, 10), U32);
-    let g4 = (BytesN::<12>, (U16, (U8, U8)));
+    let g2 = (U32Le, (U16Le, U8));
+    let g3 = (Tag::new(U8, 10), U32Le);
+    let g4 = (BytesN::<12>, (U16Le, (U8, U8)));
     let ord_choice1 = ord_choice!(
         (c1, g1),
         (c2, g2),
@@ -111,9 +111,9 @@ exec fn choice_serialize_parse() -> Result<(), Error> {
     let c3 = Tag::new(U8, 3);
     let c4 = Tag::new(U8, 4);
     let g1 = (Bytes(4), Tail);
-    let g2 = (U32, (U16, U8));
-    let g3 = (Tag::new(U8, 10), U32);
-    let g4 = (BytesN::<12>, (U16, (U8, U8)));
+    let g2 = (U32Le, (U16Le, U8));
+    let g3 = (Tag::new(U8, 10), U32Le);
+    let g4 = (BytesN::<12>, (U16Le, (U8, U8)));
     let ord_choice1 = ord_choice!(
         (c1, g1),
         (c2, g2),

--- a/vest-examples/src/depend.rs
+++ b/vest-examples/src/depend.rs
@@ -7,9 +7,9 @@ use vstd::prelude::*;
 
 verus! {
 
-pub open spec fn msg1() -> SpecDepend<(U8, U24), (Bytes, Bytes)> {
+pub open spec fn msg1() -> SpecDepend<(U8, U24Be), (Bytes, Bytes)> {
     SpecDepend {
-        fst: (U8, U24),
+        fst: (U8, U24Be),
         snd: |deps| msg1_snd(deps),
     }
 }
@@ -40,7 +40,7 @@ impl Continuation<(u8, u24)> for Msg1Snd {
 }
 
 pub fn mk_msg1() -> (o: Depend<
-    (U8, U24),
+    (U8, U24Be),
     (Bytes, Bytes),
     Msg1Snd,
     >)
@@ -48,7 +48,7 @@ pub fn mk_msg1() -> (o: Depend<
         o@ == msg1(),
 {
     Depend {
-        fst: (U8, U24),
+        fst: (U8, U24Be),
         snd: Msg1Snd,
         spec_snd: Ghost(|deps| msg1_snd(deps)),
     }

--- a/vest-examples/src/map.rs
+++ b/vest-examples/src/map.rs
@@ -148,7 +148,7 @@ impl Iso for Msg1Mapper {
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
 fn parse_serialize() -> Result<(), Error> {
-    let msg_inner = (U8, (U16, (Bytes(3), Tail)));
+    let msg_inner = (U8, (U16Le, (Bytes(3), Tail)));
     let msg = Mapped { inner: msg_inner, mapper: Msg1Mapper };
     let mut data = my_vec![1u8, 123u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
     let mut s = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -166,7 +166,7 @@ fn parse_serialize() -> Result<(), Error> {
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
 fn serialize_parse() -> Result<(), Error> {
-    let msg_inner = (U8, (U16, (Bytes(3), Tail)));
+    let msg_inner = (U8, (U16Le, (Bytes(3), Tail)));
     let msg = Mapped { inner: msg_inner, mapper: Msg1Mapper };
     let bytes1: [u8; 3] = [0u8, 0u8, 1u8];
     let bytes2: [u8; 3] = [0u8, 0u8, 2u8];
@@ -263,7 +263,7 @@ impl Iso for Msg2Mapper {
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
 fn parse_serialize2() -> Result<(), Error> {
-    let msg_inner = (U8, (U16, U32));
+    let msg_inner = (U8, (U16Le, U32Le));
     let msg = Mapped { inner: msg_inner, mapper: Msg2Mapper };
     let mut data = my_vec![1u8, 123u8, 1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8];
     let mut s = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -281,7 +281,7 @@ fn parse_serialize2() -> Result<(), Error> {
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
 fn serialize_parse2() -> Result<(), Error> {
-    let msg_inner = (U8, (U16, U32));
+    let msg_inner = (U8, (U16Le, U32Le));
     let msg = Mapped { inner: msg_inner, mapper: Msg2Mapper };
     let val = Msg2 { a: 1, b: 123, c: 1 };
     let mut s1 = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -587,8 +587,8 @@ fn parse_serialize4() -> Result<(), Error> {
     let tag1 = Tag::new(U8, 1);
     let tag2 = Tag::new(U8, 2);
     let tag3 = Tag::new(U8, 3);
-    let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16, (Bytes(3), Tail))), mapper: Msg1Mapper });
-    let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper });
+    let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16Le, (Bytes(3), Tail))), mapper: Msg1Mapper });
+    let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16Le, U32Le)), mapper: Msg2Mapper });
     let msg3 = Preceded(tag3, Mapped { inner: BytesN::<6>, mapper: Msg3Mapper });
     let msg_inner = ord_choice!(msg1, msg2, msg3);
     let msg = Mapped { inner: msg_inner, mapper: Msg4Mapper };
@@ -620,8 +620,8 @@ fn serialize_parse4() -> Result<(), Error> {
     let tag1 = Tag::new(U8, 1);
     let tag2 = Tag::new(U8, 2);
     let tag3 = Tag::new(U8, 3);
-    let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16, (Bytes(3), Tail))), mapper: Msg1Mapper });
-    let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper });
+    let msg1 = Preceded(tag1, Mapped { inner: (U8, (U16Le, (Bytes(3), Tail))), mapper: Msg1Mapper });
+    let msg2 = Preceded(tag2, Mapped { inner: (U8, (U16Le, U32Le)), mapper: Msg2Mapper });
     let msg3 = Preceded(tag3, Mapped { inner: BytesN::<6>, mapper: Msg3Mapper });
     let msg_inner = ord_choice!(msg1, msg2, msg3);
     let msg = Mapped { inner: msg_inner, mapper: Msg4Mapper };

--- a/vest-examples/src/pair.rs
+++ b/vest-examples/src/pair.rs
@@ -12,7 +12,7 @@ verus! {
 /// verify parse-serialize inverse ///
 //////////////////////////////////////
 exec fn parse_serialize() -> Result<(), Error> {
-    let msg1 = ((Tag::new(U8, 1), U32), Bytes(3));
+    let msg1 = ((Tag::new(U8, 1), U32Le), Bytes(3));
     let mut data1 = my_vec![1u8, 0x40u8, 0xE2u8, 0x01u8, 0x00u8, 0u8, 0u8, 1u8, 0u8, 0u8, 0u8, 0u8];
     let mut s1 = my_vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
     let (n1, val1) = msg1.parse(data1.as_slice())?;
@@ -38,7 +38,7 @@ exec fn parse_serialize() -> Result<(), Error> {
 /// verify serialize-parse inverse ///
 //////////////////////////////////////
 exec fn serialize_parse() -> Result<(), Error> {
-    let msg1 = ((Tag::new(U8, 1), U32), Bytes(3));
+    let msg1 = ((Tag::new(U8, 1), U32Le), Bytes(3));
     let mut bytes = my_vec![0u8, 0u8, 1u8];
     let val1 = (((), 123456u32), bytes.as_slice());
     assert(bytes@ == seq![0u8, 0u8, 1u8]);

--- a/vest/src/regular/clone.rs
+++ b/vest/src/regular/clone.rs
@@ -2,7 +2,7 @@ use super::bytes::Bytes;
 use super::bytes_n::BytesN;
 use super::tag::Tag;
 use super::tail::Tail;
-use super::uints::{U16, U32, U64, U8};
+use super::uints::{U16Le, U32Le, U64Le, U8};
 use vstd::prelude::*;
 
 verus! {
@@ -24,7 +24,7 @@ macro_rules! impl_reflexive_clone {
     };
 }
 
-impl_reflexive_clone!(U8, U16, U32, U64, Tail);
+impl_reflexive_clone!(U8, U16Le, U32Le, U64Le, Tail);
 
 macro_rules! impl_clone_for_int_tags {
     ($($combinator:ty),*) => {
@@ -43,7 +43,7 @@ macro_rules! impl_clone_for_int_tags {
     };
 }
 
-impl_clone_for_int_tags!(Tag<U8, u8>, Tag<U16, u16>, Tag<U32, u32>, Tag<U64, u64>);
+impl_clone_for_int_tags!(Tag<U8, u8>, Tag<U16Le, u16>, Tag<U32Le, u32>, Tag<U64Le, u64>);
 
 // impl<T: FromToBytes + Copy> Clone for Tag<Int<T>, T> {
 //     fn clone(&self) -> (out: Self)

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -120,9 +120,7 @@ impl<Inner: Combinator> Combinator for Cond<Inner> where
     }
 }
 
-}
-
-
+} // verus!
 #[cfg(test)]
 mod test {
     #![allow(unused_imports)]
@@ -143,6 +141,7 @@ mod test {
     use vstd::prelude::*;
 
     verus! {
+
 pub type SpecMsg3 = Seq<u8>;
 
 pub type Msg3<'a> = &'a [u8];
@@ -747,7 +746,7 @@ impl SpecPred for Predicate5821512137558126895 {
 }
 
 pub type SpecMsg1Combinator = Mapped<
-    (Refined<U8, Predicate5821512137558126895>, (U16, BytesN<3>)),
+    (Refined<U8, Predicate5821512137558126895>, (U16Le, BytesN<3>)),
     Msg1Mapper,
 >;
 
@@ -777,13 +776,13 @@ impl Pred for Predicate5821512137558126895 {
 }
 
 pub type Msg1Combinator = Mapped<
-    (Refined<U8, Predicate5821512137558126895>, (U16, BytesN<3>)),
+    (Refined<U8, Predicate5821512137558126895>, (U16Le, BytesN<3>)),
     Msg1Mapper,
 >;
 
-pub type SpecMsg2Combinator = Mapped<(U8, (U16, U32)), Msg2Mapper>;
+pub type SpecMsg2Combinator = Mapped<(U8, (U16Le, U32Le)), Msg2Mapper>;
 
-pub type Msg2Combinator = Mapped<(U8, (U16, U32)), Msg2Mapper>;
+pub type Msg2Combinator = Mapped<(U8, (U16Le, U32Le)), Msg2Mapper>;
 
 pub type SpecMsg4VCombinator = Mapped<
     OrdChoice<
@@ -834,7 +833,7 @@ pub fn a_type() -> (o: ATypeCombinator)
 
 pub open spec fn spec_msg1() -> SpecMsg1Combinator {
     Mapped {
-        inner: (Refined { inner: U8, predicate: Predicate5821512137558126895 }, (U16, BytesN::<3>)),
+        inner: (Refined { inner: U8, predicate: Predicate5821512137558126895 }, (U16Le, BytesN::<3>)),
         mapper: Msg1Mapper,
     }
 }
@@ -844,20 +843,20 @@ pub fn msg1() -> (o: Msg1Combinator)
         o@ == spec_msg1(),
 {
     Mapped {
-        inner: (Refined { inner: U8, predicate: Predicate5821512137558126895 }, (U16, BytesN::<3>)),
+        inner: (Refined { inner: U8, predicate: Predicate5821512137558126895 }, (U16Le, BytesN::<3>)),
         mapper: Msg1Mapper,
     }
 }
 
 pub open spec fn spec_msg2() -> SpecMsg2Combinator {
-    Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper }
+    Mapped { inner: (U8, (U16Le, U32Le)), mapper: Msg2Mapper }
 }
 
 pub fn msg2() -> (o: Msg2Combinator)
     ensures
         o@ == spec_msg2(),
 {
-    Mapped { inner: (U8, (U16, U32)), mapper: Msg2Mapper }
+    Mapped { inner: (U8, (U16Le, U32Le)), mapper: Msg2Mapper }
 }
 
 pub open spec fn spec_msg4_v(t: SpecAType) -> SpecMsg4VCombinator {
@@ -1095,8 +1094,5 @@ pub fn serialize_msg4(msg: Msg4<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Resu
     msg4().serialize(msg, data, pos)
 }
 
-
+} // verus!
 }
-
-}
-

--- a/vest/src/regular/cond.rs
+++ b/vest/src/regular/cond.rs
@@ -142,26 +142,57 @@ mod test {
 
     verus! {
 
-pub type SpecMsg3 = Seq<u8>;
-
-pub type Msg3<'a> = &'a [u8];
-
-pub type Msg3Owned = Vec<u8>;
-
-#[derive(Structural, Copy, Clone, PartialEq, Eq)]
-pub enum AType {
-    A = 0,
-    B = 1,
-    C = 2,
+pub struct SpecMsgD {
+    pub f1: Seq<u8>,
+    pub f2: u16,
 }
 
-pub type SpecAType = AType;
+pub type SpecMsgDInner = (Seq<u8>, u16);
 
-pub type ATypeOwned = AType;
+impl SpecFrom<SpecMsgD> for SpecMsgDInner {
+    open spec fn spec_from(m: SpecMsgD) -> SpecMsgDInner {
+        (m.f1, m.f2)
+    }
+}
 
-pub type ATypeInner = u8;
+impl SpecFrom<SpecMsgDInner> for SpecMsgD {
+    open spec fn spec_from(m: SpecMsgDInner) -> SpecMsgD {
+        let (f1, f2) = m;
+        SpecMsgD { f1, f2 }
+    }
+}
 
-impl View for AType {
+pub struct MsgD<'a> {
+    pub f1: &'a [u8],
+    pub f2: u16,
+}
+
+pub type MsgDInner<'a> = (&'a [u8], u16);
+
+impl View for MsgD<'_> {
+    type V = SpecMsgD;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgD { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl<'a> From<MsgD<'a>> for MsgDInner<'a> {
+    fn ex_from(m: MsgD<'a>) -> MsgDInner<'a> {
+        (m.f1, m.f2)
+    }
+}
+
+impl<'a> From<MsgDInner<'a>> for MsgD<'a> {
+    fn ex_from(m: MsgDInner<'a>) -> MsgD<'a> {
+        let (f1, f2) = m;
+        MsgD { f1, f2 }
+    }
+}
+
+pub struct MsgDMapper;
+
+impl View for MsgDMapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -169,70 +200,10 @@ impl View for AType {
     }
 }
 
-impl SpecTryFrom<ATypeInner> for AType {
-    type Error = ();
+impl SpecIso for MsgDMapper {
+    type Src = SpecMsgDInner;
 
-    open spec fn spec_try_from(v: ATypeInner) -> Result<AType, ()> {
-        match v {
-            0u8 => Ok(AType::A),
-            1u8 => Ok(AType::B),
-            2u8 => Ok(AType::C),
-            _ => Err(()),
-        }
-    }
-}
-
-impl SpecTryFrom<AType> for ATypeInner {
-    type Error = ();
-
-    open spec fn spec_try_from(v: AType) -> Result<ATypeInner, ()> {
-        match v {
-            AType::A => Ok(0u8),
-            AType::B => Ok(1u8),
-            AType::C => Ok(2u8),
-        }
-    }
-}
-
-impl TryFrom<ATypeInner> for AType {
-    type Error = ();
-
-    fn ex_try_from(v: ATypeInner) -> Result<AType, ()> {
-        match v {
-            0u8 => Ok(AType::A),
-            1u8 => Ok(AType::B),
-            2u8 => Ok(AType::C),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<AType> for ATypeInner {
-    type Error = ();
-
-    fn ex_try_from(v: AType) -> Result<ATypeInner, ()> {
-        match v {
-            AType::A => Ok(0u8),
-            AType::B => Ok(1u8),
-            AType::C => Ok(2u8),
-        }
-    }
-}
-
-pub struct ATypeMapper;
-
-impl View for ATypeMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFromInto for ATypeMapper {
-    type Src = ATypeInner;
-
-    type Dst = AType;
+    type Dst = SpecMsgD;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -241,69 +212,93 @@ impl SpecTryFromInto for ATypeMapper {
     }
 }
 
-impl TryFromInto for ATypeMapper {
-    type Src<'a> = ATypeInner;
+impl Iso for MsgDMapper {
+    type Src<'a> = MsgDInner<'a>;
 
-    type Dst<'a> = AType;
+    type Dst<'a> = MsgD<'a>;
 
-    type SrcOwned = ATypeInner;
+    type SrcOwned = MsgDOwnedInner;
 
-    type DstOwned = AType;
+    type DstOwned = MsgDOwned;
 }
 
-pub struct SpecMsg1 {
-    pub a: u8,
-    pub b: u16,
-    pub c: Seq<u8>,
+pub struct MsgDOwned {
+    pub f1: Vec<u8>,
+    pub f2: u16,
 }
 
-pub type SpecMsg1Inner = (u8, (u16, Seq<u8>));
+pub type MsgDOwnedInner = (Vec<u8>, u16);
 
-impl SpecFrom<SpecMsg1> for SpecMsg1Inner {
-    open spec fn spec_from(m: SpecMsg1) -> SpecMsg1Inner {
-        (m.a, (m.b, m.c))
-    }
-}
-
-impl SpecFrom<SpecMsg1Inner> for SpecMsg1 {
-    open spec fn spec_from(m: SpecMsg1Inner) -> SpecMsg1 {
-        let (a, (b, c)) = m;
-        SpecMsg1 { a, b, c }
-    }
-}
-
-pub struct Msg1<'a> {
-    pub a: u8,
-    pub b: u16,
-    pub c: &'a [u8],
-}
-
-pub type Msg1Inner<'a> = (u8, (u16, &'a [u8]));
-
-impl View for Msg1<'_> {
-    type V = SpecMsg1;
+impl View for MsgDOwned {
+    type V = SpecMsgD;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg1 { a: self.a@, b: self.b@, c: self.c@ }
+        SpecMsgD { f1: self.f1@, f2: self.f2@ }
     }
 }
 
-impl<'a> From<Msg1<'a>> for Msg1Inner<'a> {
-    fn ex_from(m: Msg1<'a>) -> Msg1Inner<'a> {
-        (m.a, (m.b, m.c))
+impl From<MsgDOwned> for MsgDOwnedInner {
+    fn ex_from(m: MsgDOwned) -> MsgDOwnedInner {
+        (m.f1, m.f2)
     }
 }
 
-impl<'a> From<Msg1Inner<'a>> for Msg1<'a> {
-    fn ex_from(m: Msg1Inner<'a>) -> Msg1<'a> {
-        let (a, (b, c)) = m;
-        Msg1 { a, b, c }
+impl From<MsgDOwnedInner> for MsgDOwned {
+    fn ex_from(m: MsgDOwnedInner) -> MsgDOwned {
+        let (f1, f2) = m;
+        MsgDOwned { f1, f2 }
     }
 }
 
-pub struct Msg1Mapper;
+pub struct SpecMsgB {
+    pub f1: SpecMsgD,
+}
 
-impl View for Msg1Mapper {
+pub type SpecMsgBInner = SpecMsgD;
+
+impl SpecFrom<SpecMsgB> for SpecMsgBInner {
+    open spec fn spec_from(m: SpecMsgB) -> SpecMsgBInner {
+        m.f1
+    }
+}
+
+impl SpecFrom<SpecMsgBInner> for SpecMsgB {
+    open spec fn spec_from(m: SpecMsgBInner) -> SpecMsgB {
+        let f1 = m;
+        SpecMsgB { f1 }
+    }
+}
+
+pub struct MsgB<'a> {
+    pub f1: MsgD<'a>,
+}
+
+pub type MsgBInner<'a> = MsgD<'a>;
+
+impl View for MsgB<'_> {
+    type V = SpecMsgB;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgB { f1: self.f1@ }
+    }
+}
+
+impl<'a> From<MsgB<'a>> for MsgBInner<'a> {
+    fn ex_from(m: MsgB<'a>) -> MsgBInner<'a> {
+        m.f1
+    }
+}
+
+impl<'a> From<MsgBInner<'a>> for MsgB<'a> {
+    fn ex_from(m: MsgBInner<'a>) -> MsgB<'a> {
+        let f1 = m;
+        MsgB { f1 }
+    }
+}
+
+pub struct MsgBMapper;
+
+impl View for MsgBMapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -311,10 +306,10 @@ impl View for Msg1Mapper {
     }
 }
 
-impl SpecIso for Msg1Mapper {
-    type Src = SpecMsg1Inner;
+impl SpecIso for MsgBMapper {
+    type Src = SpecMsgBInner;
 
-    type Dst = SpecMsg1;
+    type Dst = SpecMsgB;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -323,227 +318,133 @@ impl SpecIso for Msg1Mapper {
     }
 }
 
-impl Iso for Msg1Mapper {
-    type Src<'a> = Msg1Inner<'a>;
+impl Iso for MsgBMapper {
+    type Src<'a> = MsgBInner<'a>;
 
-    type Dst<'a> = Msg1<'a>;
+    type Dst<'a> = MsgB<'a>;
 
-    type SrcOwned = Msg1OwnedInner;
+    type SrcOwned = MsgBOwnedInner;
 
-    type DstOwned = Msg1Owned;
+    type DstOwned = MsgBOwned;
 }
 
-pub struct Msg1Owned {
-    pub a: u8,
-    pub b: u16,
-    pub c: Vec<u8>,
+pub struct MsgBOwned {
+    pub f1: MsgDOwned,
 }
 
-pub type Msg1OwnedInner = (u8, (u16, Vec<u8>));
+pub type MsgBOwnedInner = MsgDOwned;
 
-impl View for Msg1Owned {
-    type V = SpecMsg1;
+impl View for MsgBOwned {
+    type V = SpecMsgB;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg1 { a: self.a@, b: self.b@, c: self.c@ }
+        SpecMsgB { f1: self.f1@ }
     }
 }
 
-impl From<Msg1Owned> for Msg1OwnedInner {
-    fn ex_from(m: Msg1Owned) -> Msg1OwnedInner {
-        (m.a, (m.b, m.c))
+impl From<MsgBOwned> for MsgBOwnedInner {
+    fn ex_from(m: MsgBOwned) -> MsgBOwnedInner {
+        m.f1
     }
 }
 
-impl From<Msg1OwnedInner> for Msg1Owned {
-    fn ex_from(m: Msg1OwnedInner) -> Msg1Owned {
-        let (a, (b, c)) = m;
-        Msg1Owned { a, b, c }
+impl From<MsgBOwnedInner> for MsgBOwned {
+    fn ex_from(m: MsgBOwnedInner) -> MsgBOwned {
+        let f1 = m;
+        MsgBOwned { f1 }
     }
 }
 
-pub struct SpecMsg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
+pub type SpecContent0 = Seq<u8>;
+
+pub type Content0<'a> = &'a [u8];
+
+pub type Content0Owned = Vec<u8>;
+
+pub type SpecContentType = u8;
+
+pub type ContentType = u8;
+
+pub type ContentTypeOwned = u8;
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Seq<u8>),
 }
 
-pub type SpecMsg2Inner = (u8, (u16, u32));
+pub type SpecMsgCF4Inner = Either<SpecContent0, Either<u16, Either<u32, Seq<u8>>>>;
 
-impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
-    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
-        (m.a, (m.b, m.c))
-    }
-}
-
-impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
-    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
-        let (a, (b, c)) = m;
-        SpecMsg2 { a, b, c }
-    }
-}
-
-pub struct Msg2 {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type Msg2Inner = (u8, (u16, u32));
-
-impl View for Msg2 {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
-    }
-}
-
-impl From<Msg2> for Msg2Inner {
-    fn ex_from(m: Msg2) -> Msg2Inner {
-        (m.a, (m.b, m.c))
-    }
-}
-
-impl From<Msg2Inner> for Msg2 {
-    fn ex_from(m: Msg2Inner) -> Msg2 {
-        let (a, (b, c)) = m;
-        Msg2 { a, b, c }
-    }
-}
-
-pub struct Msg2Mapper;
-
-impl View for Msg2Mapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecIso for Msg2Mapper {
-    type Src = SpecMsg2Inner;
-
-    type Dst = SpecMsg2;
-
-    proof fn spec_iso(s: Self::Src) {
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) {
-    }
-}
-
-impl Iso for Msg2Mapper {
-    type Src<'a> = Msg2Inner;
-
-    type Dst<'a> = Msg2;
-
-    type SrcOwned = Msg2OwnedInner;
-
-    type DstOwned = Msg2Owned;
-}
-
-pub struct Msg2Owned {
-    pub a: u8,
-    pub b: u16,
-    pub c: u32,
-}
-
-pub type Msg2OwnedInner = (u8, (u16, u32));
-
-impl View for Msg2Owned {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 { a: self.a@, b: self.b@, c: self.c@ }
-    }
-}
-
-impl From<Msg2Owned> for Msg2OwnedInner {
-    fn ex_from(m: Msg2Owned) -> Msg2OwnedInner {
-        (m.a, (m.b, m.c))
-    }
-}
-
-impl From<Msg2OwnedInner> for Msg2Owned {
-    fn ex_from(m: Msg2OwnedInner) -> Msg2Owned {
-        let (a, (b, c)) = m;
-        Msg2Owned { a, b, c }
-    }
-}
-
-pub enum SpecMsg4V {
-    A(SpecMsg1),
-    B(SpecMsg2),
-    C(SpecMsg3),
-}
-
-pub type SpecMsg4VInner = Either<SpecMsg1, Either<SpecMsg2, SpecMsg3>>;
-
-impl SpecFrom<SpecMsg4V> for SpecMsg4VInner {
-    open spec fn spec_from(m: SpecMsg4V) -> SpecMsg4VInner {
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
         match m {
-            SpecMsg4V::A(m) => Either::Left(m),
-            SpecMsg4V::B(m) => Either::Right(Either::Left(m)),
-            SpecMsg4V::C(m) => Either::Right(Either::Right(m)),
+            SpecMsgCF4::C0(m) => Either::Left(m),
+            SpecMsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            SpecMsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecMsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
         }
     }
 }
 
-impl SpecFrom<SpecMsg4VInner> for SpecMsg4V {
-    open spec fn spec_from(m: SpecMsg4VInner) -> SpecMsg4V {
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
         match m {
-            Either::Left(m) => SpecMsg4V::A(m),
-            Either::Right(Either::Left(m)) => SpecMsg4V::B(m),
-            Either::Right(Either::Right(m)) => SpecMsg4V::C(m),
+            Either::Left(m) => SpecMsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => SpecMsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecMsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecMsgCF4::Unrecognized(m),
         }
     }
 }
 
-pub enum Msg4V<'a> {
-    A(Msg1<'a>),
-    B(Msg2),
-    C(Msg3<'a>),
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
+    Unrecognized(&'a [u8]),
 }
 
-pub type Msg4VInner<'a> = Either<Msg1<'a>, Either<Msg2, Msg3<'a>>>;
+pub type MsgCF4Inner<'a> = Either<Content0<'a>, Either<u16, Either<u32, &'a [u8]>>>;
 
-impl View for Msg4V<'_> {
-    type V = SpecMsg4V;
+impl View for MsgCF4<'_> {
+    type V = SpecMsgCF4;
 
     open spec fn view(&self) -> Self::V {
         match self {
-            Msg4V::A(m) => SpecMsg4V::A(m@),
-            Msg4V::B(m) => SpecMsg4V::B(m@),
-            Msg4V::C(m) => SpecMsg4V::C(m@),
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
         }
     }
 }
 
-impl<'a> From<Msg4V<'a>> for Msg4VInner<'a> {
-    fn ex_from(m: Msg4V<'a>) -> Msg4VInner<'a> {
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
         match m {
-            Msg4V::A(m) => Either::Left(m),
-            Msg4V::B(m) => Either::Right(Either::Left(m)),
-            Msg4V::C(m) => Either::Right(Either::Right(m)),
+            MsgCF4::C0(m) => Either::Left(m),
+            MsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
         }
     }
 }
 
-impl<'a> From<Msg4VInner<'a>> for Msg4V<'a> {
-    fn ex_from(m: Msg4VInner<'a>) -> Msg4V<'a> {
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
         match m {
-            Either::Left(m) => Msg4V::A(m),
-            Either::Right(Either::Left(m)) => Msg4V::B(m),
-            Either::Right(Either::Right(m)) => Msg4V::C(m),
+            Either::Left(m) => MsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4::Unrecognized(m),
         }
     }
 }
 
-pub struct Msg4VMapper;
+pub struct MsgCF4Mapper;
 
-impl View for Msg4VMapper {
+impl View for MsgCF4Mapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -551,10 +452,10 @@ impl View for Msg4VMapper {
     }
 }
 
-impl SpecIso for Msg4VMapper {
-    type Src = SpecMsg4VInner;
+impl SpecIso for MsgCF4Mapper {
+    type Src = SpecMsgCF4Inner;
 
-    type Dst = SpecMsg4V;
+    type Dst = SpecMsgCF4;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -563,109 +464,113 @@ impl SpecIso for Msg4VMapper {
     }
 }
 
-impl Iso for Msg4VMapper {
-    type Src<'a> = Msg4VInner<'a>;
+impl Iso for MsgCF4Mapper {
+    type Src<'a> = MsgCF4Inner<'a>;
 
-    type Dst<'a> = Msg4V<'a>;
+    type Dst<'a> = MsgCF4<'a>;
 
-    type SrcOwned = Msg4VOwnedInner;
+    type SrcOwned = MsgCF4OwnedInner;
 
-    type DstOwned = Msg4VOwned;
+    type DstOwned = MsgCF4Owned;
 }
 
-pub enum Msg4VOwned {
-    A(Msg1Owned),
-    B(Msg2Owned),
-    C(Msg3Owned),
+pub enum MsgCF4Owned {
+    C0(Content0Owned),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Vec<u8>),
 }
 
-pub type Msg4VOwnedInner = Either<Msg1Owned, Either<Msg2Owned, Msg3Owned>>;
+pub type MsgCF4OwnedInner = Either<Content0Owned, Either<u16, Either<u32, Vec<u8>>>>;
 
-impl View for Msg4VOwned {
-    type V = SpecMsg4V;
+impl View for MsgCF4Owned {
+    type V = SpecMsgCF4;
 
     open spec fn view(&self) -> Self::V {
         match self {
-            Msg4VOwned::A(m) => SpecMsg4V::A(m@),
-            Msg4VOwned::B(m) => SpecMsg4V::B(m@),
-            Msg4VOwned::C(m) => SpecMsg4V::C(m@),
+            MsgCF4Owned::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4Owned::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4Owned::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4Owned::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
         }
     }
 }
 
-impl From<Msg4VOwned> for Msg4VOwnedInner {
-    fn ex_from(m: Msg4VOwned) -> Msg4VOwnedInner {
+impl From<MsgCF4Owned> for MsgCF4OwnedInner {
+    fn ex_from(m: MsgCF4Owned) -> MsgCF4OwnedInner {
         match m {
-            Msg4VOwned::A(m) => Either::Left(m),
-            Msg4VOwned::B(m) => Either::Right(Either::Left(m)),
-            Msg4VOwned::C(m) => Either::Right(Either::Right(m)),
+            MsgCF4Owned::C0(m) => Either::Left(m),
+            MsgCF4Owned::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4Owned::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4Owned::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
         }
     }
 }
 
-impl From<Msg4VOwnedInner> for Msg4VOwned {
-    fn ex_from(m: Msg4VOwnedInner) -> Msg4VOwned {
+impl From<MsgCF4OwnedInner> for MsgCF4Owned {
+    fn ex_from(m: MsgCF4OwnedInner) -> MsgCF4Owned {
         match m {
-            Either::Left(m) => Msg4VOwned::A(m),
-            Either::Right(Either::Left(m)) => Msg4VOwned::B(m),
-            Either::Right(Either::Right(m)) => Msg4VOwned::C(m),
+            Either::Left(m) => MsgCF4Owned::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4Owned::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4Owned::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4Owned::Unrecognized(m),
         }
     }
 }
 
-pub struct SpecMsg4 {
-    pub t: SpecAType,
-    pub v: SpecMsg4V,
-    pub tail: Seq<u8>,
+pub struct SpecMsgC {
+    pub f2: SpecContentType,
+    pub f3: u24,
+    pub f4: SpecMsgCF4,
 }
 
-pub type SpecMsg4Inner = (SpecAType, (SpecMsg4V, Seq<u8>));
+pub type SpecMsgCInner = ((SpecContentType, u24), SpecMsgCF4);
 
-impl SpecFrom<SpecMsg4> for SpecMsg4Inner {
-    open spec fn spec_from(m: SpecMsg4) -> SpecMsg4Inner {
-        (m.t, (m.v, m.tail))
+impl SpecFrom<SpecMsgC> for SpecMsgCInner {
+    open spec fn spec_from(m: SpecMsgC) -> SpecMsgCInner {
+        ((m.f2, m.f3), m.f4)
     }
 }
 
-impl SpecFrom<SpecMsg4Inner> for SpecMsg4 {
-    open spec fn spec_from(m: SpecMsg4Inner) -> SpecMsg4 {
-        let (t, (v, tail)) = m;
-        SpecMsg4 { t, v, tail }
+impl SpecFrom<SpecMsgCInner> for SpecMsgC {
+    open spec fn spec_from(m: SpecMsgCInner) -> SpecMsgC {
+        let ((f2, f3), f4) = m;
+        SpecMsgC { f2, f3, f4 }
     }
 }
 
-pub struct Msg4<'a> {
-    pub t: AType,
-    pub v: Msg4V<'a>,
-    pub tail: &'a [u8],
+pub struct MsgC<'a> {
+    pub f2: ContentType,
+    pub f3: u24,
+    pub f4: MsgCF4<'a>,
 }
 
-pub type Msg4Inner<'a> = (AType, (Msg4V<'a>, &'a [u8]));
+pub type MsgCInner<'a> = ((ContentType, u24), MsgCF4<'a>);
 
-impl View for Msg4<'_> {
-    type V = SpecMsg4;
+impl View for MsgC<'_> {
+    type V = SpecMsgC;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg4 { t: self.t@, v: self.v@, tail: self.tail@ }
+        SpecMsgC { f2: self.f2@, f3: self.f3@, f4: self.f4@ }
     }
 }
 
-impl<'a> From<Msg4<'a>> for Msg4Inner<'a> {
-    fn ex_from(m: Msg4<'a>) -> Msg4Inner<'a> {
-        (m.t, (m.v, m.tail))
+impl<'a> From<MsgC<'a>> for MsgCInner<'a> {
+    fn ex_from(m: MsgC<'a>) -> MsgCInner<'a> {
+        ((m.f2, m.f3), m.f4)
     }
 }
 
-impl<'a> From<Msg4Inner<'a>> for Msg4<'a> {
-    fn ex_from(m: Msg4Inner<'a>) -> Msg4<'a> {
-        let (t, (v, tail)) = m;
-        Msg4 { t, v, tail }
+impl<'a> From<MsgCInner<'a>> for MsgC<'a> {
+    fn ex_from(m: MsgCInner<'a>) -> MsgC<'a> {
+        let ((f2, f3), f4) = m;
+        MsgC { f2, f3, f4 }
     }
 }
 
-pub struct Msg4Mapper;
+pub struct MsgCMapper;
 
-impl View for Msg4Mapper {
+impl View for MsgCMapper {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -673,10 +578,10 @@ impl View for Msg4Mapper {
     }
 }
 
-impl SpecIso for Msg4Mapper {
-    type Src = SpecMsg4Inner;
+impl SpecIso for MsgCMapper {
+    type Src = SpecMsgCInner;
 
-    type Dst = SpecMsg4;
+    type Dst = SpecMsgC;
 
     proof fn spec_iso(s: Self::Src) {
     }
@@ -685,414 +590,607 @@ impl SpecIso for Msg4Mapper {
     }
 }
 
-impl Iso for Msg4Mapper {
-    type Src<'a> = Msg4Inner<'a>;
+impl Iso for MsgCMapper {
+    type Src<'a> = MsgCInner<'a>;
 
-    type Dst<'a> = Msg4<'a>;
+    type Dst<'a> = MsgC<'a>;
 
-    type SrcOwned = Msg4OwnedInner;
+    type SrcOwned = MsgCOwnedInner;
 
-    type DstOwned = Msg4Owned;
+    type DstOwned = MsgCOwned;
 }
 
-pub struct Msg4Owned {
-    pub t: ATypeOwned,
-    pub v: Msg4VOwned,
-    pub tail: Vec<u8>,
+pub struct MsgCOwned {
+    pub f2: ContentTypeOwned,
+    pub f3: u24,
+    pub f4: MsgCF4Owned,
 }
 
-pub type Msg4OwnedInner = (ATypeOwned, (Msg4VOwned, Vec<u8>));
+pub type MsgCOwnedInner = ((ContentTypeOwned, u24), MsgCF4Owned);
 
-impl View for Msg4Owned {
-    type V = SpecMsg4;
+impl View for MsgCOwned {
+    type V = SpecMsgC;
 
     open spec fn view(&self) -> Self::V {
-        SpecMsg4 { t: self.t@, v: self.v@, tail: self.tail@ }
+        SpecMsgC { f2: self.f2@, f3: self.f3@, f4: self.f4@ }
     }
 }
 
-impl From<Msg4Owned> for Msg4OwnedInner {
-    fn ex_from(m: Msg4Owned) -> Msg4OwnedInner {
-        (m.t, (m.v, m.tail))
+impl From<MsgCOwned> for MsgCOwnedInner {
+    fn ex_from(m: MsgCOwned) -> MsgCOwnedInner {
+        ((m.f2, m.f3), m.f4)
     }
 }
 
-impl From<Msg4OwnedInner> for Msg4Owned {
-    fn ex_from(m: Msg4OwnedInner) -> Msg4Owned {
-        let (t, (v, tail)) = m;
-        Msg4Owned { t, v, tail }
+impl From<MsgCOwnedInner> for MsgCOwned {
+    fn ex_from(m: MsgCOwnedInner) -> MsgCOwned {
+        let ((f2, f3), f4) = m;
+        MsgCOwned { f2, f3, f4 }
     }
 }
 
-pub type SpecMsg3Combinator = BytesN<6>;
+pub struct SpecMsgA {
+    pub f1: SpecMsgB,
+    pub f2: Seq<u8>,
+}
 
-pub type Msg3Combinator = BytesN<6>;
+pub type SpecMsgAInner = (SpecMsgB, Seq<u8>);
 
-pub type SpecATypeCombinator = TryMap<U8, ATypeMapper>;
+impl SpecFrom<SpecMsgA> for SpecMsgAInner {
+    open spec fn spec_from(m: SpecMsgA) -> SpecMsgAInner {
+        (m.f1, m.f2)
+    }
+}
 
-pub type ATypeCombinator = TryMap<U8, ATypeMapper>;
+impl SpecFrom<SpecMsgAInner> for SpecMsgA {
+    open spec fn spec_from(m: SpecMsgAInner) -> SpecMsgA {
+        let (f1, f2) = m;
+        SpecMsgA { f1, f2 }
+    }
+}
 
-impl SpecPred for Predicate5821512137558126895 {
-    type Input = u8;
+pub struct MsgA<'a> {
+    pub f1: MsgB<'a>,
+    pub f2: &'a [u8],
+}
+
+pub type MsgAInner<'a> = (MsgB<'a>, &'a [u8]);
+
+impl View for MsgA<'_> {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl<'a> From<MsgA<'a>> for MsgAInner<'a> {
+    fn ex_from(m: MsgA<'a>) -> MsgAInner<'a> {
+        (m.f1, m.f2)
+    }
+}
+
+impl<'a> From<MsgAInner<'a>> for MsgA<'a> {
+    fn ex_from(m: MsgAInner<'a>) -> MsgA<'a> {
+        let (f1, f2) = m;
+        MsgA { f1, f2 }
+    }
+}
+
+pub struct MsgAMapper;
+
+impl View for MsgAMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecIso for MsgAMapper {
+    type Src = SpecMsgAInner;
+
+    type Dst = SpecMsgA;
+
+    proof fn spec_iso(s: Self::Src) {
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+    }
+}
+
+impl Iso for MsgAMapper {
+    type Src<'a> = MsgAInner<'a>;
+
+    type Dst<'a> = MsgA<'a>;
+
+    type SrcOwned = MsgAOwnedInner;
+
+    type DstOwned = MsgAOwned;
+}
+
+pub struct MsgAOwned {
+    pub f1: MsgBOwned,
+    pub f2: Vec<u8>,
+}
+
+pub type MsgAOwnedInner = (MsgBOwned, Vec<u8>);
+
+impl View for MsgAOwned {
+    type V = SpecMsgA;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgA { f1: self.f1@, f2: self.f2@ }
+    }
+}
+
+impl From<MsgAOwned> for MsgAOwnedInner {
+    fn ex_from(m: MsgAOwned) -> MsgAOwnedInner {
+        (m.f1, m.f2)
+    }
+}
+
+impl From<MsgAOwnedInner> for MsgAOwned {
+    fn ex_from(m: MsgAOwnedInner) -> MsgAOwned {
+        let (f1, f2) = m;
+        MsgAOwned { f1, f2 }
+    }
+}
+
+pub spec const SPEC_MSGD_F1: Seq<u8> = seq![1; 4];
+
+pub const MSGD_F2: u16 = 4660;
+
+pub type SpecMsgDCombinator = Mapped<
+    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16Be, TagPred<u16>>),
+    MsgDMapper,
+>;
+
+pub exec const MSGD_F1: [u8; 4]
+    ensures
+        MSGD_F1@ == SPEC_MSGD_F1,
+{
+    let arr: [u8; 4] = [1;4];
+    assert(arr@ == SPEC_MSGD_F1);
+    arr
+}
+
+pub struct BytesPredicate16235736133663645624;
+
+impl View for BytesPredicate16235736133663645624 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecPred for BytesPredicate16235736133663645624 {
+    type Input = Seq<u8>;
 
     open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = *i;
-        if (i >= 0 && i <= 10) || (i == 32) || (i >= 100) {
-            true
-        } else {
-            false
-        }
+        i == &SPEC_MSGD_F1
     }
 }
 
-pub type SpecMsg1Combinator = Mapped<
-    (Refined<U8, Predicate5821512137558126895>, (U16Le, BytesN<3>)),
-    Msg1Mapper,
->;
+impl Pred for BytesPredicate16235736133663645624 {
+    type Input<'a> = &'a [u8];
 
-pub struct Predicate5821512137558126895;
-
-impl View for Predicate5821512137558126895 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl Pred for Predicate5821512137558126895 {
-    type Input<'a> = u8;
-
-    type InputOwned = u8;
+    type InputOwned = Vec<u8>;
 
     fn apply(&self, i: &Self::Input<'_>) -> bool {
-        let i = *i;
-        if (i >= 0 && i <= 10) || (i == 32) || (i >= 100) {
-            true
-        } else {
-            false
-        }
+        compare_slice(i, MSGD_F1.as_slice())
     }
 }
 
-pub type Msg1Combinator = Mapped<
-    (Refined<U8, Predicate5821512137558126895>, (U16Le, BytesN<3>)),
-    Msg1Mapper,
+pub type MsgDCombinator = Mapped<
+    (Refined<BytesN<4>, BytesPredicate16235736133663645624>, Refined<U16Be, TagPred<u16>>),
+    MsgDMapper,
 >;
 
-pub type SpecMsg2Combinator = Mapped<(U8, (U16Le, U32Le)), Msg2Mapper>;
+pub type SpecMsgBCombinator = Mapped<SpecMsgDCombinator, MsgBMapper>;
 
-pub type Msg2Combinator = Mapped<(U8, (U16Le, U32Le)), Msg2Mapper>;
+pub type MsgBCombinator = Mapped<MsgDCombinator, MsgBMapper>;
 
-pub type SpecMsg4VCombinator = Mapped<
-    OrdChoice<
-        Cond<SpecMsg1Combinator>,
-        OrdChoice<Cond<SpecMsg2Combinator>, Cond<SpecMsg3Combinator>>,
+pub type SpecContent0Combinator = Bytes;
+
+pub type Content0Combinator = Bytes;
+
+pub type SpecContentTypeCombinator = U8;
+
+pub type ContentTypeCombinator = U8;
+
+pub type SpecMsgCF4Combinator = AndThen<
+    Bytes,
+    Mapped<
+        OrdChoice<
+            Cond<SpecContent0Combinator>,
+            OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>,
+        >,
+        MsgCF4Mapper,
     >,
-    Msg4VMapper,
 >;
 
-pub type Msg4VCombinator = Mapped<
-    OrdChoice<Cond<Msg1Combinator>, OrdChoice<Cond<Msg2Combinator>, Cond<Msg3Combinator>>>,
-    Msg4VMapper,
+pub type MsgCF4Combinator = AndThen<
+    Bytes,
+    Mapped<
+        OrdChoice<
+            Cond<Content0Combinator>,
+            OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>,
+        >,
+        MsgCF4Mapper,
+    >,
 >;
 
-pub type SpecMsg4Combinator = Mapped<
-    SpecDepend<SpecATypeCombinator, (SpecMsg4VCombinator, Tail)>,
-    Msg4Mapper,
+pub type SpecMsgCCombinator = Mapped<
+    SpecDepend<(SpecContentTypeCombinator, U24Be), SpecMsgCF4Combinator>,
+    MsgCMapper,
 >;
 
-pub struct Msg4Cont;
+pub struct MsgCCont;
 
-pub type Msg4Combinator = Mapped<
-    Depend<ATypeCombinator, (Msg4VCombinator, Tail), Msg4Cont>,
-    Msg4Mapper,
+pub type MsgCCombinator = Mapped<
+    Depend<(ContentTypeCombinator, U24Be), MsgCF4Combinator, MsgCCont>,
+    MsgCMapper,
 >;
 
-pub open spec fn spec_msg3() -> SpecMsg3Combinator {
-    BytesN::<6>
-}
+pub type SpecMsgACombinator = Mapped<(SpecMsgBCombinator, Tail), MsgAMapper>;
 
-pub fn msg3() -> (o: Msg3Combinator)
-    ensures
-        o@ == spec_msg3(),
-{
-    BytesN::<6>
-}
+pub type MsgACombinator = Mapped<(MsgBCombinator, Tail), MsgAMapper>;
 
-pub open spec fn spec_a_type() -> SpecATypeCombinator {
-    TryMap { inner: U8, mapper: ATypeMapper }
-}
-
-pub fn a_type() -> (o: ATypeCombinator)
-    ensures
-        o@ == spec_a_type(),
-{
-    TryMap { inner: U8, mapper: ATypeMapper }
-}
-
-pub open spec fn spec_msg1() -> SpecMsg1Combinator {
+pub open spec fn spec_msg_d() -> SpecMsgDCombinator {
     Mapped {
-        inner: (Refined { inner: U8, predicate: Predicate5821512137558126895 }, (U16Le, BytesN::<3>)),
-        mapper: Msg1Mapper,
-    }
-}
-
-pub fn msg1() -> (o: Msg1Combinator)
-    ensures
-        o@ == spec_msg1(),
-{
-    Mapped {
-        inner: (Refined { inner: U8, predicate: Predicate5821512137558126895 }, (U16Le, BytesN::<3>)),
-        mapper: Msg1Mapper,
-    }
-}
-
-pub open spec fn spec_msg2() -> SpecMsg2Combinator {
-    Mapped { inner: (U8, (U16Le, U32Le)), mapper: Msg2Mapper }
-}
-
-pub fn msg2() -> (o: Msg2Combinator)
-    ensures
-        o@ == spec_msg2(),
-{
-    Mapped { inner: (U8, (U16Le, U32Le)), mapper: Msg2Mapper }
-}
-
-pub open spec fn spec_msg4_v(t: SpecAType) -> SpecMsg4VCombinator {
-    Mapped {
-        inner: OrdChoice(
-            Cond { cond: t == AType::A, inner: spec_msg1() },
-            OrdChoice(
-                Cond { cond: t == AType::B, inner: spec_msg2() },
-                Cond { cond: t == AType::C, inner: spec_msg3() },
-            ),
+        inner: (
+            Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
+            Refined { inner: U16Be, predicate: TagPred(MSGD_F2) },
         ),
-        mapper: Msg4VMapper,
+        mapper: MsgDMapper,
     }
 }
 
-pub fn msg4_v<'a>(t: AType) -> (o: Msg4VCombinator)
+pub fn msg_d() -> (o: MsgDCombinator)
     ensures
-        o@ == spec_msg4_v(t@),
+        o@ == spec_msg_d(),
 {
     Mapped {
-        inner: OrdChoice(
-            Cond { cond: t == AType::A, inner: msg1() },
-            OrdChoice(
-                Cond { cond: t == AType::B, inner: msg2() },
-                Cond { cond: t == AType::C, inner: msg3() },
-            ),
+        inner: (
+            Refined { inner: BytesN::<4>, predicate: BytesPredicate16235736133663645624 },
+            Refined { inner: U16Be, predicate: TagPred(MSGD_F2) },
         ),
-        mapper: Msg4VMapper,
+        mapper: MsgDMapper,
     }
 }
 
-pub open spec fn spec_msg4() -> SpecMsg4Combinator {
-    let fst = spec_a_type();
-    let snd = |deps| spec_msg4_cont(deps);
-    Mapped { inner: SpecDepend { fst, snd }, mapper: Msg4Mapper }
+pub open spec fn spec_msg_b() -> SpecMsgBCombinator {
+    Mapped { inner: spec_msg_d(), mapper: MsgBMapper }
 }
 
-pub open spec fn spec_msg4_cont(deps: SpecAType) -> (SpecMsg4VCombinator, Tail) {
-    let t = deps;
-    (spec_msg4_v(t), Tail)
-}
-
-pub fn msg4() -> (o: Msg4Combinator)
+pub fn msg_b() -> (o: MsgBCombinator)
     ensures
-        o@ == spec_msg4(),
+        o@ == spec_msg_b(),
 {
-    let fst = a_type();
-    let snd = Msg4Cont;
-    let spec_snd = Ghost(|deps| spec_msg4_cont(deps));
-    Mapped { inner: Depend { fst, snd, spec_snd }, mapper: Msg4Mapper }
+    Mapped { inner: msg_d(), mapper: MsgBMapper }
 }
 
-impl Continuation<AType> for Msg4Cont {
-    type Output = (Msg4VCombinator, Tail);
+pub open spec fn spec_content_0(num: u24) -> SpecContent0Combinator {
+    Bytes(num.spec_into())
+}
 
-    open spec fn requires(&self, deps: AType) -> bool {
+pub fn content_0<'a>(num: u24) -> (o: Content0Combinator)
+    ensures
+        o@ == spec_content_0(num@),
+{
+    Bytes(num.ex_into())
+}
+
+pub open spec fn spec_content_type() -> SpecContentTypeCombinator {
+    U8
+}
+
+pub fn content_type() -> (o: ContentTypeCombinator)
+    ensures
+        o@ == spec_content_type(),
+{
+    U8
+}
+
+pub open spec fn spec_msg_c_f4(f2: SpecContentType, f3: u24) -> SpecMsgCF4Combinator {
+    AndThen(
+        Bytes(f3.spec_into()),
+        Mapped {
+            inner: OrdChoice(
+                Cond { cond: f2 == 0, inner: spec_content_0(f3) },
+                OrdChoice(
+                    Cond { cond: f2 == 1, inner: U16Be },
+                    OrdChoice(
+                        Cond { cond: f2 == 2, inner: U32Be },
+                        Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+                    ),
+                ),
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub fn msg_c_f4<'a>(f2: ContentType, f3: u24) -> (o: MsgCF4Combinator)
+    ensures
+        o@ == spec_msg_c_f4(f2@, f3@),
+{
+    AndThen(
+        Bytes(f3.ex_into()),
+        Mapped {
+            inner: OrdChoice(
+                Cond { cond: f2 == 0, inner: content_0(f3) },
+                OrdChoice(
+                    Cond { cond: f2 == 1, inner: U16Be },
+                    OrdChoice(
+                        Cond { cond: f2 == 2, inner: U32Be },
+                        Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail },
+                    ),
+                ),
+            ),
+            mapper: MsgCF4Mapper,
+        },
+    )
+}
+
+pub open spec fn spec_msg_c() -> SpecMsgCCombinator {
+    let fst = (spec_content_type(), U24Be);
+    let snd = |deps| spec_msg_c_cont(deps);
+    Mapped { inner: SpecDepend { fst, snd }, mapper: MsgCMapper }
+}
+
+pub open spec fn spec_msg_c_cont(deps: (SpecContentType, u24)) -> SpecMsgCF4Combinator {
+    let (f2, f3) = deps;
+    spec_msg_c_f4(f2, f3)
+}
+
+pub fn msg_c() -> (o: MsgCCombinator)
+    ensures
+        o@ == spec_msg_c(),
+{
+    let fst = (content_type(), U24Be);
+    let snd = MsgCCont;
+    let spec_snd = Ghost(|deps| spec_msg_c_cont(deps));
+    Mapped { inner: Depend { fst, snd, spec_snd }, mapper: MsgCMapper }
+}
+
+impl Continuation<(ContentType, u24)> for MsgCCont {
+    type Output = MsgCF4Combinator;
+
+    open spec fn requires(&self, deps: (ContentType, u24)) -> bool {
         true
     }
 
-    open spec fn ensures(&self, deps: AType, o: Self::Output) -> bool {
-        o@ == spec_msg4_cont(deps@)
+    open spec fn ensures(&self, deps: (ContentType, u24), o: Self::Output) -> bool {
+        o@ == spec_msg_c_cont(deps@)
     }
 
-    fn apply(&self, deps: AType) -> Self::Output {
-        let t = deps;
-        (msg4_v(t), Tail)
+    fn apply(&self, deps: (ContentType, u24)) -> Self::Output {
+        let (f2, f3) = deps;
+        msg_c_f4(f2, f3)
     }
 }
 
-pub open spec fn parse_spec_msg3(i: Seq<u8>) -> Result<(usize, SpecMsg3), ()> {
-    spec_msg3().spec_parse(i)
+pub open spec fn spec_msg_a() -> SpecMsgACombinator {
+    Mapped { inner: (spec_msg_b(), Tail), mapper: MsgAMapper }
 }
 
-pub open spec fn serialize_spec_msg3(msg: SpecMsg3) -> Result<Seq<u8>, ()> {
-    spec_msg3().spec_serialize(msg)
-}
-
-pub fn parse_msg3(i: &[u8]) -> (o: Result<(usize, Msg3<'_>), ParseError>)
+pub fn msg_a() -> (o: MsgACombinator)
     ensures
-        o matches Ok(r) ==> parse_spec_msg3(i@) matches Ok(r_) && r@ == r_,
+        o@ == spec_msg_a(),
 {
-    msg3().parse(i)
+    Mapped { inner: (msg_b(), Tail), mapper: MsgAMapper }
 }
 
-pub fn serialize_msg3(msg: Msg3<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+pub open spec fn parse_spec_msg_d(i: Seq<u8>) -> Result<(usize, SpecMsgD), ()> {
+    spec_msg_d().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_d(msg: SpecMsgD) -> Result<Seq<u8>, ()> {
+    spec_msg_d().spec_serialize(msg)
+}
+
+pub fn parse_msg_d(i: &[u8]) -> (o: Result<(usize, MsgD<'_>), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_d(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_d().parse(i)
+}
+
+pub fn serialize_msg_d(msg: MsgD<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
     SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg3(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_d(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg3().serialize(msg, data, pos)
+    msg_d().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_a_type(i: Seq<u8>) -> Result<(usize, SpecAType), ()> {
-    spec_a_type().spec_parse(i)
+pub open spec fn parse_spec_msg_b(i: Seq<u8>) -> Result<(usize, SpecMsgB), ()> {
+    spec_msg_b().spec_parse(i)
 }
 
-pub open spec fn serialize_spec_a_type(msg: SpecAType) -> Result<Seq<u8>, ()> {
-    spec_a_type().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_b(msg: SpecMsgB) -> Result<Seq<u8>, ()> {
+    spec_msg_b().spec_serialize(msg)
 }
 
-pub fn parse_a_type(i: &[u8]) -> (o: Result<(usize, AType), ParseError>)
+pub fn parse_msg_b(i: &[u8]) -> (o: Result<(usize, MsgB<'_>), ParseError>)
     ensures
-        o matches Ok(r) ==> parse_spec_a_type(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_b(i@) matches Ok(r_) && r@ == r_,
 {
-    a_type().parse(i)
+    msg_b().parse(i)
 }
 
-pub fn serialize_a_type(msg: AType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+pub fn serialize_msg_b(msg: MsgB<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
     SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_a_type(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_b(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    a_type().serialize(msg, data, pos)
+    msg_b().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg1(i: Seq<u8>) -> Result<(usize, SpecMsg1), ()> {
-    spec_msg1().spec_parse(i)
+pub open spec fn parse_spec_content_0(i: Seq<u8>, num: u24) -> Result<(usize, SpecContent0), ()> {
+    spec_content_0(num).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg1(msg: SpecMsg1) -> Result<Seq<u8>, ()> {
-    spec_msg1().spec_serialize(msg)
+pub open spec fn serialize_spec_content_0(msg: SpecContent0, num: u24) -> Result<Seq<u8>, ()> {
+    spec_content_0(num).spec_serialize(msg)
 }
 
-pub fn parse_msg1(i: &[u8]) -> (o: Result<(usize, Msg1<'_>), ParseError>)
+pub fn parse_content_0(i: &[u8], num: u24) -> (o: Result<(usize, Content0<'_>), ParseError>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg1(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_content_0(i@, num@) matches Ok(r_) && r@ == r_,
 {
-    msg1().parse(i)
+    content_0(num).parse(i)
 }
 
-pub fn serialize_msg1(msg: Msg1<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+pub fn serialize_content_0(msg: Content0<'_>, data: &mut Vec<u8>, pos: usize, num: u24) -> (o:
+    Result<usize, SerializeError>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_content_0(msg@, num@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    content_0(num).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_content_type(i: Seq<u8>) -> Result<(usize, SpecContentType), ()> {
+    spec_content_type().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_content_type(msg: SpecContentType) -> Result<Seq<u8>, ()> {
+    spec_content_type().spec_serialize(msg)
+}
+
+pub fn parse_content_type(i: &[u8]) -> (o: Result<(usize, ContentType), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_content_type(i@) matches Ok(r_) && r@ == r_,
+{
+    content_type().parse(i)
+}
+
+pub fn serialize_content_type(msg: ContentType, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
     SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg1(msg@) matches Ok(buf)
+            &&& serialize_spec_content_type(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg1().serialize(msg, data, pos)
+    content_type().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg2(i: Seq<u8>) -> Result<(usize, SpecMsg2), ()> {
-    spec_msg2().spec_parse(i)
+pub open spec fn parse_spec_msg_c_f4(i: Seq<u8>, f2: SpecContentType, f3: u24) -> Result<
+    (usize, SpecMsgCF4),
+    (),
+> {
+    spec_msg_c_f4(f2, f3).spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg2(msg: SpecMsg2) -> Result<Seq<u8>, ()> {
-    spec_msg2().spec_serialize(msg)
+pub open spec fn serialize_spec_msg_c_f4(msg: SpecMsgCF4, f2: SpecContentType, f3: u24) -> Result<
+    Seq<u8>,
+    (),
+> {
+    spec_msg_c_f4(f2, f3).spec_serialize(msg)
 }
 
-pub fn parse_msg2(i: &[u8]) -> (o: Result<(usize, Msg2), ParseError>)
+pub fn parse_msg_c_f4(i: &[u8], f2: ContentType, f3: u24) -> (o: Result<
+    (usize, MsgCF4<'_>),
+    ParseError,
+>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg2(i@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_c_f4(i@, f2@, f3@) matches Ok(r_) && r@ == r_,
 {
-    msg2().parse(i)
+    msg_c_f4(f2, f3).parse(i)
 }
 
-pub fn serialize_msg2(msg: Msg2, data: &mut Vec<u8>, pos: usize) -> (o: Result<
+pub fn serialize_msg_c_f4(
+    msg: MsgCF4<'_>,
+    data: &mut Vec<u8>,
+    pos: usize,
+    f2: ContentType,
+    f3: u24,
+) -> (o: Result<usize, SerializeError>)
+    ensures
+        o matches Ok(n) ==> {
+            &&& serialize_spec_msg_c_f4(msg@, f2@, f3@) matches Ok(buf)
+            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
+        },
+{
+    msg_c_f4(f2, f3).serialize(msg, data, pos)
+}
+
+pub open spec fn parse_spec_msg_c(i: Seq<u8>) -> Result<(usize, SpecMsgC), ()> {
+    spec_msg_c().spec_parse(i)
+}
+
+pub open spec fn serialize_spec_msg_c(msg: SpecMsgC) -> Result<Seq<u8>, ()> {
+    spec_msg_c().spec_serialize(msg)
+}
+
+pub fn parse_msg_c(i: &[u8]) -> (o: Result<(usize, MsgC<'_>), ParseError>)
+    ensures
+        o matches Ok(r) ==> parse_spec_msg_c(i@) matches Ok(r_) && r@ == r_,
+{
+    msg_c().parse(i)
+}
+
+pub fn serialize_msg_c(msg: MsgC<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
     SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg2(msg@) matches Ok(buf)
+            &&& serialize_spec_msg_c(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg2().serialize(msg, data, pos)
+    msg_c().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg4_v(i: Seq<u8>, t: SpecAType) -> Result<(usize, SpecMsg4V), ()> {
-    spec_msg4_v(t).spec_parse(i)
+pub open spec fn parse_spec_msg_a(i: Seq<u8>) -> Result<(usize, SpecMsgA), ()> {
+    spec_msg_a().spec_parse(i)
 }
 
-pub open spec fn serialize_spec_msg4_v(msg: SpecMsg4V, t: SpecAType) -> Result<Seq<u8>, ()> {
-    spec_msg4_v(t).spec_serialize(msg)
+pub open spec fn serialize_spec_msg_a(msg: SpecMsgA) -> Result<Seq<u8>, ()> {
+    spec_msg_a().spec_serialize(msg)
 }
 
-pub fn parse_msg4_v(i: &[u8], t: AType) -> (o: Result<(usize, Msg4V<'_>), ParseError>)
+pub fn parse_msg_a(i: &[u8]) -> (o: Result<(usize, MsgA<'_>), ParseError>)
     ensures
-        o matches Ok(r) ==> parse_spec_msg4_v(i@, t@) matches Ok(r_) && r@ == r_,
+        o matches Ok(r) ==> parse_spec_msg_a(i@) matches Ok(r_) && r@ == r_,
 {
-    msg4_v(t).parse(i)
+    msg_a().parse(i)
 }
 
-pub fn serialize_msg4_v(msg: Msg4V<'_>, data: &mut Vec<u8>, pos: usize, t: AType) -> (o: Result<
+pub fn serialize_msg_a(msg: MsgA<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
     usize,
     SerializeError,
 >)
     ensures
         o matches Ok(n) ==> {
-            &&& serialize_spec_msg4_v(msg@, t@) matches Ok(buf)
+            &&& serialize_spec_msg_a(msg@) matches Ok(buf)
             &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
         },
 {
-    msg4_v(t).serialize(msg, data, pos)
+    msg_a().serialize(msg, data, pos)
 }
 
-pub open spec fn parse_spec_msg4(i: Seq<u8>) -> Result<(usize, SpecMsg4), ()> {
-    spec_msg4().spec_parse(i)
-}
 
-pub open spec fn serialize_spec_msg4(msg: SpecMsg4) -> Result<Seq<u8>, ()> {
-    spec_msg4().spec_serialize(msg)
-}
-
-pub fn parse_msg4(i: &[u8]) -> (o: Result<(usize, Msg4<'_>), ParseError>)
-    ensures
-        o matches Ok(r) ==> parse_spec_msg4(i@) matches Ok(r_) && r@ == r_,
-{
-    msg4().parse(i)
-}
-
-pub fn serialize_msg4(msg: Msg4<'_>, data: &mut Vec<u8>, pos: usize) -> (o: Result<
-    usize,
-    SerializeError,
->)
-    ensures
-        o matches Ok(n) ==> {
-            &&& serialize_spec_msg4(msg@) matches Ok(buf)
-            &&& n == buf.len() && data@ == seq_splice(old(data)@, pos, buf)
-        },
-{
-    msg4().serialize(msg, data, pos)
-}
 
 } // verus!
 }

--- a/vest/src/regular/depend.rs
+++ b/vest/src/regular/depend.rs
@@ -137,10 +137,14 @@ pub trait Continuation<Input> {
 
     /// The actual continuation function
     fn apply(&self, i: Input) -> (o: Self::Output)
-        requires self.requires(i)
-        ensures self.ensures(i, o);
+        requires
+            self.requires(i),
+        ensures
+            self.ensures(i, o),
+    ;
 
     spec fn requires(&self, i: Input) -> bool;
+
     spec fn ensures(&self, i: Input, o: Self::Output) -> bool;
 }
 
@@ -219,7 +223,7 @@ impl<Fst, Snd, C> Combinator for Depend<Fst, Snd, C> where
         &&& self.wf()
         &&& self.fst.parse_requires()
         &&& Fst::V::is_prefix_secure()
-        &&& forall |i, snd| self.snd.ensures(i, snd) ==> snd.parse_requires()
+        &&& forall|i, snd| self.snd.ensures(i, snd) ==> snd.parse_requires()
     }
 
     fn parse<'a>(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Result<'a>), ParseError>) {
@@ -238,7 +242,7 @@ impl<Fst, Snd, C> Combinator for Depend<Fst, Snd, C> where
         &&& self.wf()
         &&& self.fst.serialize_requires()
         &&& Fst::V::is_prefix_secure()
-        &&& forall |i, snd| self.snd.ensures(i, snd) ==> snd.serialize_requires()
+        &&& forall|i, snd| self.snd.ensures(i, snd) ==> snd.serialize_requires()
     }
 
     fn serialize(&self, v: Self::Result<'_>, data: &mut Vec<u8>, pos: usize) -> (res: Result<
@@ -264,4 +268,4 @@ impl<Fst, Snd, C> Combinator for Depend<Fst, Snd, C> where
     }
 }
 
-}
+} // verus!

--- a/vest/src/regular/disjoint.rs
+++ b/vest/src/regular/disjoint.rs
@@ -2,13 +2,13 @@ use super::bytes::Bytes;
 use super::bytes_n::BytesN;
 use super::choice::OrdChoice;
 use super::cond::Cond;
+use super::depend::SpecDepend;
 use super::fail::Fail;
 use super::map::{Mapped, SpecIso};
 use super::preceded::Preceded;
 use super::refined::Refined;
-use super::depend::SpecDepend;
 use super::tag::{Tag, TagPred};
-use super::uints::{U16, U32, U64, U8};
+use super::uints::*;
 use crate::properties::*;
 use vstd::prelude::*;
 
@@ -67,19 +67,39 @@ macro_rules! impl_disjoint_for_refined_int {
 
 impl_disjoint_for_int_tag!(Tag<U8, u8>);
 
-impl_disjoint_for_int_tag!(Tag<U16, u16>);
+impl_disjoint_for_int_tag!(Tag<U16Le, u16>);
 
-impl_disjoint_for_int_tag!(Tag<U32, u32>);
+impl_disjoint_for_int_tag!(Tag<U24Le, u24>);
 
-impl_disjoint_for_int_tag!(Tag<U64, u64>);
+impl_disjoint_for_int_tag!(Tag<U32Le, u32>);
+
+impl_disjoint_for_int_tag!(Tag<U64Le, u64>);
+
+impl_disjoint_for_int_tag!(Tag<U16Be, u16>);
+
+impl_disjoint_for_int_tag!(Tag<U24Be, u24>);
+
+impl_disjoint_for_int_tag!(Tag<U32Be, u32>);
+
+impl_disjoint_for_int_tag!(Tag<U64Be, u64>);
 
 impl_disjoint_for_refined_int!(Refined<U8, TagPred<u8>>);
 
-impl_disjoint_for_refined_int!(Refined<U16, TagPred<u16>>);
+impl_disjoint_for_refined_int!(Refined<U16Le, TagPred<u16>>);
 
-impl_disjoint_for_refined_int!(Refined<U32, TagPred<u32>>);
+impl_disjoint_for_refined_int!(Refined<U24Le, TagPred<u24>>);
 
-impl_disjoint_for_refined_int!(Refined<U64, TagPred<u64>>);
+impl_disjoint_for_refined_int!(Refined<U32Le, TagPred<u32>>);
+
+impl_disjoint_for_refined_int!(Refined<U64Le, TagPred<u64>>);
+
+impl_disjoint_for_refined_int!(Refined<U16Be, TagPred<u16>>);
+
+impl_disjoint_for_refined_int!(Refined<U24Be, TagPred<u24>>);
+
+impl_disjoint_for_refined_int!(Refined<U32Be, TagPred<u32>>);
+
+impl_disjoint_for_refined_int!(Refined<U64Be, TagPred<u64>>);
 
 // two `Tag(T, value)`s are disjoint if their bytes `value`s are different
 impl<const N: usize> DisjointFrom<Tag<BytesN<N>, Seq<u8>>> for Tag<BytesN<N>, Seq<u8>> {
@@ -102,7 +122,10 @@ impl DisjointFrom<Tag<Bytes, Seq<u8>>> for Tag<Bytes, Seq<u8>> {
     }
 }
 
-impl<const N: usize> DisjointFrom<Refined<BytesN<N>, TagPred<Seq<u8>>>> for Refined<BytesN<N>, TagPred<Seq<u8>>> {
+impl<const N: usize> DisjointFrom<Refined<BytesN<N>, TagPred<Seq<u8>>>> for Refined<
+    BytesN<N>,
+    TagPred<Seq<u8>>,
+> {
     open spec fn disjoint_from(&self, other: &Refined<BytesN<N>, TagPred<Seq<u8>>>) -> bool {
         self.predicate.0 != other.predicate.0
     }

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -30,8 +30,6 @@ pub broadcast proof fn size_of_facts()
 }
 
 /// Combinator for parsing and serializing unsigned u8 integers.
-///
-/// > **Note**: Currently, little-endian byte order is used for serialization and parsing.
 pub struct U8;
 
 impl View for U8 {
@@ -42,12 +40,10 @@ impl View for U8 {
     }
 }
 
-/// Combinator for parsing and serializing unsigned u16 integers.
-///
-/// > **Note**: Currently, little-endian byte order is used for serialization and parsing.
-pub struct U16;
+/// Combinator for parsing and serializing unsigned u16 integers in little-endian byte order.
+pub struct U16Le;
 
-impl View for U16 {
+impl View for U16Le {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -55,12 +51,10 @@ impl View for U16 {
     }
 }
 
-/// Combinator for parsing and serializing unsigned u32 integers.
-///
-/// > **Note**: Currently, little-endian byte order is used for serialization and parsing.
-pub struct U32;
+/// Combinator for parsing and serializing unsigned u32 integers in little-endian byte order.
+pub struct U32Le;
 
-impl View for U32 {
+impl View for U32Le {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -68,12 +62,10 @@ impl View for U32 {
     }
 }
 
-/// Combinator for parsing and serializing unsigned u64 integers.
-///
-/// > **Note**: Currently, little-endian byte order is used for serialization and parsing.
-pub struct U64;
+/// Combinator for parsing and serializing unsigned u64 integers in little-endian byte order.
+pub struct U64Le;
 
-impl View for U64 {
+impl View for U64Le {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
@@ -81,7 +73,40 @@ impl View for U64 {
     }
 }
 
-macro_rules! impl_combinator_for_int_type {
+/// Combinator for parsing and serializing unsigned u16 integers in big-endian byte order.
+pub struct U16Be;
+
+impl View for U16Be {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+/// Combinator for parsing and serializing unsigned u32 integers in big-endian byte order.
+pub struct U32Be;
+
+impl View for U32Be {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+/// Combinator for parsing and serializing unsigned u64 integers in big-endian byte order.
+pub struct U64Be;
+
+impl View for U64Be {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+macro_rules! impl_combinator_for_le_uint_type {
     ($combinator:ty, $int_type:ty) => {
         ::builtin_macros::verus! {
             impl SpecCombinator for $combinator {
@@ -181,13 +206,119 @@ macro_rules! impl_combinator_for_int_type {
     };
 }
 
-impl_combinator_for_int_type!(U8, u8);
+macro_rules! impl_combinator_for_be_uint_type {
+    ($combinator:ty, $int_type:ty) => {
+        ::builtin_macros::verus! {
+            impl SpecCombinator for $combinator {
+                type SpecResult = $int_type;
 
-impl_combinator_for_int_type!(U16, u16);
+                open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, $int_type), ()> {
+                    if s.len() >= size_of::<$int_type>() {
+                        Ok((size_of::<$int_type>() as usize, <$int_type>::spec_from_be_bytes(s)))
+                    } else {
+                        Err(())
+                    }
+                }
 
-impl_combinator_for_int_type!(U32, u32);
+                proof fn spec_parse_wf(&self, s: Seq<u8>) {
+                }
 
-impl_combinator_for_int_type!(U64, u64);
+                open spec fn spec_serialize(&self, v: $int_type) -> Result<Seq<u8>, ()> {
+                    Ok(<$int_type>::spec_to_be_bytes(&v))
+                }
+            }
+
+            impl SecureSpecCombinator for $combinator {
+                open spec fn is_prefix_secure() -> bool {
+                    true
+                }
+
+                proof fn theorem_serialize_parse_roundtrip(&self, v: $int_type) {
+                    $int_type::lemma_spec_to_from_be_bytes(&v);
+                }
+
+                proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>) {
+                    let n = size_of::<$int_type>();
+                    if buf.len() >= n {
+                        let fst = buf.subrange(0, n as int);
+                        let snd = buf.subrange(n as int, buf.len() as int);
+                        $int_type::lemma_spec_from_to_be_bytes(fst);
+                        self.lemma_prefix_secure(fst, snd);
+                        assert(fst.add(snd) == buf);
+                    }
+                }
+
+                proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>) {
+                    $int_type::lemma_spec_from_be_bytes_no_lookahead(s1, s2);
+                }
+            }
+
+            impl Combinator for $combinator {
+                type Result<'a> = $int_type;
+
+                type Owned = $int_type;
+
+                open spec fn spec_length(&self) -> Option<usize> {
+                    Some(size_of::<$int_type>())
+                }
+
+                fn length(&self) -> Option<usize> {
+                    Some(size_of::<$int_type>())
+                }
+
+                fn parse(&self, s: &[u8]) -> (res: Result<(usize, $int_type), ParseError>) {
+                    if s.len() >= size_of::<$int_type>() {
+                        let s_ = slice_subrange(s, 0, size_of::<$int_type>());
+                        let v = $int_type::ex_from_be_bytes(s_);
+                        proof {
+                            let s_ = s_@;
+                            let s__ = s@.subrange(size_of::<$int_type>() as int, s@.len() as int);
+                            $int_type::lemma_spec_from_be_bytes_no_lookahead(s_, s__);
+                            assert(s_.add(s__) == s@);
+                            assert($int_type::spec_from_be_bytes(s@) == v);
+                            v.reflex();
+                        }
+                        Ok((size_of::<$int_type>(), v))
+                    } else {
+                        Err(ParseError::UnexpectedEndOfInput)
+                    }
+                }
+
+                fn serialize(&self, v: $int_type, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
+                    if pos <= data.len() {
+                        if size_of::<$int_type>() <= data.len() - pos {
+                            $int_type::ex_to_be_bytes(&v, data, pos);
+                            proof {
+                                v.reflex();
+                                assert(data@.subrange(pos as int, pos + size_of::<$int_type>() as int)
+                                    == self.spec_serialize(v@).unwrap());
+                            }
+                            Ok(size_of::<$int_type>())
+                        } else {
+                            Err(SerializeError::InsufficientBuffer)
+                        }
+                    } else {
+                        Err(SerializeError::InsufficientBuffer)
+                    }
+                }
+            }
+        } // verus!
+    };
+}
+
+impl_combinator_for_le_uint_type!(U8, u8);
+
+impl_combinator_for_le_uint_type!(U16Le, u16);
+
+impl_combinator_for_le_uint_type!(U32Le, u32);
+
+impl_combinator_for_le_uint_type!(U64Le, u64);
+
+impl_combinator_for_be_uint_type!(U16Be, u16);
+
+impl_combinator_for_be_uint_type!(U32Be, u32);
+
+impl_combinator_for_be_uint_type!(U64Be, u64);
 
 // helpers
 /// A trait for converting an integer type to and from a sequence of bytes.
@@ -198,9 +329,14 @@ pub trait FromToBytes where Self: ViewReflex + std::marker::Sized + Copy {
     /// Spec version of [`Self::ex_to_le_bytes`]
     spec fn spec_to_le_bytes(&self) -> Seq<u8>;
 
-    // spec fn spec_from_be_bytes(s: Seq<u8>) -> Self;
-    // spec fn spec_to_be_bytes(&self) -> Seq<u8>;
-    /// Lemma that asserts that converting an integer to bytes and back results in the original
+    /// Spec version of [`Self::ex_from_be_bytes`]
+    spec fn spec_from_be_bytes(s: Seq<u8>) -> Self;
+
+    /// Spec version of [`Self::ex_to_be_bytes`]
+    spec fn spec_to_be_bytes(&self) -> Seq<u8>;
+
+    /// Lemma that asserts that converting an integer in little-endian byte order to bytes and back
+    /// results in the original integer
     proof fn lemma_spec_to_from_le_bytes(&self)
     // requires
     //     is_sized::<Self>(),
@@ -210,8 +346,8 @@ pub trait FromToBytes where Self: ViewReflex + std::marker::Sized + Copy {
             Self::spec_from_le_bytes(self.spec_to_le_bytes()) == *self,
     ;
 
-    /// Lemma that asserts that converting a sequence of bytes to an integer and back results in
-    /// the original sequence
+    /// Lemma that asserts that converting a sequence of bytes to an integer in little-endian byte
+    /// order and back results in the original sequence
     proof fn lemma_spec_from_to_le_bytes(s: Seq<u8>)
     // requires
     //     is_sized::<Self>(),
@@ -228,6 +364,31 @@ pub trait FromToBytes where Self: ViewReflex + std::marker::Sized + Copy {
         ensures
             s1.len() >= size_of::<Self>() ==> Self::spec_from_le_bytes(s1)
                 == Self::spec_from_le_bytes(s1.add(s2)),
+    ;
+
+    /// Lemma that asserts that converting an integer in big-endian byte order to bytes and back
+    /// results in the original integer
+    proof fn lemma_spec_to_from_be_bytes(&self)
+        ensures
+            self.spec_to_be_bytes().len() == size_of::<Self>(),
+            Self::spec_from_be_bytes(self.spec_to_be_bytes()) == *self,
+    ;
+
+    /// Lemma that asserts that converting a sequence of bytes to an integer in big-endian byte
+    /// order and back results in the original sequence
+    proof fn lemma_spec_from_to_be_bytes(s: Seq<u8>)
+        ensures
+            s.len() == size_of::<Self>() ==> Self::spec_to_be_bytes(&Self::spec_from_be_bytes(s))
+                == s,
+    ;
+
+    /// Helper lemma for proving [`SecureSpecCombinator::lemma_prefix_secure`]
+    proof fn lemma_spec_from_be_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>)
+        requires
+            s1.len() + s2.len() <= usize::MAX,
+        ensures
+            s1.len() >= size_of::<Self>() ==> Self::spec_from_be_bytes(s1)
+                == Self::spec_from_be_bytes(s1.add(s2)),
     ;
 
     /// Converts a sequence of bytes to an integer in little-endian byte order.
@@ -248,6 +409,24 @@ pub trait FromToBytes where Self: ViewReflex + std::marker::Sized + Copy {
             s@ == seq_splice(old(s)@, pos, self.spec_to_le_bytes()),
     ;
 
+    /// Converts a sequence of bytes to an integer in big-endian byte order.
+    fn ex_from_be_bytes(s: &[u8]) -> (x: Self)
+        requires
+            s@.len() == size_of::<Self>(),
+        ensures
+            x == Self::spec_from_be_bytes(s@),
+    ;
+
+    /// Converts an integer to a sequence of bytes in big-endian byte order.
+    fn ex_to_be_bytes(&self, s: &mut Vec<u8>, pos: usize)
+        requires
+            old(s)@.len() - pos >= size_of::<Self>(),
+        ensures
+            old(s)@.len() == s@.len(),
+            self.spec_to_be_bytes().len() == size_of::<Self>(),
+            s@ == seq_splice(old(s)@, pos, self.spec_to_be_bytes()),
+    ;
+
     /// Compares two integers for equality.
     fn eq(&self, other: &Self) -> (res: bool)
         ensures
@@ -264,8 +443,14 @@ impl FromToBytes for u8 {
         seq![*self]
     }
 
-    // open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self { s[0] }
-    // open spec fn spec_to_be_bytes(&self) -> Seq<u8> { seq![*self] }
+    open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {
+        s[0]
+    }
+
+    open spec fn spec_to_be_bytes(&self) -> Seq<u8> {
+        seq![*self]
+    }
+
     proof fn lemma_spec_to_from_le_bytes(&self) {
     }
 
@@ -278,6 +463,18 @@ impl FromToBytes for u8 {
     proof fn lemma_spec_from_le_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
     }
 
+    proof fn lemma_spec_to_from_be_bytes(&self) {
+    }
+
+    proof fn lemma_spec_from_to_be_bytes(s: Seq<u8>) {
+        if s.len() == size_of::<u8>() {
+            assert(Self::spec_to_be_bytes(&Self::spec_from_be_bytes(s)) == s);
+        }
+    }
+
+    proof fn lemma_spec_from_be_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
+    }
+
     fn ex_from_le_bytes(s: &[u8]) -> (x: u8) {
         *slice_index_get(s, 0)
     }
@@ -287,6 +484,18 @@ impl FromToBytes for u8 {
         s.set(pos, *self);
         proof {
             assert(s@ == seq_splice(old, pos, self.spec_to_le_bytes()));
+        }
+    }
+
+    fn ex_from_be_bytes(s: &[u8]) -> (x: u8) {
+        *slice_index_get(s, 0)
+    }
+
+    fn ex_to_be_bytes(&self, s: &mut Vec<u8>, pos: usize) {
+        let ghost old = s@;
+        s.set(pos, *self);
+        proof {
+            assert(s@ == seq_splice(old, pos, self.spec_to_be_bytes()));
         }
     }
 
@@ -304,10 +513,15 @@ impl FromToBytes for u16 {
         seq![(self & 0xff) as u8, ((self >> 8) & 0xff) as u8]
     }
 
-    // open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {  }
-    // open spec fn spec_to_be_bytes(&self) -> Seq<u8> {  }
+    open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {
+        (s[0] as u16) << 8 | (s[1] as u16)
+    }
+
+    open spec fn spec_to_be_bytes(&self) -> Seq<u8> {
+        seq![((self >> 8) & 0xff) as u8, (self & 0xff) as u8]
+    }
+
     proof fn lemma_spec_to_from_le_bytes(&self) {
-        let s = self.spec_to_le_bytes();
         assert({
             &&& self & 0xff < 256
             &&& (self >> 8) & 0xff < 256
@@ -329,6 +543,28 @@ impl FromToBytes for u16 {
     proof fn lemma_spec_from_le_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
     }
 
+    proof fn lemma_spec_to_from_be_bytes(&self) {
+        assert({
+            &&& self & 0xff < 256
+            &&& (self >> 8) & 0xff < 256
+        }) by (bit_vector);
+        assert(self == (((self >> 8) & 0xff) << 8 | (self & 0xff))) by (bit_vector);
+    }
+
+    proof fn lemma_spec_from_to_be_bytes(s: Seq<u8>) {
+        if s.len() == size_of::<u16>() {
+            let x = Self::spec_from_be_bytes(s);
+            let s0 = s[0] as u16;
+            let s1 = s[1] as u16;
+            assert(((x == s0 << 8 | s1) && (s0 < 256) && (s1 < 256)) ==> s0 == ((x >> 8) & 0xff) &&
+            s1 == (x & 0xff)) by (bit_vector);
+            assert_seqs_equal!(Self::spec_to_be_bytes(&Self::spec_from_be_bytes(s)) == s);
+        }
+    }
+
+    proof fn lemma_spec_from_be_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
+    }
+
     #[verifier::external_body]
     fn ex_from_le_bytes(s: &[u8]) -> (x: u16) {
         use core::convert::TryInto;
@@ -338,6 +574,18 @@ impl FromToBytes for u16 {
     #[verifier::external_body]
     fn ex_to_le_bytes(&self, s: &mut Vec<u8>, pos: usize) {
         let bytes = self.to_le_bytes();
+        s[pos..pos + 2].copy_from_slice(&bytes);
+    }
+
+    #[verifier::external_body]
+    fn ex_from_be_bytes(s: &[u8]) -> (x: u16) {
+        use core::convert::TryInto;
+        u16::from_be_bytes(s.try_into().unwrap())
+    }
+
+    #[verifier::external_body]
+    fn ex_to_be_bytes(&self, s: &mut Vec<u8>, pos: usize) {
+        let bytes = self.to_be_bytes();
         s[pos..pos + 2].copy_from_slice(&bytes);
     }
 
@@ -359,9 +607,20 @@ impl FromToBytes for u32 {
             ((self >> 24) & 0xff) as u8,
         ]
     }
+    
+    open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {
+        (s[0] as u32) << 24 | (s[1] as u32) << 16 | (s[2] as u32) << 8 | (s[3] as u32)
+    }
 
-    // open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {  }
-    // open spec fn spec_to_be_bytes(&self) -> Seq<u8> {  }
+    open spec fn spec_to_be_bytes(&self) -> Seq<u8> {
+        seq![
+            ((self >> 24) & 0xff) as u8,
+            ((self >> 16) & 0xff) as u8,
+            ((self >> 8) & 0xff) as u8,
+            (self & 0xff) as u8,
+        ]
+    }
+
     proof fn lemma_spec_to_from_le_bytes(&self) {
         let s = self.spec_to_le_bytes();
         assert({
@@ -391,6 +650,35 @@ impl FromToBytes for u32 {
     proof fn lemma_spec_from_le_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
     }
 
+    proof fn lemma_spec_to_from_be_bytes(&self) {
+        let s = self.spec_to_be_bytes();
+        assert({
+            &&& self & 0xff < 256
+            &&& (self >> 8) & 0xff < 256
+            &&& (self >> 16) & 0xff < 256
+            &&& (self >> 24) & 0xff < 256
+        }) by (bit_vector);
+        assert(self == (((self >> 24) & 0xff) << 24 | ((self >> 16) & 0xff) << 16 | ((self >> 8) &
+        0xff) << 8 | (self & 0xff))) by (bit_vector);
+    }
+
+    proof fn lemma_spec_from_to_be_bytes(s: Seq<u8>) {
+        if s.len() == size_of::<u32>() {
+            let x = Self::spec_from_be_bytes(s);
+            let s0 = s[0] as u32;
+            let s1 = s[1] as u32;
+            let s2 = s[2] as u32;
+            let s3 = s[3] as u32;
+            assert(((x == s0 << 24 | s1 << 16 | s2 << 8 | s3) && (s0 < 256) && (s1 < 256) && (s2
+                < 256) && (s3 < 256)) ==> s0 == ((x >> 24) & 0xff) && s1 == ((x >> 16) & 0xff) && s2
+                == ((x >> 8) & 0xff) && s3 == (x & 0xff)) by (bit_vector);
+            assert_seqs_equal!(Self::spec_to_be_bytes(&Self::spec_from_be_bytes(s)) == s);
+        }
+    }
+
+    proof fn lemma_spec_from_be_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
+    }
+
     #[verifier::external_body]
     fn ex_from_le_bytes(s: &[u8]) -> (x: u32) {
         use core::convert::TryInto;
@@ -400,6 +688,18 @@ impl FromToBytes for u32 {
     #[verifier::external_body]
     fn ex_to_le_bytes(&self, s: &mut Vec<u8>, pos: usize) {
         let bytes = self.to_le_bytes();
+        s[pos..pos + 4].copy_from_slice(&bytes);
+    }
+
+    #[verifier::external_body]
+    fn ex_from_be_bytes(s: &[u8]) -> (x: u32) {
+        use core::convert::TryInto;
+        u32::from_be_bytes(s.try_into().unwrap())
+    }
+
+    #[verifier::external_body]
+    fn ex_to_be_bytes(&self, s: &mut Vec<u8>, pos: usize) {
+        let bytes = self.to_be_bytes();
         s[pos..pos + 4].copy_from_slice(&bytes);
     }
 
@@ -427,8 +727,24 @@ impl FromToBytes for u64 {
         ]
     }
 
-    // open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {  }
-    // open spec fn spec_to_be_bytes(&self) -> Seq<u8> {  }
+    open spec fn spec_from_be_bytes(s: Seq<u8>) -> Self {
+        (s[0] as u64) << 56 | (s[1] as u64) << 48 | (s[2] as u64) << 40 | (s[3] as u64) << 32 | (
+        s[4] as u64) << 24 | (s[5] as u64) << 16 | (s[6] as u64) << 8 | (s[7] as u64)
+    }
+
+    open spec fn spec_to_be_bytes(&self) -> Seq<u8> {
+        seq![
+            ((self >> 56) & 0xff) as u8,
+            ((self >> 48) & 0xff) as u8,
+            ((self >> 40) & 0xff) as u8,
+            ((self >> 32) & 0xff) as u8,
+            ((self >> 24) & 0xff) as u8,
+            ((self >> 16) & 0xff) as u8,
+            ((self >> 8) & 0xff) as u8,
+            (self & 0xff) as u8,
+        ]
+    }
+
     proof fn lemma_spec_to_from_le_bytes(&self) {
         let s = self.spec_to_le_bytes();
         assert({
@@ -470,6 +786,47 @@ impl FromToBytes for u64 {
     proof fn lemma_spec_from_le_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
     }
 
+    proof fn lemma_spec_to_from_be_bytes(&self) {
+        let s = self.spec_to_be_bytes();
+        assert({
+            &&& self & 0xff < 256
+            &&& (self >> 8) & 0xff < 256
+            &&& (self >> 16) & 0xff < 256
+            &&& (self >> 24) & 0xff < 256
+            &&& (self >> 32) & 0xff < 256
+            &&& (self >> 40) & 0xff < 256
+            &&& (self >> 48) & 0xff < 256
+            &&& (self >> 56) & 0xff < 256
+        }) by (bit_vector);
+        assert(self == (((self >> 56) & 0xff) << 56 | ((self >> 48) & 0xff) << 48 | ((self >> 40) &
+        0xff) << 40 | ((self >> 32) & 0xff) << 32 | ((self >> 24) & 0xff) << 24 | ((self >> 16) &
+        0xff) << 16 | ((self >> 8) & 0xff) << 8 | (self & 0xff))) by (bit_vector);
+    }
+
+    proof fn lemma_spec_from_to_be_bytes(s: Seq<u8>) {
+        if s.len() == size_of::<u64>() {
+            let x = Self::spec_from_be_bytes(s);
+            let s0 = s[0] as u64;
+            let s1 = s[1] as u64;
+            let s2 = s[2] as u64;
+            let s3 = s[3] as u64;
+            let s4 = s[4] as u64;
+            let s5 = s[5] as u64;
+            let s6 = s[6] as u64;
+            let s7 = s[7] as u64;
+            assert(((x == s0 << 56 | s1 << 48 | s2 << 40 | s3 << 32 | s4 << 24 | s5 << 16 | s6 << 8
+                | s7) && (s0 < 256) && (s1 < 256) && (s2 < 256) && (s3 < 256) && (s4 < 256) && (s5
+                < 256) && (s6 < 256) && (s7 < 256)) ==> s0 == ((x >> 56) & 0xff) && s1 == ((x >> 48)
+                & 0xff) && s2 == ((x >> 40) & 0xff) && s3 == ((x >> 32) & 0xff) && s4 == ((x >> 24)
+                & 0xff) && s5 == ((x >> 16) & 0xff) && s6 == ((x >> 8) & 0xff) && s7 == (x & 0xff))
+                by (bit_vector);
+            assert_seqs_equal!(Self::spec_to_be_bytes(&Self::spec_from_be_bytes(s)) == s);
+        }
+    }
+
+    proof fn lemma_spec_from_be_bytes_no_lookahead(s1: Seq<u8>, s2: Seq<u8>) {
+    }
+
     #[verifier::external_body]
     fn ex_from_le_bytes(s: &[u8]) -> (x: u64) {
         use core::convert::TryInto;
@@ -479,6 +836,18 @@ impl FromToBytes for u64 {
     #[verifier::external_body]
     fn ex_to_le_bytes(&self, s: &mut Vec<u8>, pos: usize) {
         let bytes = self.to_le_bytes();
+        s[pos..pos + 8].copy_from_slice(&bytes);
+    }
+
+    #[verifier::external_body]
+    fn ex_from_be_bytes(s: &[u8]) -> (x: u64) {
+        use core::convert::TryInto;
+        u64::from_be_bytes(s.try_into().unwrap())
+    }
+
+    #[verifier::external_body]
+    fn ex_to_be_bytes(&self, s: &mut Vec<u8>, pos: usize) {
+        let bytes = self.to_be_bytes();
         s[pos..pos + 8].copy_from_slice(&bytes);
     }
 
@@ -513,7 +882,7 @@ impl SpecFrom<u64> for usize {
 
 impl SpecFrom<u24> for usize {
     open spec fn spec_from(t: u24) -> usize {
-        t.spec_to_u32() as usize
+        t.spec_as_u32() as usize
     }
 }
 
@@ -543,11 +912,12 @@ impl From<u64> for usize {
 
 impl From<u24> for usize {
     fn ex_from(t: u24) -> usize {
-        t.to_u32() as usize
+        t.as_u32() as usize
     }
 }
 
 /// Vest's u24 (3-byte unsigned integer) type.
+/// For simplicity, this type always stores the integer in big-endian byte order.
 #[allow(non_camel_case_types)]
 pub struct u24(pub [u8; 3]);
 
@@ -561,38 +931,130 @@ impl View for u24 {
 
 impl u24 {
     /// Converts the `u24` to a `u32`.
-    pub open spec fn spec_to_u32(&self) -> u32 {
+    pub open spec fn spec_as_u32(&self) -> u32 {
         let s = self.0;
-        (s[0] as u32) | (s[1] as u32) << 8 | (s[2] as u32) << 16
+        let bytes = seq![0, s[0], s[1], s[2]];
+        u32::spec_from_be_bytes(bytes)
     }
 
     /// Converts the `u24` to a `u32`.
-    #[verifier::external_body]
-    pub fn to_u32(&self) -> (o: u32)
+    pub fn as_u32(&self) -> (o: u32)
         ensures
-            o == self.spec_to_u32(),
+            o == self.spec_as_u32(),
     {
         let mut bytes = [0; 4];
-        bytes[..3].copy_from_slice(&self.0);
-        u32::from_le_bytes(bytes)
+        bytes.set(1, self.0[0]);
+        bytes.set(2, self.0[1]);
+        bytes.set(3, self.0[2]);
+        u32::ex_from_be_bytes(bytes.as_slice())
     }
 }
 
+/// Combinator for parsing and serializing unsigned u24 integers in little-endian byte order.
+pub struct U24Le;
 
-/// Combinator for parsing and serializing unsigned u24 integers.
-///
-/// > **Note**: Currently, little-endian byte order is used for serialization and parsing.
-pub struct U24;
-
-impl View for U24 {
-    type V = U24;
+impl View for U24Le {
+    type V = U24Le;
 
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
 
-impl SpecCombinator for U24 {
+impl SpecCombinator for U24Le {
+    type SpecResult = u24;
+    
+    // To parse a u24 in little-endian byte order, we simply reverse the 3 bytes parsed by the
+    // `BytesN<3>` combinator.
+    // Later when this `u24` is used, it's converted to a `u32` in big-endian byte order.
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, u24), ()> {
+        match BytesN::<3>.spec_parse(s) {
+            Ok((n, bytes)) => Ok((n, u24([bytes[2], bytes[1], bytes[0]]))),
+            _ => Err(()),
+        }
+    }
+
+    proof fn spec_parse_wf(&self, s: Seq<u8>) {
+    }
+
+    open spec fn spec_serialize(&self, v: u24) -> Result<Seq<u8>, ()> {
+        let bytes = v.0;
+        BytesN::<3>.spec_serialize([bytes[2], bytes[1], bytes[0]]@)
+    }
+}
+
+impl SecureSpecCombinator for U24Le {
+    open spec fn is_prefix_secure() -> bool {
+        true
+    }
+
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>) {
+        BytesN::<3>.lemma_prefix_secure(s1, s2);
+    }
+
+    proof fn theorem_serialize_parse_roundtrip(&self, v: u24) {
+        let v_rev = u24([v.0[2], v.0[1], v.0[0]]);
+        BytesN::<3>.theorem_serialize_parse_roundtrip(v_rev.0@);
+        match BytesN::<3>.spec_serialize(v_rev.0@) {
+            Ok(buf) => {
+                match BytesN::<3>.spec_parse(buf) {
+                    Ok((n, bytes)) => {
+                        bytes_eq_view_implies_eq([bytes[2], bytes[1], bytes[0]], v.0);
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+
+    proof fn theorem_parse_serialize_roundtrip(&self, s: Seq<u8>) {
+        BytesN::<3>.theorem_parse_serialize_roundtrip(s);
+        match BytesN::<3>.spec_parse(s) {
+            Ok((n, bytes)) => {
+                assert([bytes[0], bytes[1], bytes[2]]@ == bytes);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Combinator for U24Le {
+    type Result<'a> = u24;
+
+    type Owned = u24;
+
+    open spec fn spec_length(&self) -> Option<usize> {
+        Some(3)
+    }
+
+    fn length(&self) -> Option<usize> {
+        Some(3)
+    }
+
+    fn parse(&self, s: &[u8]) -> (res: Result<(usize, u24), ParseError>) {
+        let (n, bytes) = BytesN::<3>.parse(s)?;
+        Ok((n, u24([bytes[2], bytes[1], bytes[0]])))
+    }
+
+    fn serialize(&self, v: u24, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
+        BytesN::<3>.serialize([v.0[2], v.0[1], v.0[0]].as_slice(), data, pos)
+    }
+}
+
+
+/// Combinator for parsing and serializing unsigned u24 integers in big-endian byte order.
+pub struct U24Be;
+
+impl View for U24Be {
+    type V = U24Be;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecCombinator for U24Be {
     type SpecResult = u24;
     
     open spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, u24), ()> {
@@ -611,7 +1073,7 @@ impl SpecCombinator for U24 {
     }
 }
 
-impl SecureSpecCombinator for U24 {
+impl SecureSpecCombinator for U24Be {
     open spec fn is_prefix_secure() -> bool {
         true
     }
@@ -656,7 +1118,7 @@ proof fn bytes_eq_view_implies_eq<T: View, const N: usize>(a: [T; N], b: [T; N])
     admit();
 }
 
-impl Combinator for U24 {
+impl Combinator for U24Be {
     type Result<'a> = u24;
 
     type Owned = u24;

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -919,6 +919,7 @@ impl From<u24> for usize {
 /// Vest's u24 (3-byte unsigned integer) type.
 /// For simplicity, this type always stores the integer in big-endian byte order.
 #[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub struct u24(pub [u8; 3]);
 
 impl View for u24 {


### PR DESCRIPTION
* `U16`, `U24`, `U32`, and `U64` are renamed to `U16Le`, `U24Le`, `U32Le`, and `U64Le`, respectively.
* New combinators `U16Be`, `U24Be`, `U32Be`, and `U64Be` are added to the backend.
* Tag disjointness are implemented for the big-endian counterparts
* Verified tests and examples updated


> NOTE: Both `U24Le` and `U24Be` parse into `u24`, which is represented as `[u8; 3]`. `u24` in Vest is always encoded as big-endian, so the parser for `U24Be` simply take 3 bytes from input, while `U24Le` takes 3 bytes from input and reverses the byte order.

TODO:

- [x] Update DSL to account for endianness 