### PR TITLE
remove unnecessary T::V: Builder bound in Combinator impl for Builder

### DIFF
--- a/vest/src/regular/builder.rs
+++ b/vest/src/regular/builder.rs
@@ -90,7 +90,7 @@ impl<T: Builder> SecureSpecCombinator for BuilderCombinator<T> {
     }
 }
 
-impl<T> Combinator for BuilderCombinator<T> where T: Builder + View, T::V: Builder {
+impl<T> Combinator for BuilderCombinator<T> where T: Builder + View {
     type Result<'a> = ();
 
     type Owned = ();


### PR DESCRIPTION
I think this trait bound is unnecessary, and it results in my examples that use the Builder trait failing. `vest` and `vest-examples` still verify without this bound.