### PR TITLE
New `IsoFn` and `PartialIsoFn` traits and blanket impls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Cargo.lock
 
 # nvim project settings
 .nvim.lua
+
+# Verus LOC metadata
+*.d

--- a/vest-dsl/src/codegen.rs
+++ b/vest-dsl/src/codegen.rs
@@ -1545,10 +1545,12 @@ impl View for {msg_type_name}Mapper {{
     }}
 }}
 
-impl SpecTryFromInto for {msg_type_name}Mapper {{
+impl SpecPartialIso for {msg_type_name}Mapper {{
     type Src = {msg_type_name}Inner;
     type Dst = {msg_type_name};
+}}
 
+impl SpecPartialIsoProof for {msg_type_name}Mapper {{
     proof fn spec_iso(s: Self::Src) {{ 
         assert(
             Self::spec_apply(s) matches Ok(v) ==> {{
@@ -1566,7 +1568,7 @@ impl SpecTryFromInto for {msg_type_name}Mapper {{
     }}
 }}
 
-impl TryFromInto for {msg_type_name}Mapper {{
+impl PartialIso for {msg_type_name}Mapper {{
     type Src = {msg_type_name}Inner;
     type Dst = {msg_type_name};
 }}
@@ -2239,6 +2241,8 @@ impl View for {name}Mapper{inferred_lifetime} {{
 impl SpecIso for {name}Mapper{inferred_lifetime} {{
     type Src = Spec{name}Inner;
     type Dst = Spec{name};
+}}
+impl SpecIsoProof for {name}Mapper{inferred_lifetime} {{
     proof fn spec_iso(s: Self::Src) {{
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }}

--- a/vest-dsl/test/Makefile
+++ b/vest-dsl/test/Makefile
@@ -1,2 +1,15 @@
-all:  
+all: vest verus
+
+# List all .vest files in the src directory
+VEST_FILES := ./src/codegen.vest ./src/elab.vest ./src/enums.vest ./src/josh.vest ./src/matches.vest ./src/opt.vest ./src/repeat.vest
+# Path to the vest-dsl binary
+VEST_DSL := ../target/debug/vest-dsl
+vest:
+	@for file in $(VEST_FILES); do \
+		echo "==================================="; \
+		echo "Processing $$file"; \
+		$(VEST_DSL) $$file; \
+	done
+	 
+verus:
 	verus --crate-type=lib  --import vest=../../vest/vest.verusdata --extern vest=../../vest/libvest.rlib src/lib.rs --trace --time

--- a/vest-dsl/test/src/elab.rs
+++ b/vest-dsl/test/src/elab.rs
@@ -21,548 +21,8 @@ use vest::bitcoin::varint::{BtcVarint, VarInt};
 use vest::regular::preceded::*;
 use vest::regular::terminated::*;
 use vest::regular::disjoint::DisjointFrom;
+use vest::regular::leb128::*;
 verus!{
-pub type SpecContentType = u8;
-pub type ContentType = u8;
-
-
-pub struct SpecContentTypeCombinator(SpecContentTypeCombinatorAlias);
-
-impl SpecCombinator for SpecContentTypeCombinator {
-    type Type = SpecContentType;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecContentTypeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecContentTypeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecContentTypeCombinatorAlias = U8;
-
-pub struct ContentTypeCombinator(ContentTypeCombinatorAlias);
-
-impl View for ContentTypeCombinator {
-    type V = SpecContentTypeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecContentTypeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ContentTypeCombinator {
-    type Type = ContentType;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ContentTypeCombinatorAlias = U8;
-
-
-pub closed spec fn spec_content_type() -> SpecContentTypeCombinator {
-    SpecContentTypeCombinator(U8)
-}
-
-                
-pub fn content_type() -> (o: ContentTypeCombinator)
-    ensures o@ == spec_content_type(),
-{
-    ContentTypeCombinator(U8)
-}
-
-                
-pub type SpecContent0 = Seq<u8>;
-pub type Content0<'a> = &'a [u8];
-
-
-pub struct SpecContent0Combinator(SpecContent0CombinatorAlias);
-
-impl SpecCombinator for SpecContent0Combinator {
-    type Type = SpecContent0;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecContent0Combinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecContent0CombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecContent0CombinatorAlias = Bytes;
-
-pub struct Content0Combinator(Content0CombinatorAlias);
-
-impl View for Content0Combinator {
-    type V = SpecContent0Combinator;
-    closed spec fn view(&self) -> Self::V { SpecContent0Combinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Content0Combinator {
-    type Type = Content0<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Content0CombinatorAlias = Bytes;
-
-
-pub closed spec fn spec_content_0(num: u24) -> SpecContent0Combinator {
-    SpecContent0Combinator(Bytes(num.spec_into()))
-}
-
-                
-pub fn content_0<'a>(num: u24) -> (o: Content0Combinator)
-    ensures o@ == spec_content_0(num@),
-{
-    Content0Combinator(Bytes(num.ex_into()))
-}
-
-                
-
-pub enum SpecMsgCF4 {
-    C0(SpecContent0),
-    C1(u16),
-    C2(u32),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecMsgCF4Inner = Either<SpecContent0, Either<u16, Either<u32, Seq<u8>>>>;
-
-
-
-impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
-    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
-        match m {
-            SpecMsgCF4::C0(m) => Either::Left(m),
-            SpecMsgCF4::C1(m) => Either::Right(Either::Left(m)),
-            SpecMsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
-            SpecMsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
-    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
-        match m {
-            Either::Left(m) => SpecMsgCF4::C0(m),
-            Either::Right(Either::Left(m)) => SpecMsgCF4::C1(m),
-            Either::Right(Either::Right(Either::Left(m))) => SpecMsgCF4::C2(m),
-            Either::Right(Either::Right(Either::Right(m))) => SpecMsgCF4::Unrecognized(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MsgCF4<'a> {
-    C0(Content0<'a>),
-    C1(u16),
-    C2(u32),
-    Unrecognized(&'a [u8]),
-}
-
-pub type MsgCF4Inner<'a> = Either<Content0<'a>, Either<u16, Either<u32, &'a [u8]>>>;
-
-
-impl<'a> View for MsgCF4<'a> {
-    type V = SpecMsgCF4;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
-            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
-            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
-            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
-        }
-    }
-}
-
-
-impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
-    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
-        match m {
-            MsgCF4::C0(m) => Either::Left(m),
-            MsgCF4::C1(m) => Either::Right(Either::Left(m)),
-            MsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
-            MsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
-    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
-        match m {
-            Either::Left(m) => MsgCF4::C0(m),
-            Either::Right(Either::Left(m)) => MsgCF4::C1(m),
-            Either::Right(Either::Right(Either::Left(m))) => MsgCF4::C2(m),
-            Either::Right(Either::Right(Either::Right(m))) => MsgCF4::Unrecognized(m),
-        }
-    }
-    
-}
-
-
-pub struct MsgCF4Mapper<'a>(PhantomData<&'a ()>);
-impl<'a> MsgCF4Mapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        MsgCF4Mapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        MsgCF4Mapper(PhantomData)
-    }
-}
-impl View for MsgCF4Mapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for MsgCF4Mapper<'_> {
-    type Src = SpecMsgCF4Inner;
-    type Dst = SpecMsgCF4;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for MsgCF4Mapper<'a> {
-    type Src = MsgCF4Inner<'a>;
-    type Dst = MsgCF4<'a>;
-}
-
-
-pub struct SpecMsgCF4Combinator(SpecMsgCF4CombinatorAlias);
-
-impl SpecCombinator for SpecMsgCF4Combinator {
-    type Type = SpecMsgCF4;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsgCF4Combinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsgCF4CombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsgCF4CombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecContent0Combinator>, OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>>, MsgCF4Mapper<'static>>>;
-
-pub struct MsgCF4Combinator<'a>(MsgCF4CombinatorAlias<'a>);
-
-impl<'a> View for MsgCF4Combinator<'a> {
-    type V = SpecMsgCF4Combinator;
-    closed spec fn view(&self) -> Self::V { SpecMsgCF4Combinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for MsgCF4Combinator<'a> {
-    type Type = MsgCF4<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type MsgCF4CombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<Content0Combinator>, OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>>, MsgCF4Mapper<'a>>>;
-
-
-pub closed spec fn spec_msg_c_f4(f3: u24, f2: SpecContentType) -> SpecMsgCF4Combinator {
-    SpecMsgCF4Combinator(AndThen(Bytes(f3.spec_into()), Mapped { inner: OrdChoice(Cond { cond: f2 == 0, inner: spec_content_0(f3) }, OrdChoice(Cond { cond: f2 == 1, inner: U16Be }, OrdChoice(Cond { cond: f2 == 2, inner: U32Be }, Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail }))), mapper: MsgCF4Mapper::spec_new() }))
-}
-
-                
-pub fn msg_c_f4<'a>(f3: u24, f2: ContentType) -> (o: MsgCF4Combinator<'a>)
-    ensures o@ == spec_msg_c_f4(f3@, f2@),
-{
-    MsgCF4Combinator(AndThen(Bytes(f3.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: f2 == 0, inner: content_0(f3) }, OrdChoice::new(Cond { cond: f2 == 1, inner: U16Be }, OrdChoice::new(Cond { cond: f2 == 2, inner: U32Be }, Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail }))), mapper: MsgCF4Mapper::new() }))
-}
-
-                
-
-pub struct SpecMsgC {
-    pub f2: SpecContentType,
-    pub f3: u24,
-    pub f4: SpecMsgCF4,
-}
-
-pub type SpecMsgCInner = ((SpecContentType, u24), SpecMsgCF4);
-impl SpecFrom<SpecMsgC> for SpecMsgCInner {
-    open spec fn spec_from(m: SpecMsgC) -> SpecMsgCInner {
-        ((m.f2, m.f3), m.f4)
-    }
-}
-impl SpecFrom<SpecMsgCInner> for SpecMsgC {
-    open spec fn spec_from(m: SpecMsgCInner) -> SpecMsgC {
-        let ((f2, f3), f4) = m;
-        SpecMsgC { f2, f3, f4 }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct MsgC<'a> {
-    pub f2: ContentType,
-    pub f3: u24,
-    pub f4: MsgCF4<'a>,
-}
-
-impl View for MsgC<'_> {
-    type V = SpecMsgC;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsgC {
-            f2: self.f2@,
-            f3: self.f3@,
-            f4: self.f4@,
-        }
-    }
-}
-pub type MsgCInner<'a> = ((ContentType, u24), MsgCF4<'a>);
-impl<'a> From<MsgC<'a>> for MsgCInner<'a> {
-    fn ex_from(m: MsgC) -> MsgCInner {
-        ((m.f2, m.f3), m.f4)
-    }
-}
-impl<'a> From<MsgCInner<'a>> for MsgC<'a> {
-    fn ex_from(m: MsgCInner) -> MsgC {
-        let ((f2, f3), f4) = m;
-        MsgC { f2, f3, f4 }
-    }
-}
-
-pub struct MsgCMapper<'a>(PhantomData<&'a ()>);
-impl<'a> MsgCMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        MsgCMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        MsgCMapper(PhantomData)
-    }
-}
-impl View for MsgCMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for MsgCMapper<'_> {
-    type Src = SpecMsgCInner;
-    type Dst = SpecMsgC;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for MsgCMapper<'a> {
-    type Src = MsgCInner<'a>;
-    type Dst = MsgC<'a>;
-}
-
-pub struct SpecMsgCCombinator(SpecMsgCCombinatorAlias);
-
-impl SpecCombinator for SpecMsgCCombinator {
-    type Type = SpecMsgC;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsgCCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsgCCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsgCCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecContentTypeCombinator, U24Be>, SpecMsgCF4Combinator>, MsgCMapper<'static>>;
-
-pub struct MsgCCombinator<'a>(MsgCCombinatorAlias<'a>);
-
-impl<'a> View for MsgCCombinator<'a> {
-    type V = SpecMsgCCombinator;
-    closed spec fn view(&self) -> Self::V { SpecMsgCCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for MsgCCombinator<'a> {
-    type Type = MsgC<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type MsgCCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ContentTypeCombinator, U24Be, MsgCCont1<'a>>, MsgCF4Combinator<'a>, MsgCCont0<'a>>, MsgCMapper<'a>>;
-
-
-pub closed spec fn spec_msg_c() -> SpecMsgCCombinator {
-    SpecMsgCCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_content_type(), snd: |deps| spec_msg_c_cont1(deps) }, snd: |deps| spec_msg_c_cont0(deps) },
-        mapper: MsgCMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_msg_c_cont1(deps: SpecContentType) -> U24Be {
-    let f2 = deps;
-    U24Be
-}
-pub open spec fn spec_msg_c_cont0(deps: (SpecContentType, u24)) -> SpecMsgCF4Combinator {
-    let (f2, f3) = deps;
-    spec_msg_c_f4(f3, f2)
-}
-                
-pub fn msg_c<'a>() -> (o: MsgCCombinator<'a>)
-    ensures o@ == spec_msg_c(),
-{
-    MsgCCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: content_type(), snd: MsgCCont1::new(), spec_snd: Ghost(|deps| spec_msg_c_cont1(deps)) }, snd: MsgCCont0::new(), spec_snd: Ghost(|deps| spec_msg_c_cont0(deps)) },
-        mapper: MsgCMapper::new(),
-    })
-}
-
-pub struct MsgCCont1<'a>(PhantomData<&'a ()>);
-impl<'a> MsgCCont1<'a> {
-    pub fn new() -> Self {
-        MsgCCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&ContentType> for MsgCCont1<'a> {
-    type Output = U24Be;
-
-    open spec fn requires(&self, deps: &ContentType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &ContentType, o: Self::Output) -> bool {
-        o@ == spec_msg_c_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &ContentType) -> Self::Output {
-        let f2 = *deps;
-        U24Be
-    }
-}
-pub struct MsgCCont0<'a>(PhantomData<&'a ()>);
-impl<'a> MsgCCont0<'a> {
-    pub fn new() -> Self {
-        MsgCCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(ContentType, u24)> for MsgCCont0<'a> {
-    type Output = MsgCF4Combinator<'a>;
-
-    open spec fn requires(&self, deps: &(ContentType, u24)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(ContentType, u24), o: Self::Output) -> bool {
-        o@ == spec_msg_c_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(ContentType, u24)) -> Self::Output {
-        let (f2, f3) = *deps;
-        msg_c_f4(f3, f2)
-    }
-}
-                
-pub type SpecF5 = Seq<u8>;
-pub type F5<'a> = &'a [u8];
-
-pub spec const SPEC_F5_CONST: Seq<u8> = seq![1; 5];pub type SpecF5Combinator = Refined<BytesN<5>, TagPred<Seq<u8>>>;
-pub exec static F5_CONST: [u8; 5]
-    ensures F5_CONST@ == SPEC_F5_CONST,
-{
-    let arr: [u8; 5] = [1; 5];
-    assert(arr@ == SPEC_F5_CONST);
-    arr
-}
-pub type F5Combinator<'a> = Refined<BytesN<5>, TagPred<&'a [u8]>>;
-
-
-pub closed spec fn spec_F5() -> SpecF5Combinator {
-    Refined { inner: BytesN::<5>, predicate: TagPred(SPEC_F5_CONST) }
-}
-
-                
-pub fn F5<'a>() -> (o: F5Combinator<'a>)
-    ensures o@ == spec_F5(),
-{
-    Refined { inner: BytesN::<5>, predicate: TagPred(F5_CONST.as_slice()) }
-}
-
-                
 
 pub struct SpecMsgD {
     pub f1: Seq<u8>,
@@ -632,6 +92,8 @@ impl View for MsgDMapper<'_> {
 impl SpecIso for MsgDMapper<'_> {
     type Src = SpecMsgDInner;
     type Dst = SpecMsgD;
+}
+impl SpecIsoProof for MsgDMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -786,6 +248,8 @@ impl View for MsgBMapper<'_> {
 impl SpecIso for MsgBMapper<'_> {
     type Src = SpecMsgBInner;
     type Dst = SpecMsgB;
+}
+impl SpecIsoProof for MsgBMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -935,6 +399,8 @@ impl View for MsgAMapper<'_> {
 impl SpecIso for MsgAMapper<'_> {
     type Src = SpecMsgAInner;
     type Dst = SpecMsgA;
+}
+impl SpecIsoProof for MsgAMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -1017,6 +483,545 @@ pub fn msg_a<'a>() -> (o: MsgACombinator<'a>)
     })
 }
 
+                
+pub type SpecContentType = u8;
+pub type ContentType = u8;
+
+
+pub struct SpecContentTypeCombinator(SpecContentTypeCombinatorAlias);
+
+impl SpecCombinator for SpecContentTypeCombinator {
+    type Type = SpecContentType;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecContentTypeCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecContentTypeCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecContentTypeCombinatorAlias = U8;
+
+pub struct ContentTypeCombinator(ContentTypeCombinatorAlias);
+
+impl View for ContentTypeCombinator {
+    type V = SpecContentTypeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecContentTypeCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ContentTypeCombinator {
+    type Type = ContentType;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ContentTypeCombinatorAlias = U8;
+
+
+pub closed spec fn spec_content_type() -> SpecContentTypeCombinator {
+    SpecContentTypeCombinator(U8)
+}
+
+                
+pub fn content_type() -> (o: ContentTypeCombinator)
+    ensures o@ == spec_content_type(),
+{
+    ContentTypeCombinator(U8)
+}
+
+                
+pub type SpecContent0 = Seq<u8>;
+pub type Content0<'a> = &'a [u8];
+
+
+pub struct SpecContent0Combinator(SpecContent0CombinatorAlias);
+
+impl SpecCombinator for SpecContent0Combinator {
+    type Type = SpecContent0;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecContent0Combinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecContent0CombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecContent0CombinatorAlias = Bytes;
+
+pub struct Content0Combinator(Content0CombinatorAlias);
+
+impl View for Content0Combinator {
+    type V = SpecContent0Combinator;
+    closed spec fn view(&self) -> Self::V { SpecContent0Combinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Content0Combinator {
+    type Type = Content0<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Content0CombinatorAlias = Bytes;
+
+
+pub closed spec fn spec_content_0(num: u24) -> SpecContent0Combinator {
+    SpecContent0Combinator(Bytes(num.spec_into()))
+}
+
+pub fn content_0<'a>(num: u24) -> (o: Content0Combinator)
+    ensures o@ == spec_content_0(num@),
+{
+    Content0Combinator(Bytes(num.ex_into()))
+}
+
+pub type SpecF5 = Seq<u8>;
+pub type F5<'a> = &'a [u8];
+
+pub spec const SPEC_F5_CONST: Seq<u8> = seq![1; 5];pub type SpecF5Combinator = Refined<BytesN<5>, TagPred<Seq<u8>>>;
+pub exec static F5_CONST: [u8; 5]
+    ensures F5_CONST@ == SPEC_F5_CONST,
+{
+    let arr: [u8; 5] = [1; 5];
+    assert(arr@ == SPEC_F5_CONST);
+    arr
+}
+pub type F5Combinator<'a> = Refined<BytesN<5>, TagPred<&'a [u8]>>;
+
+
+pub closed spec fn spec_F5() -> SpecF5Combinator {
+    Refined { inner: BytesN::<5>, predicate: TagPred(SPEC_F5_CONST) }
+}
+
+pub fn F5<'a>() -> (o: F5Combinator<'a>)
+    ensures o@ == spec_F5(),
+{
+    Refined { inner: BytesN::<5>, predicate: TagPred(F5_CONST.as_slice()) }
+}
+
+
+pub enum SpecMsgCF4 {
+    C0(SpecContent0),
+    C1(u16),
+    C2(u32),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecMsgCF4Inner = Either<SpecContent0, Either<u16, Either<u32, Seq<u8>>>>;
+
+
+
+impl SpecFrom<SpecMsgCF4> for SpecMsgCF4Inner {
+    open spec fn spec_from(m: SpecMsgCF4) -> SpecMsgCF4Inner {
+        match m {
+            SpecMsgCF4::C0(m) => Either::Left(m),
+            SpecMsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            SpecMsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecMsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecMsgCF4Inner> for SpecMsgCF4 {
+    open spec fn spec_from(m: SpecMsgCF4Inner) -> SpecMsgCF4 {
+        match m {
+            Either::Left(m) => SpecMsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => SpecMsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecMsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecMsgCF4::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MsgCF4<'a> {
+    C0(Content0<'a>),
+    C1(u16),
+    C2(u32),
+    Unrecognized(&'a [u8]),
+}
+
+pub type MsgCF4Inner<'a> = Either<Content0<'a>, Either<u16, Either<u32, &'a [u8]>>>;
+
+
+impl<'a> View for MsgCF4<'a> {
+    type V = SpecMsgCF4;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MsgCF4::C0(m) => SpecMsgCF4::C0(m@),
+            MsgCF4::C1(m) => SpecMsgCF4::C1(m@),
+            MsgCF4::C2(m) => SpecMsgCF4::C2(m@),
+            MsgCF4::Unrecognized(m) => SpecMsgCF4::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<MsgCF4<'a>> for MsgCF4Inner<'a> {
+    fn ex_from(m: MsgCF4<'a>) -> MsgCF4Inner<'a> {
+        match m {
+            MsgCF4::C0(m) => Either::Left(m),
+            MsgCF4::C1(m) => Either::Right(Either::Left(m)),
+            MsgCF4::C2(m) => Either::Right(Either::Right(Either::Left(m))),
+            MsgCF4::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl<'a> From<MsgCF4Inner<'a>> for MsgCF4<'a> {
+    fn ex_from(m: MsgCF4Inner<'a>) -> MsgCF4<'a> {
+        match m {
+            Either::Left(m) => MsgCF4::C0(m),
+            Either::Right(Either::Left(m)) => MsgCF4::C1(m),
+            Either::Right(Either::Right(Either::Left(m))) => MsgCF4::C2(m),
+            Either::Right(Either::Right(Either::Right(m))) => MsgCF4::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct MsgCF4Mapper<'a>(PhantomData<&'a ()>);
+impl<'a> MsgCF4Mapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        MsgCF4Mapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        MsgCF4Mapper(PhantomData)
+    }
+}
+impl View for MsgCF4Mapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for MsgCF4Mapper<'_> {
+    type Src = SpecMsgCF4Inner;
+    type Dst = SpecMsgCF4;
+}
+impl SpecIsoProof for MsgCF4Mapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for MsgCF4Mapper<'a> {
+    type Src = MsgCF4Inner<'a>;
+    type Dst = MsgCF4<'a>;
+}
+
+
+pub struct SpecMsgCF4Combinator(SpecMsgCF4CombinatorAlias);
+
+impl SpecCombinator for SpecMsgCF4Combinator {
+    type Type = SpecMsgCF4;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsgCF4Combinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsgCF4CombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsgCF4CombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecContent0Combinator>, OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>>, MsgCF4Mapper<'static>>>;
+
+pub struct MsgCF4Combinator<'a>(MsgCF4CombinatorAlias<'a>);
+
+impl<'a> View for MsgCF4Combinator<'a> {
+    type V = SpecMsgCF4Combinator;
+    closed spec fn view(&self) -> Self::V { SpecMsgCF4Combinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for MsgCF4Combinator<'a> {
+    type Type = MsgCF4<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type MsgCF4CombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<Content0Combinator>, OrdChoice<Cond<U16Be>, OrdChoice<Cond<U32Be>, Cond<Tail>>>>, MsgCF4Mapper<'a>>>;
+
+
+pub closed spec fn spec_msg_c_f4(f3: u24, f2: SpecContentType) -> SpecMsgCF4Combinator {
+    SpecMsgCF4Combinator(AndThen(Bytes(f3.spec_into()), Mapped { inner: OrdChoice(Cond { cond: f2 == 0, inner: spec_content_0(f3) }, OrdChoice(Cond { cond: f2 == 1, inner: U16Be }, OrdChoice(Cond { cond: f2 == 2, inner: U32Be }, Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail }))), mapper: MsgCF4Mapper::spec_new() }))
+}
+
+pub fn msg_c_f4<'a>(f3: u24, f2: ContentType) -> (o: MsgCF4Combinator<'a>)
+    ensures o@ == spec_msg_c_f4(f3@, f2@),
+{
+    MsgCF4Combinator(AndThen(Bytes(f3.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: f2 == 0, inner: content_0(f3) }, OrdChoice::new(Cond { cond: f2 == 1, inner: U16Be }, OrdChoice::new(Cond { cond: f2 == 2, inner: U32Be }, Cond { cond: !(f2 == 0 || f2 == 1 || f2 == 2), inner: Tail }))), mapper: MsgCF4Mapper::new() }))
+}
+
+
+pub struct SpecMsgC {
+    pub f2: SpecContentType,
+    pub f3: u24,
+    pub f4: SpecMsgCF4,
+}
+
+pub type SpecMsgCInner = ((SpecContentType, u24), SpecMsgCF4);
+impl SpecFrom<SpecMsgC> for SpecMsgCInner {
+    open spec fn spec_from(m: SpecMsgC) -> SpecMsgCInner {
+        ((m.f2, m.f3), m.f4)
+    }
+}
+impl SpecFrom<SpecMsgCInner> for SpecMsgC {
+    open spec fn spec_from(m: SpecMsgCInner) -> SpecMsgC {
+        let ((f2, f3), f4) = m;
+        SpecMsgC { f2, f3, f4 }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct MsgC<'a> {
+    pub f2: ContentType,
+    pub f3: u24,
+    pub f4: MsgCF4<'a>,
+}
+
+impl View for MsgC<'_> {
+    type V = SpecMsgC;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsgC {
+            f2: self.f2@,
+            f3: self.f3@,
+            f4: self.f4@,
+        }
+    }
+}
+pub type MsgCInner<'a> = ((ContentType, u24), MsgCF4<'a>);
+impl<'a> From<MsgC<'a>> for MsgCInner<'a> {
+    fn ex_from(m: MsgC) -> MsgCInner {
+        ((m.f2, m.f3), m.f4)
+    }
+}
+impl<'a> From<MsgCInner<'a>> for MsgC<'a> {
+    fn ex_from(m: MsgCInner) -> MsgC {
+        let ((f2, f3), f4) = m;
+        MsgC { f2, f3, f4 }
+    }
+}
+
+pub struct MsgCMapper<'a>(PhantomData<&'a ()>);
+impl<'a> MsgCMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        MsgCMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        MsgCMapper(PhantomData)
+    }
+}
+impl View for MsgCMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for MsgCMapper<'_> {
+    type Src = SpecMsgCInner;
+    type Dst = SpecMsgC;
+}
+impl SpecIsoProof for MsgCMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for MsgCMapper<'a> {
+    type Src = MsgCInner<'a>;
+    type Dst = MsgC<'a>;
+}
+
+pub struct SpecMsgCCombinator(SpecMsgCCombinatorAlias);
+
+impl SpecCombinator for SpecMsgCCombinator {
+    type Type = SpecMsgC;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsgCCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsgCCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsgCCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecContentTypeCombinator, U24Be>, SpecMsgCF4Combinator>, MsgCMapper<'static>>;
+
+pub struct MsgCCombinator<'a>(MsgCCombinatorAlias<'a>);
+
+impl<'a> View for MsgCCombinator<'a> {
+    type V = SpecMsgCCombinator;
+    closed spec fn view(&self) -> Self::V { SpecMsgCCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for MsgCCombinator<'a> {
+    type Type = MsgC<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type MsgCCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ContentTypeCombinator, U24Be, MsgCCont1<'a>>, MsgCF4Combinator<'a>, MsgCCont0<'a>>, MsgCMapper<'a>>;
+
+
+pub closed spec fn spec_msg_c() -> SpecMsgCCombinator {
+    SpecMsgCCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_content_type(), snd: |deps| spec_msg_c_cont1(deps) }, snd: |deps| spec_msg_c_cont0(deps) },
+        mapper: MsgCMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_msg_c_cont1(deps: SpecContentType) -> U24Be {
+    let f2 = deps;
+    U24Be
+}
+pub open spec fn spec_msg_c_cont0(deps: (SpecContentType, u24)) -> SpecMsgCF4Combinator {
+    let (f2, f3) = deps;
+    spec_msg_c_f4(f3, f2)
+}
+                
+pub fn msg_c<'a>() -> (o: MsgCCombinator<'a>)
+    ensures o@ == spec_msg_c(),
+{
+    MsgCCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: content_type(), snd: MsgCCont1::new(), spec_snd: Ghost(|deps| spec_msg_c_cont1(deps)) }, snd: MsgCCont0::new(), spec_snd: Ghost(|deps| spec_msg_c_cont0(deps)) },
+        mapper: MsgCMapper::new(),
+    })
+}
+
+pub struct MsgCCont1<'a>(PhantomData<&'a ()>);
+impl<'a> MsgCCont1<'a> {
+    pub fn new() -> Self {
+        MsgCCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&ContentType> for MsgCCont1<'a> {
+    type Output = U24Be;
+
+    open spec fn requires(&self, deps: &ContentType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &ContentType, o: Self::Output) -> bool {
+        o@ == spec_msg_c_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &ContentType) -> Self::Output {
+        let f2 = *deps;
+        U24Be
+    }
+}
+pub struct MsgCCont0<'a>(PhantomData<&'a ()>);
+impl<'a> MsgCCont0<'a> {
+    pub fn new() -> Self {
+        MsgCCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(ContentType, u24)> for MsgCCont0<'a> {
+    type Output = MsgCF4Combinator<'a>;
+
+    open spec fn requires(&self, deps: &(ContentType, u24)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(ContentType, u24), o: Self::Output) -> bool {
+        o@ == spec_msg_c_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(ContentType, u24)) -> Self::Output {
+        let (f2, f3) = *deps;
+        msg_c_f4(f3, f2)
+    }
+}
                 
 
 }

--- a/vest-dsl/test/src/josh.rs
+++ b/vest-dsl/test/src/josh.rs
@@ -21,74 +21,8 @@ use vest::bitcoin::varint::{BtcVarint, VarInt};
 use vest::regular::preceded::*;
 use vest::regular::terminated::*;
 use vest::regular::disjoint::DisjointFrom;
+use vest::regular::leb128::*;
 verus!{
-pub type SpecTstTag = u8;
-pub type TstTag = u8;
-
-
-pub struct SpecTstTagCombinator(SpecTstTagCombinatorAlias);
-
-impl SpecCombinator for SpecTstTagCombinator {
-    type Type = SpecTstTag;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecTstTagCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecTstTagCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecTstTagCombinatorAlias = U8;
-
-pub struct TstTagCombinator(TstTagCombinatorAlias);
-
-impl View for TstTagCombinator {
-    type V = SpecTstTagCombinator;
-    closed spec fn view(&self) -> Self::V { SpecTstTagCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for TstTagCombinator {
-    type Type = TstTag;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type TstTagCombinatorAlias = U8;
-
-
-pub closed spec fn spec_tst_tag() -> SpecTstTagCombinator {
-    SpecTstTagCombinator(U8)
-}
-
-                
-pub fn tst_tag() -> (o: TstTagCombinator)
-    ensures o@ == spec_tst_tag(),
-{
-    TstTagCombinator(U8)
-}
-
-                
 
 pub struct SpecMydata {
     pub foo: Seq<u8>,
@@ -155,6 +89,8 @@ impl View for MydataMapper<'_> {
 impl SpecIso for MydataMapper<'_> {
     type Src = SpecMydataInner;
     type Dst = SpecMydata;
+}
+impl SpecIsoProof for MydataMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -532,6 +468,8 @@ impl View for TstMydataMapper<'_> {
 impl SpecIso for TstMydataMapper<'_> {
     type Src = SpecTstMydataInner;
     type Dst = SpecTstMydata;
+}
+impl SpecIsoProof for TstMydataMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -600,11 +538,76 @@ pub closed spec fn spec_tst_mydata(tag: SpecTstTag) -> SpecTstMydataCombinator {
     SpecTstMydataCombinator(Mapped { inner: OrdChoice(Cond { cond: tag == 0, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 1, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 2, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 3, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 4, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 5, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 6, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 7, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 8, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 9, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 10, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 11, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 12, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 13, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 14, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 15, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 16, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 17, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 18, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 19, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 20, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 21, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 22, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 23, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 24, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 25, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 26, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 27, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 28, inner: spec_mydata() }, OrdChoice(Cond { cond: tag == 29, inner: spec_mydata() }, Cond { cond: tag == 30, inner: spec_mydata() })))))))))))))))))))))))))))))), mapper: TstMydataMapper::spec_new() })
 }
 
-                
 pub fn tst_mydata<'a>(tag: TstTag) -> (o: TstMydataCombinator<'a>)
     ensures o@ == spec_tst_mydata(tag@),
 {
     TstMydataCombinator(Mapped { inner: OrdChoice::new(Cond { cond: tag == 0, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 1, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 2, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 3, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 4, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 5, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 6, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 7, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 8, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 9, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 10, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 11, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 12, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 13, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 14, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 15, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 16, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 17, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 18, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 19, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 20, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 21, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 22, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 23, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 24, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 25, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 26, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 27, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 28, inner: mydata() }, OrdChoice::new(Cond { cond: tag == 29, inner: mydata() }, Cond { cond: tag == 30, inner: mydata() })))))))))))))))))))))))))))))), mapper: TstMydataMapper::new() })
+}
+
+pub type SpecTstTag = u8;
+pub type TstTag = u8;
+
+
+pub struct SpecTstTagCombinator(SpecTstTagCombinatorAlias);
+
+impl SpecCombinator for SpecTstTagCombinator {
+    type Type = SpecTstTag;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecTstTagCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecTstTagCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecTstTagCombinatorAlias = U8;
+
+pub struct TstTagCombinator(TstTagCombinatorAlias);
+
+impl View for TstTagCombinator {
+    type V = SpecTstTagCombinator;
+    closed spec fn view(&self) -> Self::V { SpecTstTagCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for TstTagCombinator {
+    type Type = TstTag;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type TstTagCombinatorAlias = U8;
+
+
+pub closed spec fn spec_tst_tag() -> SpecTstTagCombinator {
+    SpecTstTagCombinator(U8)
+}
+
+                
+pub fn tst_tag() -> (o: TstTagCombinator)
+    ensures o@ == spec_tst_tag(),
+{
+    TstTagCombinator(U8)
 }
 
                 
@@ -674,6 +677,8 @@ impl View for TstMapper<'_> {
 impl SpecIso for TstMapper<'_> {
     type Src = SpecTstInner;
     type Dst = SpecTst;
+}
+impl SpecIsoProof for TstMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }

--- a/vest-dsl/test/src/matches.rs
+++ b/vest-dsl/test/src/matches.rs
@@ -21,355 +21,8 @@ use vest::bitcoin::varint::{BtcVarint, VarInt};
 use vest::regular::preceded::*;
 use vest::regular::terminated::*;
 use vest::regular::disjoint::DisjointFrom;
+use vest::regular::leb128::*;
 verus!{
-
-pub enum SpecMsg3Content {
-    Variant0(u16),
-    Variant1(u32),
-    Variant2(u32),
-    Variant3(Seq<u8>),
-}
-
-pub type SpecMsg3ContentInner = Either<u16, Either<u32, Either<u32, Seq<u8>>>>;
-
-
-
-impl SpecFrom<SpecMsg3Content> for SpecMsg3ContentInner {
-    open spec fn spec_from(m: SpecMsg3Content) -> SpecMsg3ContentInner {
-        match m {
-            SpecMsg3Content::Variant0(m) => Either::Left(m),
-            SpecMsg3Content::Variant1(m) => Either::Right(Either::Left(m)),
-            SpecMsg3Content::Variant2(m) => Either::Right(Either::Right(Either::Left(m))),
-            SpecMsg3Content::Variant3(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecMsg3ContentInner> for SpecMsg3Content {
-    open spec fn spec_from(m: SpecMsg3ContentInner) -> SpecMsg3Content {
-        match m {
-            Either::Left(m) => SpecMsg3Content::Variant0(m),
-            Either::Right(Either::Left(m)) => SpecMsg3Content::Variant1(m),
-            Either::Right(Either::Right(Either::Left(m))) => SpecMsg3Content::Variant2(m),
-            Either::Right(Either::Right(Either::Right(m))) => SpecMsg3Content::Variant3(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Msg3Content<'a> {
-    Variant0(u16),
-    Variant1(u32),
-    Variant2(u32),
-    Variant3(&'a [u8]),
-}
-
-pub type Msg3ContentInner<'a> = Either<u16, Either<u32, Either<u32, &'a [u8]>>>;
-
-
-impl<'a> View for Msg3Content<'a> {
-    type V = SpecMsg3Content;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            Msg3Content::Variant0(m) => SpecMsg3Content::Variant0(m@),
-            Msg3Content::Variant1(m) => SpecMsg3Content::Variant1(m@),
-            Msg3Content::Variant2(m) => SpecMsg3Content::Variant2(m@),
-            Msg3Content::Variant3(m) => SpecMsg3Content::Variant3(m@),
-        }
-    }
-}
-
-
-impl<'a> From<Msg3Content<'a>> for Msg3ContentInner<'a> {
-    fn ex_from(m: Msg3Content<'a>) -> Msg3ContentInner<'a> {
-        match m {
-            Msg3Content::Variant0(m) => Either::Left(m),
-            Msg3Content::Variant1(m) => Either::Right(Either::Left(m)),
-            Msg3Content::Variant2(m) => Either::Right(Either::Right(Either::Left(m))),
-            Msg3Content::Variant3(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl<'a> From<Msg3ContentInner<'a>> for Msg3Content<'a> {
-    fn ex_from(m: Msg3ContentInner<'a>) -> Msg3Content<'a> {
-        match m {
-            Either::Left(m) => Msg3Content::Variant0(m),
-            Either::Right(Either::Left(m)) => Msg3Content::Variant1(m),
-            Either::Right(Either::Right(Either::Left(m))) => Msg3Content::Variant2(m),
-            Either::Right(Either::Right(Either::Right(m))) => Msg3Content::Variant3(m),
-        }
-    }
-    
-}
-
-
-pub struct Msg3ContentMapper<'a>(PhantomData<&'a ()>);
-impl<'a> Msg3ContentMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        Msg3ContentMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        Msg3ContentMapper(PhantomData)
-    }
-}
-impl View for Msg3ContentMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Msg3ContentMapper<'_> {
-    type Src = SpecMsg3ContentInner;
-    type Dst = SpecMsg3Content;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for Msg3ContentMapper<'a> {
-    type Src = Msg3ContentInner<'a>;
-    type Dst = Msg3Content<'a>;
-}
-
-
-pub struct SpecMsg3ContentCombinator(SpecMsg3ContentCombinatorAlias);
-
-impl SpecCombinator for SpecMsg3ContentCombinator {
-    type Type = SpecMsg3Content;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsg3ContentCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsg3ContentCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsg3ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, OrdChoice<Cond<U32Le>, OrdChoice<Cond<U32Le>, Cond<Tail>>>>, Msg3ContentMapper<'static>>;
-
-pub struct Msg3ContentCombinator<'a>(Msg3ContentCombinatorAlias<'a>);
-
-impl<'a> View for Msg3ContentCombinator<'a> {
-    type V = SpecMsg3ContentCombinator;
-    closed spec fn view(&self) -> Self::V { SpecMsg3ContentCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg3ContentCombinator<'a> {
-    type Type = Msg3Content<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Msg3ContentCombinatorAlias<'a> = Mapped<OrdChoice<Cond<U16Le>, OrdChoice<Cond<U32Le>, OrdChoice<Cond<U32Le>, Cond<Tail>>>>, Msg3ContentMapper<'a>>;
-
-
-pub closed spec fn spec_msg3_content(i: u8) -> SpecMsg3ContentCombinator {
-    SpecMsg3ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: i == 1, inner: U16Le }, OrdChoice(Cond { cond: i == 2, inner: U32Le }, OrdChoice(Cond { cond: i == 3, inner: U32Le }, Cond { cond: !(i == 1 || i == 2 || i == 3), inner: Tail }))), mapper: Msg3ContentMapper::spec_new() })
-}
-
-                
-pub fn msg3_content<'a>(i: u8) -> (o: Msg3ContentCombinator<'a>)
-    ensures o@ == spec_msg3_content(i@),
-{
-    Msg3ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: i == 1, inner: U16Le }, OrdChoice::new(Cond { cond: i == 2, inner: U32Le }, OrdChoice::new(Cond { cond: i == 3, inner: U32Le }, Cond { cond: !(i == 1 || i == 2 || i == 3), inner: Tail }))), mapper: Msg3ContentMapper::new() })
-}
-
-                
-
-pub enum SpecMsg4Content {
-    Variant0(u16),
-    Variant1(Seq<u8>),
-}
-
-pub type SpecMsg4ContentInner = Either<u16, Seq<u8>>;
-
-
-
-impl SpecFrom<SpecMsg4Content> for SpecMsg4ContentInner {
-    open spec fn spec_from(m: SpecMsg4Content) -> SpecMsg4ContentInner {
-        match m {
-            SpecMsg4Content::Variant0(m) => Either::Left(m),
-            SpecMsg4Content::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecMsg4ContentInner> for SpecMsg4Content {
-    open spec fn spec_from(m: SpecMsg4ContentInner) -> SpecMsg4Content {
-        match m {
-            Either::Left(m) => SpecMsg4Content::Variant0(m),
-            Either::Right(m) => SpecMsg4Content::Variant1(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Msg4Content<'a> {
-    Variant0(u16),
-    Variant1(&'a [u8]),
-}
-
-pub type Msg4ContentInner<'a> = Either<u16, &'a [u8]>;
-
-
-impl<'a> View for Msg4Content<'a> {
-    type V = SpecMsg4Content;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            Msg4Content::Variant0(m) => SpecMsg4Content::Variant0(m@),
-            Msg4Content::Variant1(m) => SpecMsg4Content::Variant1(m@),
-        }
-    }
-}
-
-
-impl<'a> From<Msg4Content<'a>> for Msg4ContentInner<'a> {
-    fn ex_from(m: Msg4Content<'a>) -> Msg4ContentInner<'a> {
-        match m {
-            Msg4Content::Variant0(m) => Either::Left(m),
-            Msg4Content::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl<'a> From<Msg4ContentInner<'a>> for Msg4Content<'a> {
-    fn ex_from(m: Msg4ContentInner<'a>) -> Msg4Content<'a> {
-        match m {
-            Either::Left(m) => Msg4Content::Variant0(m),
-            Either::Right(m) => Msg4Content::Variant1(m),
-        }
-    }
-    
-}
-
-
-pub struct Msg4ContentMapper<'a>(PhantomData<&'a ()>);
-impl<'a> Msg4ContentMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        Msg4ContentMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        Msg4ContentMapper(PhantomData)
-    }
-}
-impl View for Msg4ContentMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Msg4ContentMapper<'_> {
-    type Src = SpecMsg4ContentInner;
-    type Dst = SpecMsg4Content;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for Msg4ContentMapper<'a> {
-    type Src = Msg4ContentInner<'a>;
-    type Dst = Msg4Content<'a>;
-}
-
-
-pub struct SpecMsg4ContentCombinator(SpecMsg4ContentCombinatorAlias);
-
-impl SpecCombinator for SpecMsg4ContentCombinator {
-    type Type = SpecMsg4Content;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsg4ContentCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsg4ContentCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsg4ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, Cond<Tail>>, Msg4ContentMapper<'static>>;
-
-pub struct Msg4ContentCombinator<'a>(Msg4ContentCombinatorAlias<'a>);
-
-impl<'a> View for Msg4ContentCombinator<'a> {
-    type V = SpecMsg4ContentCombinator;
-    closed spec fn view(&self) -> Self::V { SpecMsg4ContentCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg4ContentCombinator<'a> {
-    type Type = Msg4Content<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Msg4ContentCombinatorAlias<'a> = Mapped<OrdChoice<Cond<U16Le>, Cond<Tail>>, Msg4ContentMapper<'a>>;
-
-
-pub closed spec fn spec_msg4_content(i: u24) -> SpecMsg4ContentCombinator {
-    SpecMsg4ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: i.spec_as_u32() == 1, inner: U16Le }, Cond { cond: !(i.spec_as_u32() == 1), inner: Tail }), mapper: Msg4ContentMapper::spec_new() })
-}
-
-                
-pub fn msg4_content<'a>(i: u24) -> (o: Msg4ContentCombinator<'a>)
-    ensures o@ == spec_msg4_content(i@),
-{
-    Msg4ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: i.as_u32() == 1, inner: U16Le }, Cond { cond: !(i.as_u32() == 1), inner: Tail }), mapper: Msg4ContentMapper::new() })
-}
-
-                
 
 pub enum SpecMsg5Content {
     Variant0(u16),
@@ -461,6 +114,8 @@ impl View for Msg5ContentMapper<'_> {
 impl SpecIso for Msg5ContentMapper<'_> {
     type Src = SpecMsg5ContentInner;
     type Dst = SpecMsg5Content;
+}
+impl SpecIsoProof for Msg5ContentMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -529,14 +184,12 @@ pub closed spec fn spec_msg5_content(i: VarInt) -> SpecMsg5ContentCombinator {
     SpecMsg5ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: i.spec_as_usize() == 1, inner: U16Le }, Cond { cond: !(i.spec_as_usize() == 1), inner: Tail }), mapper: Msg5ContentMapper::spec_new() })
 }
 
-                
 pub fn msg5_content<'a>(i: VarInt) -> (o: Msg5ContentCombinator<'a>)
     ensures o@ == spec_msg5_content(i@),
 {
     Msg5ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: i.as_usize() == 1, inner: U16Le }, Cond { cond: !(i.as_usize() == 1), inner: Tail }), mapper: Msg5ContentMapper::new() })
 }
 
-                
 
 pub struct SpecMsg5 {
     pub i: VarInt,
@@ -603,6 +256,8 @@ impl View for Msg5Mapper<'_> {
 impl SpecIso for Msg5Mapper<'_> {
     type Src = SpecMsg5Inner;
     type Dst = SpecMsg5;
+}
+impl SpecIsoProof for Msg5Mapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -707,519 +362,6 @@ impl<'a> Continuation<&VarInt> for Msg5Cont0<'a> {
     fn apply(&self, deps: &VarInt) -> Self::Output {
         let i = *deps;
         msg5_content(i)
-    }
-}
-                
-
-pub enum SpecMsg2Content {
-    Variant0(u16),
-    Variant1(u32),
-}
-
-pub type SpecMsg2ContentInner = Either<u16, u32>;
-
-
-
-impl SpecFrom<SpecMsg2Content> for SpecMsg2ContentInner {
-    open spec fn spec_from(m: SpecMsg2Content) -> SpecMsg2ContentInner {
-        match m {
-            SpecMsg2Content::Variant0(m) => Either::Left(m),
-            SpecMsg2Content::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecMsg2ContentInner> for SpecMsg2Content {
-    open spec fn spec_from(m: SpecMsg2ContentInner) -> SpecMsg2Content {
-        match m {
-            Either::Left(m) => SpecMsg2Content::Variant0(m),
-            Either::Right(m) => SpecMsg2Content::Variant1(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Msg2Content {
-    Variant0(u16),
-    Variant1(u32),
-}
-
-pub type Msg2ContentInner = Either<u16, u32>;
-
-
-impl View for Msg2Content {
-    type V = SpecMsg2Content;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            Msg2Content::Variant0(m) => SpecMsg2Content::Variant0(m@),
-            Msg2Content::Variant1(m) => SpecMsg2Content::Variant1(m@),
-        }
-    }
-}
-
-
-impl From<Msg2Content> for Msg2ContentInner {
-    fn ex_from(m: Msg2Content) -> Msg2ContentInner {
-        match m {
-            Msg2Content::Variant0(m) => Either::Left(m),
-            Msg2Content::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl From<Msg2ContentInner> for Msg2Content {
-    fn ex_from(m: Msg2ContentInner) -> Msg2Content {
-        match m {
-            Either::Left(m) => Msg2Content::Variant0(m),
-            Either::Right(m) => Msg2Content::Variant1(m),
-        }
-    }
-    
-}
-
-
-pub struct Msg2ContentMapper;
-impl Msg2ContentMapper {
-    pub closed spec fn spec_new() -> Self {
-        Msg2ContentMapper
-    }
-    pub fn new() -> Self {
-        Msg2ContentMapper
-    }
-}
-impl View for Msg2ContentMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Msg2ContentMapper {
-    type Src = SpecMsg2ContentInner;
-    type Dst = SpecMsg2Content;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for Msg2ContentMapper {
-    type Src = Msg2ContentInner;
-    type Dst = Msg2Content;
-}
-
-
-pub struct SpecMsg2ContentCombinator(SpecMsg2ContentCombinatorAlias);
-
-impl SpecCombinator for SpecMsg2ContentCombinator {
-    type Type = SpecMsg2Content;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsg2ContentCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsg2ContentCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsg2ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, Cond<U32Le>>, Msg2ContentMapper>;
-
-pub struct Msg2ContentCombinator(Msg2ContentCombinatorAlias);
-
-impl View for Msg2ContentCombinator {
-    type V = SpecMsg2ContentCombinator;
-    closed spec fn view(&self) -> Self::V { SpecMsg2ContentCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg2ContentCombinator {
-    type Type = Msg2Content;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Msg2ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, Cond<U32Le>>, Msg2ContentMapper>;
-
-
-pub closed spec fn spec_msg2_content(b: Seq<u8>) -> SpecMsg2ContentCombinator {
-    SpecMsg2ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: b == seq![22u8, 3u8, 1u8], inner: U16Le }, Cond { cond: !(b == seq![22u8, 3u8, 1u8]), inner: U32Le }), mapper: Msg2ContentMapper::spec_new() })
-}
-
-                
-pub fn msg2_content<'a>(b: &'a [u8]) -> (o: Msg2ContentCombinator)
-    ensures o@ == spec_msg2_content(b@),
-{
-    Msg2ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: compare_slice(b, [22, 3, 1].as_slice()), inner: U16Le }, Cond { cond: !(compare_slice(b, [22, 3, 1].as_slice())), inner: U32Le }), mapper: Msg2ContentMapper::new() })
-}
-
-                
-
-pub struct SpecMsg2 {
-    pub b: Seq<u8>,
-    pub content: SpecMsg2Content,
-}
-
-pub type SpecMsg2Inner = (Seq<u8>, SpecMsg2Content);
-impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
-    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
-        (m.b, m.content)
-    }
-}
-impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
-    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
-        let (b, content) = m;
-        SpecMsg2 { b, content }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct Msg2<'a> {
-    pub b: &'a [u8],
-    pub content: Msg2Content,
-}
-
-impl View for Msg2<'_> {
-    type V = SpecMsg2;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg2 {
-            b: self.b@,
-            content: self.content@,
-        }
-    }
-}
-pub type Msg2Inner<'a> = (&'a [u8], Msg2Content);
-impl<'a> From<Msg2<'a>> for Msg2Inner<'a> {
-    fn ex_from(m: Msg2) -> Msg2Inner {
-        (m.b, m.content)
-    }
-}
-impl<'a> From<Msg2Inner<'a>> for Msg2<'a> {
-    fn ex_from(m: Msg2Inner) -> Msg2 {
-        let (b, content) = m;
-        Msg2 { b, content }
-    }
-}
-
-pub struct Msg2Mapper<'a>(PhantomData<&'a ()>);
-impl<'a> Msg2Mapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        Msg2Mapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        Msg2Mapper(PhantomData)
-    }
-}
-impl View for Msg2Mapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Msg2Mapper<'_> {
-    type Src = SpecMsg2Inner;
-    type Dst = SpecMsg2;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for Msg2Mapper<'a> {
-    type Src = Msg2Inner<'a>;
-    type Dst = Msg2<'a>;
-}
-
-pub struct SpecMsg2Combinator(SpecMsg2CombinatorAlias);
-
-impl SpecCombinator for SpecMsg2Combinator {
-    type Type = SpecMsg2;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsg2Combinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsg2CombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsg2CombinatorAlias = Mapped<SpecDepend<BytesN<3>, SpecMsg2ContentCombinator>, Msg2Mapper<'static>>;
-
-pub struct Msg2Combinator<'a>(Msg2CombinatorAlias<'a>);
-
-impl<'a> View for Msg2Combinator<'a> {
-    type V = SpecMsg2Combinator;
-    closed spec fn view(&self) -> Self::V { SpecMsg2Combinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg2Combinator<'a> {
-    type Type = Msg2<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Msg2CombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, BytesN<3>, Msg2ContentCombinator, Msg2Cont0<'a>>, Msg2Mapper<'a>>;
-
-
-pub closed spec fn spec_msg2() -> SpecMsg2Combinator {
-    SpecMsg2Combinator(
-    Mapped {
-        inner: SpecDepend { fst: BytesN::<3>, snd: |deps| spec_msg2_cont0(deps) },
-        mapper: Msg2Mapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_msg2_cont0(deps: Seq<u8>) -> SpecMsg2ContentCombinator {
-    let b = deps;
-    spec_msg2_content(b)
-}
-                
-pub fn msg2<'a>() -> (o: Msg2Combinator<'a>)
-    ensures o@ == spec_msg2(),
-{
-    Msg2Combinator(
-    Mapped {
-        inner: Depend { fst: BytesN::<3>, snd: Msg2Cont0::new(), spec_snd: Ghost(|deps| spec_msg2_cont0(deps)) },
-        mapper: Msg2Mapper::new(),
-    })
-}
-
-pub struct Msg2Cont0<'a>(PhantomData<&'a ()>);
-impl<'a> Msg2Cont0<'a> {
-    pub fn new() -> Self {
-        Msg2Cont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&&'a [u8]> for Msg2Cont0<'a> {
-    type Output = Msg2ContentCombinator;
-
-    open spec fn requires(&self, deps: &&'a [u8]) -> bool { true }
-
-    open spec fn ensures(&self, deps: &&'a [u8], o: Self::Output) -> bool {
-        o@ == spec_msg2_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &&'a [u8]) -> Self::Output {
-        let b = *deps;
-        msg2_content(b)
-    }
-}
-                
-
-pub struct SpecMsg4 {
-    pub i: u24,
-    pub content: SpecMsg4Content,
-}
-
-pub type SpecMsg4Inner = (u24, SpecMsg4Content);
-impl SpecFrom<SpecMsg4> for SpecMsg4Inner {
-    open spec fn spec_from(m: SpecMsg4) -> SpecMsg4Inner {
-        (m.i, m.content)
-    }
-}
-impl SpecFrom<SpecMsg4Inner> for SpecMsg4 {
-    open spec fn spec_from(m: SpecMsg4Inner) -> SpecMsg4 {
-        let (i, content) = m;
-        SpecMsg4 { i, content }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct Msg4<'a> {
-    pub i: u24,
-    pub content: Msg4Content<'a>,
-}
-
-impl View for Msg4<'_> {
-    type V = SpecMsg4;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMsg4 {
-            i: self.i@,
-            content: self.content@,
-        }
-    }
-}
-pub type Msg4Inner<'a> = (u24, Msg4Content<'a>);
-impl<'a> From<Msg4<'a>> for Msg4Inner<'a> {
-    fn ex_from(m: Msg4) -> Msg4Inner {
-        (m.i, m.content)
-    }
-}
-impl<'a> From<Msg4Inner<'a>> for Msg4<'a> {
-    fn ex_from(m: Msg4Inner) -> Msg4 {
-        let (i, content) = m;
-        Msg4 { i, content }
-    }
-}
-
-pub struct Msg4Mapper<'a>(PhantomData<&'a ()>);
-impl<'a> Msg4Mapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        Msg4Mapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        Msg4Mapper(PhantomData)
-    }
-}
-impl View for Msg4Mapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Msg4Mapper<'_> {
-    type Src = SpecMsg4Inner;
-    type Dst = SpecMsg4;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for Msg4Mapper<'a> {
-    type Src = Msg4Inner<'a>;
-    type Dst = Msg4<'a>;
-}
-
-pub struct SpecMsg4Combinator(SpecMsg4CombinatorAlias);
-
-impl SpecCombinator for SpecMsg4Combinator {
-    type Type = SpecMsg4;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMsg4Combinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMsg4CombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMsg4CombinatorAlias = Mapped<SpecDepend<U24Le, SpecMsg4ContentCombinator>, Msg4Mapper<'static>>;
-
-pub struct Msg4Combinator<'a>(Msg4CombinatorAlias<'a>);
-
-impl<'a> View for Msg4Combinator<'a> {
-    type V = SpecMsg4Combinator;
-    closed spec fn view(&self) -> Self::V { SpecMsg4Combinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg4Combinator<'a> {
-    type Type = Msg4<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Msg4CombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U24Le, Msg4ContentCombinator<'a>, Msg4Cont0<'a>>, Msg4Mapper<'a>>;
-
-
-pub closed spec fn spec_msg4() -> SpecMsg4Combinator {
-    SpecMsg4Combinator(
-    Mapped {
-        inner: SpecDepend { fst: U24Le, snd: |deps| spec_msg4_cont0(deps) },
-        mapper: Msg4Mapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_msg4_cont0(deps: u24) -> SpecMsg4ContentCombinator {
-    let i = deps;
-    spec_msg4_content(i)
-}
-                
-pub fn msg4<'a>() -> (o: Msg4Combinator<'a>)
-    ensures o@ == spec_msg4(),
-{
-    Msg4Combinator(
-    Mapped {
-        inner: Depend { fst: U24Le, snd: Msg4Cont0::new(), spec_snd: Ghost(|deps| spec_msg4_cont0(deps)) },
-        mapper: Msg4Mapper::new(),
-    })
-}
-
-pub struct Msg4Cont0<'a>(PhantomData<&'a ()>);
-impl<'a> Msg4Cont0<'a> {
-    pub fn new() -> Self {
-        Msg4Cont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u24> for Msg4Cont0<'a> {
-    type Output = Msg4ContentCombinator<'a>;
-
-    open spec fn requires(&self, deps: &u24) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u24, o: Self::Output) -> bool {
-        o@ == spec_msg4_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u24) -> Self::Output {
-        let i = *deps;
-        msg4_content(i)
     }
 }
                 
@@ -1448,6 +590,8 @@ impl View for Msg1PayloadMapper {
 impl SpecIso for Msg1PayloadMapper {
     type Src = SpecMsg1PayloadInner;
     type Dst = SpecMsg1Payload;
+}
+impl SpecIsoProof for Msg1PayloadMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -1516,13 +660,353 @@ pub closed spec fn spec_msg1_payload(b: Seq<u8>) -> SpecMsg1PayloadCombinator {
     SpecMsg1PayloadCombinator(Mapped { inner: OrdChoice(Cond { cond: b == seq![207u8, 33u8, 173u8, 116u8, 229u8, 154u8, 97u8, 17u8, 190u8, 29u8, 140u8, 2u8, 30u8, 101u8, 184u8, 145u8, 194u8, 162u8, 17u8, 22u8, 122u8, 187u8, 140u8, 94u8, 7u8, 158u8, 9u8, 226u8, 200u8, 168u8, 51u8, 156u8], inner: spec_hello_retry_request() }, Cond { cond: !(b == seq![207u8, 33u8, 173u8, 116u8, 229u8, 154u8, 97u8, 17u8, 190u8, 29u8, 140u8, 2u8, 30u8, 101u8, 184u8, 145u8, 194u8, 162u8, 17u8, 22u8, 122u8, 187u8, 140u8, 94u8, 7u8, 158u8, 9u8, 226u8, 200u8, 168u8, 51u8, 156u8]), inner: spec_server_hello() }), mapper: Msg1PayloadMapper::spec_new() })
 }
 
-                
 pub fn msg1_payload<'a>(b: &'a [u8]) -> (o: Msg1PayloadCombinator)
     ensures o@ == spec_msg1_payload(b@),
 {
     Msg1PayloadCombinator(Mapped { inner: OrdChoice::new(Cond { cond: compare_slice(b, [207, 33, 173, 116, 229, 154, 97, 17, 190, 29, 140, 2, 30, 101, 184, 145, 194, 162, 17, 22, 122, 187, 140, 94, 7, 158, 9, 226, 200, 168, 51, 156].as_slice()), inner: hello_retry_request() }, Cond { cond: !(compare_slice(b, [207, 33, 173, 116, 229, 154, 97, 17, 190, 29, 140, 2, 30, 101, 184, 145, 194, 162, 17, 22, 122, 187, 140, 94, 7, 158, 9, 226, 200, 168, 51, 156].as_slice())), inner: server_hello() }), mapper: Msg1PayloadMapper::new() })
 }
 
+
+pub enum SpecMsg4Content {
+    Variant0(u16),
+    Variant1(Seq<u8>),
+}
+
+pub type SpecMsg4ContentInner = Either<u16, Seq<u8>>;
+
+
+
+impl SpecFrom<SpecMsg4Content> for SpecMsg4ContentInner {
+    open spec fn spec_from(m: SpecMsg4Content) -> SpecMsg4ContentInner {
+        match m {
+            SpecMsg4Content::Variant0(m) => Either::Left(m),
+            SpecMsg4Content::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecMsg4ContentInner> for SpecMsg4Content {
+    open spec fn spec_from(m: SpecMsg4ContentInner) -> SpecMsg4Content {
+        match m {
+            Either::Left(m) => SpecMsg4Content::Variant0(m),
+            Either::Right(m) => SpecMsg4Content::Variant1(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Msg4Content<'a> {
+    Variant0(u16),
+    Variant1(&'a [u8]),
+}
+
+pub type Msg4ContentInner<'a> = Either<u16, &'a [u8]>;
+
+
+impl<'a> View for Msg4Content<'a> {
+    type V = SpecMsg4Content;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            Msg4Content::Variant0(m) => SpecMsg4Content::Variant0(m@),
+            Msg4Content::Variant1(m) => SpecMsg4Content::Variant1(m@),
+        }
+    }
+}
+
+
+impl<'a> From<Msg4Content<'a>> for Msg4ContentInner<'a> {
+    fn ex_from(m: Msg4Content<'a>) -> Msg4ContentInner<'a> {
+        match m {
+            Msg4Content::Variant0(m) => Either::Left(m),
+            Msg4Content::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl<'a> From<Msg4ContentInner<'a>> for Msg4Content<'a> {
+    fn ex_from(m: Msg4ContentInner<'a>) -> Msg4Content<'a> {
+        match m {
+            Either::Left(m) => Msg4Content::Variant0(m),
+            Either::Right(m) => Msg4Content::Variant1(m),
+        }
+    }
+    
+}
+
+
+pub struct Msg4ContentMapper<'a>(PhantomData<&'a ()>);
+impl<'a> Msg4ContentMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        Msg4ContentMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        Msg4ContentMapper(PhantomData)
+    }
+}
+impl View for Msg4ContentMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Msg4ContentMapper<'_> {
+    type Src = SpecMsg4ContentInner;
+    type Dst = SpecMsg4Content;
+}
+impl SpecIsoProof for Msg4ContentMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for Msg4ContentMapper<'a> {
+    type Src = Msg4ContentInner<'a>;
+    type Dst = Msg4Content<'a>;
+}
+
+
+pub struct SpecMsg4ContentCombinator(SpecMsg4ContentCombinatorAlias);
+
+impl SpecCombinator for SpecMsg4ContentCombinator {
+    type Type = SpecMsg4Content;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsg4ContentCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsg4ContentCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsg4ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, Cond<Tail>>, Msg4ContentMapper<'static>>;
+
+pub struct Msg4ContentCombinator<'a>(Msg4ContentCombinatorAlias<'a>);
+
+impl<'a> View for Msg4ContentCombinator<'a> {
+    type V = SpecMsg4ContentCombinator;
+    closed spec fn view(&self) -> Self::V { SpecMsg4ContentCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg4ContentCombinator<'a> {
+    type Type = Msg4Content<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Msg4ContentCombinatorAlias<'a> = Mapped<OrdChoice<Cond<U16Le>, Cond<Tail>>, Msg4ContentMapper<'a>>;
+
+
+pub closed spec fn spec_msg4_content(i: u24) -> SpecMsg4ContentCombinator {
+    SpecMsg4ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: i.spec_as_u32() == 1, inner: U16Le }, Cond { cond: !(i.spec_as_u32() == 1), inner: Tail }), mapper: Msg4ContentMapper::spec_new() })
+}
+
+pub fn msg4_content<'a>(i: u24) -> (o: Msg4ContentCombinator<'a>)
+    ensures o@ == spec_msg4_content(i@),
+{
+    Msg4ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: i.as_u32() == 1, inner: U16Le }, Cond { cond: !(i.as_u32() == 1), inner: Tail }), mapper: Msg4ContentMapper::new() })
+}
+
+
+pub struct SpecMsg4 {
+    pub i: u24,
+    pub content: SpecMsg4Content,
+}
+
+pub type SpecMsg4Inner = (u24, SpecMsg4Content);
+impl SpecFrom<SpecMsg4> for SpecMsg4Inner {
+    open spec fn spec_from(m: SpecMsg4) -> SpecMsg4Inner {
+        (m.i, m.content)
+    }
+}
+impl SpecFrom<SpecMsg4Inner> for SpecMsg4 {
+    open spec fn spec_from(m: SpecMsg4Inner) -> SpecMsg4 {
+        let (i, content) = m;
+        SpecMsg4 { i, content }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct Msg4<'a> {
+    pub i: u24,
+    pub content: Msg4Content<'a>,
+}
+
+impl View for Msg4<'_> {
+    type V = SpecMsg4;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsg4 {
+            i: self.i@,
+            content: self.content@,
+        }
+    }
+}
+pub type Msg4Inner<'a> = (u24, Msg4Content<'a>);
+impl<'a> From<Msg4<'a>> for Msg4Inner<'a> {
+    fn ex_from(m: Msg4) -> Msg4Inner {
+        (m.i, m.content)
+    }
+}
+impl<'a> From<Msg4Inner<'a>> for Msg4<'a> {
+    fn ex_from(m: Msg4Inner) -> Msg4 {
+        let (i, content) = m;
+        Msg4 { i, content }
+    }
+}
+
+pub struct Msg4Mapper<'a>(PhantomData<&'a ()>);
+impl<'a> Msg4Mapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        Msg4Mapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        Msg4Mapper(PhantomData)
+    }
+}
+impl View for Msg4Mapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Msg4Mapper<'_> {
+    type Src = SpecMsg4Inner;
+    type Dst = SpecMsg4;
+}
+impl SpecIsoProof for Msg4Mapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for Msg4Mapper<'a> {
+    type Src = Msg4Inner<'a>;
+    type Dst = Msg4<'a>;
+}
+
+pub struct SpecMsg4Combinator(SpecMsg4CombinatorAlias);
+
+impl SpecCombinator for SpecMsg4Combinator {
+    type Type = SpecMsg4;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsg4Combinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsg4CombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsg4CombinatorAlias = Mapped<SpecDepend<U24Le, SpecMsg4ContentCombinator>, Msg4Mapper<'static>>;
+
+pub struct Msg4Combinator<'a>(Msg4CombinatorAlias<'a>);
+
+impl<'a> View for Msg4Combinator<'a> {
+    type V = SpecMsg4Combinator;
+    closed spec fn view(&self) -> Self::V { SpecMsg4Combinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg4Combinator<'a> {
+    type Type = Msg4<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Msg4CombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U24Le, Msg4ContentCombinator<'a>, Msg4Cont0<'a>>, Msg4Mapper<'a>>;
+
+
+pub closed spec fn spec_msg4() -> SpecMsg4Combinator {
+    SpecMsg4Combinator(
+    Mapped {
+        inner: SpecDepend { fst: U24Le, snd: |deps| spec_msg4_cont0(deps) },
+        mapper: Msg4Mapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_msg4_cont0(deps: u24) -> SpecMsg4ContentCombinator {
+    let i = deps;
+    spec_msg4_content(i)
+}
+                
+pub fn msg4<'a>() -> (o: Msg4Combinator<'a>)
+    ensures o@ == spec_msg4(),
+{
+    Msg4Combinator(
+    Mapped {
+        inner: Depend { fst: U24Le, snd: Msg4Cont0::new(), spec_snd: Ghost(|deps| spec_msg4_cont0(deps)) },
+        mapper: Msg4Mapper::new(),
+    })
+}
+
+pub struct Msg4Cont0<'a>(PhantomData<&'a ()>);
+impl<'a> Msg4Cont0<'a> {
+    pub fn new() -> Self {
+        Msg4Cont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u24> for Msg4Cont0<'a> {
+    type Output = Msg4ContentCombinator<'a>;
+
+    open spec fn requires(&self, deps: &u24) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u24, o: Self::Output) -> bool {
+        o@ == spec_msg4_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u24) -> Self::Output {
+        let i = *deps;
+        msg4_content(i)
+    }
+}
                 
 
 pub struct SpecMsg1 {
@@ -1590,6 +1074,8 @@ impl View for Msg1Mapper<'_> {
 impl SpecIso for Msg1Mapper<'_> {
     type Src = SpecMsg1Inner;
     type Dst = SpecMsg1;
+}
+impl SpecIsoProof for Msg1Mapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -1698,6 +1184,187 @@ impl<'a> Continuation<&&'a [u8]> for Msg1Cont0<'a> {
 }
                 
 
+pub enum SpecMsg3Content {
+    Variant0(u16),
+    Variant1(u32),
+    Variant2(u32),
+    Variant3(Seq<u8>),
+}
+
+pub type SpecMsg3ContentInner = Either<u16, Either<u32, Either<u32, Seq<u8>>>>;
+
+
+
+impl SpecFrom<SpecMsg3Content> for SpecMsg3ContentInner {
+    open spec fn spec_from(m: SpecMsg3Content) -> SpecMsg3ContentInner {
+        match m {
+            SpecMsg3Content::Variant0(m) => Either::Left(m),
+            SpecMsg3Content::Variant1(m) => Either::Right(Either::Left(m)),
+            SpecMsg3Content::Variant2(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecMsg3Content::Variant3(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecMsg3ContentInner> for SpecMsg3Content {
+    open spec fn spec_from(m: SpecMsg3ContentInner) -> SpecMsg3Content {
+        match m {
+            Either::Left(m) => SpecMsg3Content::Variant0(m),
+            Either::Right(Either::Left(m)) => SpecMsg3Content::Variant1(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecMsg3Content::Variant2(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecMsg3Content::Variant3(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Msg3Content<'a> {
+    Variant0(u16),
+    Variant1(u32),
+    Variant2(u32),
+    Variant3(&'a [u8]),
+}
+
+pub type Msg3ContentInner<'a> = Either<u16, Either<u32, Either<u32, &'a [u8]>>>;
+
+
+impl<'a> View for Msg3Content<'a> {
+    type V = SpecMsg3Content;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            Msg3Content::Variant0(m) => SpecMsg3Content::Variant0(m@),
+            Msg3Content::Variant1(m) => SpecMsg3Content::Variant1(m@),
+            Msg3Content::Variant2(m) => SpecMsg3Content::Variant2(m@),
+            Msg3Content::Variant3(m) => SpecMsg3Content::Variant3(m@),
+        }
+    }
+}
+
+
+impl<'a> From<Msg3Content<'a>> for Msg3ContentInner<'a> {
+    fn ex_from(m: Msg3Content<'a>) -> Msg3ContentInner<'a> {
+        match m {
+            Msg3Content::Variant0(m) => Either::Left(m),
+            Msg3Content::Variant1(m) => Either::Right(Either::Left(m)),
+            Msg3Content::Variant2(m) => Either::Right(Either::Right(Either::Left(m))),
+            Msg3Content::Variant3(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl<'a> From<Msg3ContentInner<'a>> for Msg3Content<'a> {
+    fn ex_from(m: Msg3ContentInner<'a>) -> Msg3Content<'a> {
+        match m {
+            Either::Left(m) => Msg3Content::Variant0(m),
+            Either::Right(Either::Left(m)) => Msg3Content::Variant1(m),
+            Either::Right(Either::Right(Either::Left(m))) => Msg3Content::Variant2(m),
+            Either::Right(Either::Right(Either::Right(m))) => Msg3Content::Variant3(m),
+        }
+    }
+    
+}
+
+
+pub struct Msg3ContentMapper<'a>(PhantomData<&'a ()>);
+impl<'a> Msg3ContentMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        Msg3ContentMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        Msg3ContentMapper(PhantomData)
+    }
+}
+impl View for Msg3ContentMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Msg3ContentMapper<'_> {
+    type Src = SpecMsg3ContentInner;
+    type Dst = SpecMsg3Content;
+}
+impl SpecIsoProof for Msg3ContentMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for Msg3ContentMapper<'a> {
+    type Src = Msg3ContentInner<'a>;
+    type Dst = Msg3Content<'a>;
+}
+
+
+pub struct SpecMsg3ContentCombinator(SpecMsg3ContentCombinatorAlias);
+
+impl SpecCombinator for SpecMsg3ContentCombinator {
+    type Type = SpecMsg3Content;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsg3ContentCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsg3ContentCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsg3ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, OrdChoice<Cond<U32Le>, OrdChoice<Cond<U32Le>, Cond<Tail>>>>, Msg3ContentMapper<'static>>;
+
+pub struct Msg3ContentCombinator<'a>(Msg3ContentCombinatorAlias<'a>);
+
+impl<'a> View for Msg3ContentCombinator<'a> {
+    type V = SpecMsg3ContentCombinator;
+    closed spec fn view(&self) -> Self::V { SpecMsg3ContentCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg3ContentCombinator<'a> {
+    type Type = Msg3Content<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Msg3ContentCombinatorAlias<'a> = Mapped<OrdChoice<Cond<U16Le>, OrdChoice<Cond<U32Le>, OrdChoice<Cond<U32Le>, Cond<Tail>>>>, Msg3ContentMapper<'a>>;
+
+
+pub closed spec fn spec_msg3_content(i: u8) -> SpecMsg3ContentCombinator {
+    SpecMsg3ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: i == 1, inner: U16Le }, OrdChoice(Cond { cond: i == 2, inner: U32Le }, OrdChoice(Cond { cond: i == 3, inner: U32Le }, Cond { cond: !(i == 1 || i == 2 || i == 3), inner: Tail }))), mapper: Msg3ContentMapper::spec_new() })
+}
+
+pub fn msg3_content<'a>(i: u8) -> (o: Msg3ContentCombinator<'a>)
+    ensures o@ == spec_msg3_content(i@),
+{
+    Msg3ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: i == 1, inner: U16Le }, OrdChoice::new(Cond { cond: i == 2, inner: U32Le }, OrdChoice::new(Cond { cond: i == 3, inner: U32Le }, Cond { cond: !(i == 1 || i == 2 || i == 3), inner: Tail }))), mapper: Msg3ContentMapper::new() })
+}
+
+
 pub struct SpecMsg3 {
     pub i: u8,
     pub content: SpecMsg3Content,
@@ -1763,6 +1430,8 @@ impl View for Msg3Mapper<'_> {
 impl SpecIso for Msg3Mapper<'_> {
     type Src = SpecMsg3Inner;
     type Dst = SpecMsg3;
+}
+impl SpecIsoProof for Msg3Mapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -1867,6 +1536,348 @@ impl<'a> Continuation<&u8> for Msg3Cont0<'a> {
     fn apply(&self, deps: &u8) -> Self::Output {
         let i = *deps;
         msg3_content(i)
+    }
+}
+                
+
+pub enum SpecMsg2Content {
+    Variant0(u16),
+    Variant1(u32),
+}
+
+pub type SpecMsg2ContentInner = Either<u16, u32>;
+
+
+
+impl SpecFrom<SpecMsg2Content> for SpecMsg2ContentInner {
+    open spec fn spec_from(m: SpecMsg2Content) -> SpecMsg2ContentInner {
+        match m {
+            SpecMsg2Content::Variant0(m) => Either::Left(m),
+            SpecMsg2Content::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecMsg2ContentInner> for SpecMsg2Content {
+    open spec fn spec_from(m: SpecMsg2ContentInner) -> SpecMsg2Content {
+        match m {
+            Either::Left(m) => SpecMsg2Content::Variant0(m),
+            Either::Right(m) => SpecMsg2Content::Variant1(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Msg2Content {
+    Variant0(u16),
+    Variant1(u32),
+}
+
+pub type Msg2ContentInner = Either<u16, u32>;
+
+
+impl View for Msg2Content {
+    type V = SpecMsg2Content;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            Msg2Content::Variant0(m) => SpecMsg2Content::Variant0(m@),
+            Msg2Content::Variant1(m) => SpecMsg2Content::Variant1(m@),
+        }
+    }
+}
+
+
+impl From<Msg2Content> for Msg2ContentInner {
+    fn ex_from(m: Msg2Content) -> Msg2ContentInner {
+        match m {
+            Msg2Content::Variant0(m) => Either::Left(m),
+            Msg2Content::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl From<Msg2ContentInner> for Msg2Content {
+    fn ex_from(m: Msg2ContentInner) -> Msg2Content {
+        match m {
+            Either::Left(m) => Msg2Content::Variant0(m),
+            Either::Right(m) => Msg2Content::Variant1(m),
+        }
+    }
+    
+}
+
+
+pub struct Msg2ContentMapper;
+impl Msg2ContentMapper {
+    pub closed spec fn spec_new() -> Self {
+        Msg2ContentMapper
+    }
+    pub fn new() -> Self {
+        Msg2ContentMapper
+    }
+}
+impl View for Msg2ContentMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Msg2ContentMapper {
+    type Src = SpecMsg2ContentInner;
+    type Dst = SpecMsg2Content;
+}
+impl SpecIsoProof for Msg2ContentMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for Msg2ContentMapper {
+    type Src = Msg2ContentInner;
+    type Dst = Msg2Content;
+}
+
+
+pub struct SpecMsg2ContentCombinator(SpecMsg2ContentCombinatorAlias);
+
+impl SpecCombinator for SpecMsg2ContentCombinator {
+    type Type = SpecMsg2Content;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsg2ContentCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsg2ContentCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsg2ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, Cond<U32Le>>, Msg2ContentMapper>;
+
+pub struct Msg2ContentCombinator(Msg2ContentCombinatorAlias);
+
+impl View for Msg2ContentCombinator {
+    type V = SpecMsg2ContentCombinator;
+    closed spec fn view(&self) -> Self::V { SpecMsg2ContentCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg2ContentCombinator {
+    type Type = Msg2Content;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Msg2ContentCombinatorAlias = Mapped<OrdChoice<Cond<U16Le>, Cond<U32Le>>, Msg2ContentMapper>;
+
+
+pub closed spec fn spec_msg2_content(b: Seq<u8>) -> SpecMsg2ContentCombinator {
+    SpecMsg2ContentCombinator(Mapped { inner: OrdChoice(Cond { cond: b == seq![22u8, 3u8, 1u8], inner: U16Le }, Cond { cond: !(b == seq![22u8, 3u8, 1u8]), inner: U32Le }), mapper: Msg2ContentMapper::spec_new() })
+}
+
+pub fn msg2_content<'a>(b: &'a [u8]) -> (o: Msg2ContentCombinator)
+    ensures o@ == spec_msg2_content(b@),
+{
+    Msg2ContentCombinator(Mapped { inner: OrdChoice::new(Cond { cond: compare_slice(b, [22, 3, 1].as_slice()), inner: U16Le }, Cond { cond: !(compare_slice(b, [22, 3, 1].as_slice())), inner: U32Le }), mapper: Msg2ContentMapper::new() })
+}
+
+
+pub struct SpecMsg2 {
+    pub b: Seq<u8>,
+    pub content: SpecMsg2Content,
+}
+
+pub type SpecMsg2Inner = (Seq<u8>, SpecMsg2Content);
+impl SpecFrom<SpecMsg2> for SpecMsg2Inner {
+    open spec fn spec_from(m: SpecMsg2) -> SpecMsg2Inner {
+        (m.b, m.content)
+    }
+}
+impl SpecFrom<SpecMsg2Inner> for SpecMsg2 {
+    open spec fn spec_from(m: SpecMsg2Inner) -> SpecMsg2 {
+        let (b, content) = m;
+        SpecMsg2 { b, content }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct Msg2<'a> {
+    pub b: &'a [u8],
+    pub content: Msg2Content,
+}
+
+impl View for Msg2<'_> {
+    type V = SpecMsg2;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMsg2 {
+            b: self.b@,
+            content: self.content@,
+        }
+    }
+}
+pub type Msg2Inner<'a> = (&'a [u8], Msg2Content);
+impl<'a> From<Msg2<'a>> for Msg2Inner<'a> {
+    fn ex_from(m: Msg2) -> Msg2Inner {
+        (m.b, m.content)
+    }
+}
+impl<'a> From<Msg2Inner<'a>> for Msg2<'a> {
+    fn ex_from(m: Msg2Inner) -> Msg2 {
+        let (b, content) = m;
+        Msg2 { b, content }
+    }
+}
+
+pub struct Msg2Mapper<'a>(PhantomData<&'a ()>);
+impl<'a> Msg2Mapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        Msg2Mapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        Msg2Mapper(PhantomData)
+    }
+}
+impl View for Msg2Mapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Msg2Mapper<'_> {
+    type Src = SpecMsg2Inner;
+    type Dst = SpecMsg2;
+}
+impl SpecIsoProof for Msg2Mapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for Msg2Mapper<'a> {
+    type Src = Msg2Inner<'a>;
+    type Dst = Msg2<'a>;
+}
+
+pub struct SpecMsg2Combinator(SpecMsg2CombinatorAlias);
+
+impl SpecCombinator for SpecMsg2Combinator {
+    type Type = SpecMsg2;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMsg2Combinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMsg2CombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMsg2CombinatorAlias = Mapped<SpecDepend<BytesN<3>, SpecMsg2ContentCombinator>, Msg2Mapper<'static>>;
+
+pub struct Msg2Combinator<'a>(Msg2CombinatorAlias<'a>);
+
+impl<'a> View for Msg2Combinator<'a> {
+    type V = SpecMsg2Combinator;
+    closed spec fn view(&self) -> Self::V { SpecMsg2Combinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Msg2Combinator<'a> {
+    type Type = Msg2<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Msg2CombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, BytesN<3>, Msg2ContentCombinator, Msg2Cont0<'a>>, Msg2Mapper<'a>>;
+
+
+pub closed spec fn spec_msg2() -> SpecMsg2Combinator {
+    SpecMsg2Combinator(
+    Mapped {
+        inner: SpecDepend { fst: BytesN::<3>, snd: |deps| spec_msg2_cont0(deps) },
+        mapper: Msg2Mapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_msg2_cont0(deps: Seq<u8>) -> SpecMsg2ContentCombinator {
+    let b = deps;
+    spec_msg2_content(b)
+}
+                
+pub fn msg2<'a>() -> (o: Msg2Combinator<'a>)
+    ensures o@ == spec_msg2(),
+{
+    Msg2Combinator(
+    Mapped {
+        inner: Depend { fst: BytesN::<3>, snd: Msg2Cont0::new(), spec_snd: Ghost(|deps| spec_msg2_cont0(deps)) },
+        mapper: Msg2Mapper::new(),
+    })
+}
+
+pub struct Msg2Cont0<'a>(PhantomData<&'a ()>);
+impl<'a> Msg2Cont0<'a> {
+    pub fn new() -> Self {
+        Msg2Cont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&&'a [u8]> for Msg2Cont0<'a> {
+    type Output = Msg2ContentCombinator;
+
+    open spec fn requires(&self, deps: &&'a [u8]) -> bool { true }
+
+    open spec fn ensures(&self, deps: &&'a [u8], o: Self::Output) -> bool {
+        o@ == spec_msg2_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &&'a [u8]) -> Self::Output {
+        let b = *deps;
+        msg2_content(b)
     }
 }
                 

--- a/vest-dsl/test/src/opt.rs
+++ b/vest-dsl/test/src/opt.rs
@@ -21,240 +21,8 @@ use vest::bitcoin::varint::{BtcVarint, VarInt};
 use vest::regular::preceded::*;
 use vest::regular::terminated::*;
 use vest::regular::disjoint::DisjointFrom;
+use vest::regular::leb128::*;
 verus!{
-pub type SpecA = Seq<u8>;
-pub type A<'a> = &'a [u8];
-
-pub const A_0_FRONT_CONST: u8 = 1;
-
-pub const A_1_FRONT_CONST: u8 = 2;
-
-pub const A_0_BACK_CONST: u8 = 3;
-
-pub struct SpecACombinator(SpecACombinatorAlias);
-
-impl SpecCombinator for SpecACombinator {
-    type Type = SpecA;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecACombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecACombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecACombinatorAlias = Terminated<Preceded<Tag<U8, u8>, Preceded<Tag<U8, u8>, BytesN<10>>>, Tag<U8, u8>>;
-
-
-
-pub struct ACombinator(ACombinatorAlias);
-
-impl View for ACombinator {
-    type V = SpecACombinator;
-    closed spec fn view(&self) -> Self::V { SpecACombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ACombinator {
-    type Type = A<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ACombinatorAlias = Terminated<Preceded<Tag<U8, u8>, Preceded<Tag<U8, u8>, BytesN<10>>>, Tag<U8, u8>>;
-
-
-pub closed spec fn spec_a() -> SpecACombinator {
-    SpecACombinator(Terminated(Preceded(Tag::spec_new(U8, A_0_FRONT_CONST), Preceded(Tag::spec_new(U8, A_1_FRONT_CONST), BytesN::<10>)), Tag::spec_new(U8, A_0_BACK_CONST)))
-}
-
-                
-pub fn a() -> (o: ACombinator)
-    ensures o@ == spec_a(),
-{
-    ACombinator(Terminated(Preceded(Tag::new(U8, A_0_FRONT_CONST), Preceded(Tag::new(U8, A_1_FRONT_CONST), BytesN::<10>)), Tag::new(U8, A_0_BACK_CONST)))
-}
-
-                
-
-pub struct SpecB {
-    pub x: Seq<u8>,
-    pub y: SpecA,
-}
-
-pub type SpecBInner = (Seq<u8>, SpecA);
-impl SpecFrom<SpecB> for SpecBInner {
-    open spec fn spec_from(m: SpecB) -> SpecBInner {
-        (m.x, m.y)
-    }
-}
-impl SpecFrom<SpecBInner> for SpecB {
-    open spec fn spec_from(m: SpecBInner) -> SpecB {
-        let (x, y) = m;
-        SpecB { x, y }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct B<'a> {
-    pub x: &'a [u8],
-    pub y: A<'a>,
-}
-
-impl View for B<'_> {
-    type V = SpecB;
-
-    open spec fn view(&self) -> Self::V {
-        SpecB {
-            x: self.x@,
-            y: self.y@,
-        }
-    }
-}
-pub type BInner<'a> = (&'a [u8], A<'a>);
-impl<'a> From<B<'a>> for BInner<'a> {
-    fn ex_from(m: B) -> BInner {
-        (m.x, m.y)
-    }
-}
-impl<'a> From<BInner<'a>> for B<'a> {
-    fn ex_from(m: BInner) -> B {
-        let (x, y) = m;
-        B { x, y }
-    }
-}
-
-pub struct BMapper<'a>(PhantomData<&'a ()>);
-impl<'a> BMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        BMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        BMapper(PhantomData)
-    }
-}
-impl View for BMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for BMapper<'_> {
-    type Src = SpecBInner;
-    type Dst = SpecB;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for BMapper<'a> {
-    type Src = BInner<'a>;
-    type Dst = B<'a>;
-}
-pub spec const SPEC_BY_0_FRONT_CONST: Seq<u8> = seq![1, 2, 3];
-pub const BY_0_BACK_CONST: u8 = 1;
-
-pub struct SpecBCombinator(SpecBCombinatorAlias);
-
-impl SpecCombinator for SpecBCombinator {
-    type Type = SpecB;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecBCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecBCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecBCombinatorAlias = Mapped<(BytesN<10>, Terminated<Preceded<Tag<BytesN<3>, Seq<u8>>, SpecACombinator>, Tag<U8, u8>>), BMapper<'static>>;
-pub exec static BY_0_FRONT_CONST: [u8; 3]
-    ensures BY_0_FRONT_CONST@ == SPEC_BY_0_FRONT_CONST,
-{
-    let arr: [u8; 3] = [1, 2, 3];
-    assert(arr@ == SPEC_BY_0_FRONT_CONST);
-    arr
-}
-
-
-pub struct BCombinator<'a>(BCombinatorAlias<'a>);
-
-impl<'a> View for BCombinator<'a> {
-    type V = SpecBCombinator;
-    closed spec fn view(&self) -> Self::V { SpecBCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for BCombinator<'a> {
-    type Type = B<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type BCombinatorAlias<'a> = Mapped<(BytesN<10>, Terminated<Preceded<Tag<BytesN<3>, &'a [u8]>, ACombinator>, Tag<U8, u8>>), BMapper<'a>>;
-
-
-pub closed spec fn spec_b() -> SpecBCombinator {
-    SpecBCombinator(
-    Mapped {
-        inner: (BytesN::<10>, Terminated(Preceded(Tag::spec_new(BytesN::<3>, SPEC_BY_0_FRONT_CONST), spec_a()), Tag::spec_new(U8, BY_0_BACK_CONST))),
-        mapper: BMapper::spec_new(),
-    })
-}
-
-                
-pub fn b<'a>() -> (o: BCombinator<'a>)
-    ensures o@ == spec_b(),
-{
-    BCombinator(
-    Mapped {
-        inner: (BytesN::<10>, Terminated(Preceded(Tag::new(BytesN::<3>, BY_0_FRONT_CONST.as_slice()), a()), Tag::new(U8, BY_0_BACK_CONST))),
-        mapper: BMapper::new(),
-    })
-}
-
-                
 
 pub struct SpecMsg {
     pub a: u8,
@@ -321,6 +89,8 @@ impl View for MsgMapper<'_> {
 impl SpecIso for MsgMapper<'_> {
     type Src = SpecMsgInner;
     type Dst = SpecMsg;
+}
+impl SpecIsoProof for MsgMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -412,6 +182,80 @@ pub fn msg<'a>() -> (o: MsgCombinator<'a>)
 }
 
                 
+pub type SpecA = Seq<u8>;
+pub type A<'a> = &'a [u8];
+
+pub const A_0_FRONT_CONST: u8 = 1;
+
+pub const A_1_FRONT_CONST: u8 = 2;
+
+pub const A_0_BACK_CONST: u8 = 3;
+
+pub struct SpecACombinator(SpecACombinatorAlias);
+
+impl SpecCombinator for SpecACombinator {
+    type Type = SpecA;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecACombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecACombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecACombinatorAlias = Terminated<Preceded<Tag<U8, u8>, Preceded<Tag<U8, u8>, BytesN<10>>>, Tag<U8, u8>>;
+
+
+
+pub struct ACombinator(ACombinatorAlias);
+
+impl View for ACombinator {
+    type V = SpecACombinator;
+    closed spec fn view(&self) -> Self::V { SpecACombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ACombinator {
+    type Type = A<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ACombinatorAlias = Terminated<Preceded<Tag<U8, u8>, Preceded<Tag<U8, u8>, BytesN<10>>>, Tag<U8, u8>>;
+
+
+pub closed spec fn spec_a() -> SpecACombinator {
+    SpecACombinator(Terminated(Preceded(Tag::spec_new(U8, A_0_FRONT_CONST), Preceded(Tag::spec_new(U8, A_1_FRONT_CONST), BytesN::<10>)), Tag::spec_new(U8, A_0_BACK_CONST)))
+}
+
+                
+pub fn a() -> (o: ACombinator)
+    ensures o@ == spec_a(),
+{
+    ACombinator(Terminated(Preceded(Tag::new(U8, A_0_FRONT_CONST), Preceded(Tag::new(U8, A_1_FRONT_CONST), BytesN::<10>)), Tag::new(U8, A_0_BACK_CONST)))
+}
+
+                
 pub type SpecOptmsg = Option<SpecMsg>;
 pub type Optmsg<'a> = Optional<Msg<'a>>;
 
@@ -476,6 +320,167 @@ pub fn optmsg<'a>() -> (o: OptmsgCombinator<'a>)
     ensures o@ == spec_optmsg(),
 {
     OptmsgCombinator(Opt::new(msg()))
+}
+
+                
+
+pub struct SpecB {
+    pub x: Seq<u8>,
+    pub y: SpecA,
+}
+
+pub type SpecBInner = (Seq<u8>, SpecA);
+impl SpecFrom<SpecB> for SpecBInner {
+    open spec fn spec_from(m: SpecB) -> SpecBInner {
+        (m.x, m.y)
+    }
+}
+impl SpecFrom<SpecBInner> for SpecB {
+    open spec fn spec_from(m: SpecBInner) -> SpecB {
+        let (x, y) = m;
+        SpecB { x, y }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct B<'a> {
+    pub x: &'a [u8],
+    pub y: A<'a>,
+}
+
+impl View for B<'_> {
+    type V = SpecB;
+
+    open spec fn view(&self) -> Self::V {
+        SpecB {
+            x: self.x@,
+            y: self.y@,
+        }
+    }
+}
+pub type BInner<'a> = (&'a [u8], A<'a>);
+impl<'a> From<B<'a>> for BInner<'a> {
+    fn ex_from(m: B) -> BInner {
+        (m.x, m.y)
+    }
+}
+impl<'a> From<BInner<'a>> for B<'a> {
+    fn ex_from(m: BInner) -> B {
+        let (x, y) = m;
+        B { x, y }
+    }
+}
+
+pub struct BMapper<'a>(PhantomData<&'a ()>);
+impl<'a> BMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        BMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        BMapper(PhantomData)
+    }
+}
+impl View for BMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for BMapper<'_> {
+    type Src = SpecBInner;
+    type Dst = SpecB;
+}
+impl SpecIsoProof for BMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for BMapper<'a> {
+    type Src = BInner<'a>;
+    type Dst = B<'a>;
+}
+pub spec const SPEC_BY_0_FRONT_CONST: Seq<u8> = seq![1, 2, 3];
+pub const BY_0_BACK_CONST: u8 = 1;
+
+pub struct SpecBCombinator(SpecBCombinatorAlias);
+
+impl SpecCombinator for SpecBCombinator {
+    type Type = SpecB;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecBCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecBCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecBCombinatorAlias = Mapped<(BytesN<10>, Terminated<Preceded<Tag<BytesN<3>, Seq<u8>>, SpecACombinator>, Tag<U8, u8>>), BMapper<'static>>;
+pub exec static BY_0_FRONT_CONST: [u8; 3]
+    ensures BY_0_FRONT_CONST@ == SPEC_BY_0_FRONT_CONST,
+{
+    let arr: [u8; 3] = [1, 2, 3];
+    assert(arr@ == SPEC_BY_0_FRONT_CONST);
+    arr
+}
+
+
+pub struct BCombinator<'a>(BCombinatorAlias<'a>);
+
+impl<'a> View for BCombinator<'a> {
+    type V = SpecBCombinator;
+    closed spec fn view(&self) -> Self::V { SpecBCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for BCombinator<'a> {
+    type Type = B<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type BCombinatorAlias<'a> = Mapped<(BytesN<10>, Terminated<Preceded<Tag<BytesN<3>, &'a [u8]>, ACombinator>, Tag<U8, u8>>), BMapper<'a>>;
+
+
+pub closed spec fn spec_b() -> SpecBCombinator {
+    SpecBCombinator(
+    Mapped {
+        inner: (BytesN::<10>, Terminated(Preceded(Tag::spec_new(BytesN::<3>, SPEC_BY_0_FRONT_CONST), spec_a()), Tag::spec_new(U8, BY_0_BACK_CONST))),
+        mapper: BMapper::spec_new(),
+    })
+}
+
+                
+pub fn b<'a>() -> (o: BCombinator<'a>)
+    ensures o@ == spec_b(),
+{
+    BCombinator(
+    Mapped {
+        inner: (BytesN::<10>, Terminated(Preceded(Tag::new(BytesN::<3>, BY_0_FRONT_CONST.as_slice()), a()), Tag::new(U8, BY_0_BACK_CONST))),
+        mapper: BMapper::new(),
+    })
 }
 
                 

--- a/vest-dsl/test/src/repeat.rs
+++ b/vest-dsl/test/src/repeat.rs
@@ -21,6 +21,7 @@ use vest::bitcoin::varint::{BtcVarint, VarInt};
 use vest::regular::preceded::*;
 use vest::regular::terminated::*;
 use vest::regular::disjoint::DisjointFrom;
+use vest::regular::leb128::*;
 verus!{
 
 pub struct SpecOpaqueU16 {
@@ -88,6 +89,8 @@ impl View for OpaqueU16Mapper<'_> {
 impl SpecIso for OpaqueU16Mapper<'_> {
     type Src = SpecOpaqueU16Inner;
     type Dst = SpecOpaqueU16;
+}
+impl SpecIsoProof for OpaqueU16Mapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -352,6 +355,8 @@ impl View for ResponderIdListMapper<'_> {
 impl SpecIso for ResponderIdListMapper<'_> {
     type Src = SpecResponderIdListInner;
     type Dst = SpecResponderIdList;
+}
+impl SpecIsoProof for ResponderIdListMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -549,6 +554,8 @@ impl View for RepeatDynMapper<'_> {
 impl SpecIso for RepeatDynMapper<'_> {
     type Src = SpecRepeatDynInner;
     type Dst = SpecRepeatDyn;
+}
+impl SpecIsoProof for RepeatDynMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }

--- a/vest-dsl/tls/src/tls_combinators.rs
+++ b/vest-dsl/tls/src/tls_combinators.rs
@@ -21,94 +21,24 @@ use vest::bitcoin::varint::{BtcVarint, VarInt};
 use vest::regular::preceded::*;
 use vest::regular::terminated::*;
 use vest::regular::disjoint::DisjointFrom;
+use vest::regular::leb128::*;
 verus!{
+pub type SpecSignatureScheme = u16;
+pub type SignatureScheme = u16;
 
-pub struct SpecEarlyDataIndicationNewSessionTicket {
-    pub max_early_data_size: u32,
-}
 
-pub type SpecEarlyDataIndicationNewSessionTicketInner = u32;
-impl SpecFrom<SpecEarlyDataIndicationNewSessionTicket> for SpecEarlyDataIndicationNewSessionTicketInner {
-    open spec fn spec_from(m: SpecEarlyDataIndicationNewSessionTicket) -> SpecEarlyDataIndicationNewSessionTicketInner {
-        m.max_early_data_size
-    }
-}
-impl SpecFrom<SpecEarlyDataIndicationNewSessionTicketInner> for SpecEarlyDataIndicationNewSessionTicket {
-    open spec fn spec_from(m: SpecEarlyDataIndicationNewSessionTicketInner) -> SpecEarlyDataIndicationNewSessionTicket {
-        let max_early_data_size = m;
-        SpecEarlyDataIndicationNewSessionTicket { max_early_data_size }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecSignatureSchemeCombinator(SpecSignatureSchemeCombinatorAlias);
 
-pub struct EarlyDataIndicationNewSessionTicket {
-    pub max_early_data_size: u32,
-}
-
-impl View for EarlyDataIndicationNewSessionTicket {
-    type V = SpecEarlyDataIndicationNewSessionTicket;
-
-    open spec fn view(&self) -> Self::V {
-        SpecEarlyDataIndicationNewSessionTicket {
-            max_early_data_size: self.max_early_data_size@,
-        }
-    }
-}
-pub type EarlyDataIndicationNewSessionTicketInner = u32;
-impl From<EarlyDataIndicationNewSessionTicket> for EarlyDataIndicationNewSessionTicketInner {
-    fn ex_from(m: EarlyDataIndicationNewSessionTicket) -> EarlyDataIndicationNewSessionTicketInner {
-        m.max_early_data_size
-    }
-}
-impl From<EarlyDataIndicationNewSessionTicketInner> for EarlyDataIndicationNewSessionTicket {
-    fn ex_from(m: EarlyDataIndicationNewSessionTicketInner) -> EarlyDataIndicationNewSessionTicket {
-        let max_early_data_size = m;
-        EarlyDataIndicationNewSessionTicket { max_early_data_size }
-    }
-}
-
-pub struct EarlyDataIndicationNewSessionTicketMapper;
-impl EarlyDataIndicationNewSessionTicketMapper {
-    pub closed spec fn spec_new() -> Self {
-        EarlyDataIndicationNewSessionTicketMapper
-    }
-    pub fn new() -> Self {
-        EarlyDataIndicationNewSessionTicketMapper
-    }
-}
-impl View for EarlyDataIndicationNewSessionTicketMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for EarlyDataIndicationNewSessionTicketMapper {
-    type Src = SpecEarlyDataIndicationNewSessionTicketInner;
-    type Dst = SpecEarlyDataIndicationNewSessionTicket;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for EarlyDataIndicationNewSessionTicketMapper {
-    type Src = EarlyDataIndicationNewSessionTicketInner;
-    type Dst = EarlyDataIndicationNewSessionTicket;
-}
-
-pub struct SpecEarlyDataIndicationNewSessionTicketCombinator(SpecEarlyDataIndicationNewSessionTicketCombinatorAlias);
-
-impl SpecCombinator for SpecEarlyDataIndicationNewSessionTicketCombinator {
-    type Type = SpecEarlyDataIndicationNewSessionTicket;
+impl SpecCombinator for SpecSignatureSchemeCombinator {
+    type Type = SpecSignatureScheme;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecEarlyDataIndicationNewSessionTicketCombinator {
+impl SecureSpecCombinator for SpecSignatureSchemeCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecEarlyDataIndicationNewSessionTicketCombinatorAlias::is_prefix_secure() }
+    { SpecSignatureSchemeCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -122,16 +52,16 @@ impl SecureSpecCombinator for SpecEarlyDataIndicationNewSessionTicketCombinator 
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecEarlyDataIndicationNewSessionTicketCombinatorAlias = Mapped<U32Be, EarlyDataIndicationNewSessionTicketMapper>;
+pub type SpecSignatureSchemeCombinatorAlias = U16Be;
 
-pub struct EarlyDataIndicationNewSessionTicketCombinator(EarlyDataIndicationNewSessionTicketCombinatorAlias);
+pub struct SignatureSchemeCombinator(SignatureSchemeCombinatorAlias);
 
-impl View for EarlyDataIndicationNewSessionTicketCombinator {
-    type V = SpecEarlyDataIndicationNewSessionTicketCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEarlyDataIndicationNewSessionTicketCombinator(self.0@) }
+impl View for SignatureSchemeCombinator {
+    type V = SpecSignatureSchemeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSignatureSchemeCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EarlyDataIndicationNewSessionTicketCombinator {
-    type Type = EarlyDataIndicationNewSessionTicket;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SignatureSchemeCombinator {
+    type Type = SignatureScheme;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -145,95 +75,89 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for EarlyDataIndicationNewSessionTicketCo
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type EarlyDataIndicationNewSessionTicketCombinatorAlias = Mapped<U32Be, EarlyDataIndicationNewSessionTicketMapper>;
+pub type SignatureSchemeCombinatorAlias = U16Be;
 
 
-pub closed spec fn spec_early_data_indication_new_session_ticket() -> SpecEarlyDataIndicationNewSessionTicketCombinator {
-    SpecEarlyDataIndicationNewSessionTicketCombinator(
-    Mapped {
-        inner: U32Be,
-        mapper: EarlyDataIndicationNewSessionTicketMapper::spec_new(),
-    })
+pub closed spec fn spec_signature_scheme() -> SpecSignatureSchemeCombinator {
+    SpecSignatureSchemeCombinator(U16Be)
 }
 
                 
-pub fn early_data_indication_new_session_ticket() -> (o: EarlyDataIndicationNewSessionTicketCombinator)
-    ensures o@ == spec_early_data_indication_new_session_ticket(),
+pub fn signature_scheme() -> (o: SignatureSchemeCombinator)
+    ensures o@ == spec_signature_scheme(),
 {
-    EarlyDataIndicationNewSessionTicketCombinator(
-    Mapped {
-        inner: U32Be,
-        mapper: EarlyDataIndicationNewSessionTicketMapper::new(),
-    })
+    SignatureSchemeCombinator(U16Be)
 }
 
                 
 
-pub struct SpecOpaque1Ffffff {
-    pub l: u24,
-    pub data: Seq<u8>,
+pub struct SpecSignatureSchemeList {
+    pub l: u16,
+    pub list: Seq<SpecSignatureScheme>,
 }
 
-pub type SpecOpaque1FfffffInner = (u24, Seq<u8>);
-impl SpecFrom<SpecOpaque1Ffffff> for SpecOpaque1FfffffInner {
-    open spec fn spec_from(m: SpecOpaque1Ffffff) -> SpecOpaque1FfffffInner {
-        (m.l, m.data)
+pub type SpecSignatureSchemeListInner = (u16, Seq<SpecSignatureScheme>);
+impl SpecFrom<SpecSignatureSchemeList> for SpecSignatureSchemeListInner {
+    open spec fn spec_from(m: SpecSignatureSchemeList) -> SpecSignatureSchemeListInner {
+        (m.l, m.list)
     }
 }
-impl SpecFrom<SpecOpaque1FfffffInner> for SpecOpaque1Ffffff {
-    open spec fn spec_from(m: SpecOpaque1FfffffInner) -> SpecOpaque1Ffffff {
-        let (l, data) = m;
-        SpecOpaque1Ffffff { l, data }
+impl SpecFrom<SpecSignatureSchemeListInner> for SpecSignatureSchemeList {
+    open spec fn spec_from(m: SpecSignatureSchemeListInner) -> SpecSignatureSchemeList {
+        let (l, list) = m;
+        SpecSignatureSchemeList { l, list }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 
-pub struct Opaque1Ffffff<'a> {
-    pub l: u24,
-    pub data: &'a [u8],
+pub struct SignatureSchemeList {
+    pub l: u16,
+    pub list: RepeatResult<SignatureScheme>,
 }
 
-impl View for Opaque1Ffffff<'_> {
-    type V = SpecOpaque1Ffffff;
+impl View for SignatureSchemeList {
+    type V = SpecSignatureSchemeList;
 
     open spec fn view(&self) -> Self::V {
-        SpecOpaque1Ffffff {
+        SpecSignatureSchemeList {
             l: self.l@,
-            data: self.data@,
+            list: self.list@,
         }
     }
 }
-pub type Opaque1FfffffInner<'a> = (u24, &'a [u8]);
-impl<'a> From<Opaque1Ffffff<'a>> for Opaque1FfffffInner<'a> {
-    fn ex_from(m: Opaque1Ffffff) -> Opaque1FfffffInner {
-        (m.l, m.data)
+pub type SignatureSchemeListInner = (u16, RepeatResult<SignatureScheme>);
+impl From<SignatureSchemeList> for SignatureSchemeListInner {
+    fn ex_from(m: SignatureSchemeList) -> SignatureSchemeListInner {
+        (m.l, m.list)
     }
 }
-impl<'a> From<Opaque1FfffffInner<'a>> for Opaque1Ffffff<'a> {
-    fn ex_from(m: Opaque1FfffffInner) -> Opaque1Ffffff {
-        let (l, data) = m;
-        Opaque1Ffffff { l, data }
+impl From<SignatureSchemeListInner> for SignatureSchemeList {
+    fn ex_from(m: SignatureSchemeListInner) -> SignatureSchemeList {
+        let (l, list) = m;
+        SignatureSchemeList { l, list }
     }
 }
 
-pub struct Opaque1FfffffMapper<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque1FfffffMapper<'a> {
+pub struct SignatureSchemeListMapper;
+impl SignatureSchemeListMapper {
     pub closed spec fn spec_new() -> Self {
-        Opaque1FfffffMapper(PhantomData)
+        SignatureSchemeListMapper
     }
     pub fn new() -> Self {
-        Opaque1FfffffMapper(PhantomData)
+        SignatureSchemeListMapper
     }
 }
-impl View for Opaque1FfffffMapper<'_> {
+impl View for SignatureSchemeListMapper {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for Opaque1FfffffMapper<'_> {
-    type Src = SpecOpaque1FfffffInner;
-    type Dst = SpecOpaque1Ffffff;
+impl SpecIso for SignatureSchemeListMapper {
+    type Src = SpecSignatureSchemeListInner;
+    type Dst = SpecSignatureSchemeList;
+}
+impl SpecIsoProof for SignatureSchemeListMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -241,23 +165,23 @@ impl SpecIso for Opaque1FfffffMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for Opaque1FfffffMapper<'a> {
-    type Src = Opaque1FfffffInner<'a>;
-    type Dst = Opaque1Ffffff<'a>;
+impl Iso for SignatureSchemeListMapper {
+    type Src = SignatureSchemeListInner;
+    type Dst = SignatureSchemeList;
 }
 
-pub struct SpecOpaque1FfffffCombinator(SpecOpaque1FfffffCombinatorAlias);
+pub struct SpecSignatureSchemeListCombinator(SpecSignatureSchemeListCombinatorAlias);
 
-impl SpecCombinator for SpecOpaque1FfffffCombinator {
-    type Type = SpecOpaque1Ffffff;
+impl SpecCombinator for SpecSignatureSchemeListCombinator {
+    type Type = SpecSignatureSchemeList;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecOpaque1FfffffCombinator {
+impl SecureSpecCombinator for SpecSignatureSchemeListCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecOpaque1FfffffCombinatorAlias::is_prefix_secure() }
+    { SpecSignatureSchemeListCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -271,40 +195,40 @@ impl SecureSpecCombinator for SpecOpaque1FfffffCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecOpaque1FfffffCombinatorAlias = Mapped<SpecDepend<Refined<U24Be, Predicate15036445817960576151>, Bytes>, Opaque1FfffffMapper<'static>>;
-pub struct Predicate15036445817960576151;
-impl View for Predicate15036445817960576151 {
+pub type SpecSignatureSchemeListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<SpecSignatureSchemeCombinator>>>, SignatureSchemeListMapper>;
+pub struct Predicate15206902916018849611;
+impl View for Predicate15206902916018849611 {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl Pred for Predicate15036445817960576151 {
-    type Input = u24;
+impl Pred for Predicate15206902916018849611 {
+    type Input = u16;
 
     fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i).as_u32();
-        (i >= 1 && i <= 16777215)
+        let i = (*i);
+        (i >= 2 && i <= 65534)
     }
 }
-impl SpecPred for Predicate15036445817960576151 {
-    type Input = u24;
+impl SpecPred for Predicate15206902916018849611 {
+    type Input = u16;
 
     open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i).spec_as_u32();
-        (i >= 1 && i <= 16777215)
+        let i = (*i);
+        (i >= 2 && i <= 65534)
     }
 }
 
-pub struct Opaque1FfffffCombinator<'a>(Opaque1FfffffCombinatorAlias<'a>);
+pub struct SignatureSchemeListCombinator<'a>(SignatureSchemeListCombinatorAlias<'a>);
 
-impl<'a> View for Opaque1FfffffCombinator<'a> {
-    type V = SpecOpaque1FfffffCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOpaque1FfffffCombinator(self.0@) }
+impl<'a> View for SignatureSchemeListCombinator<'a> {
+    type V = SpecSignatureSchemeListCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSignatureSchemeListCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque1FfffffCombinator<'a> {
-    type Type = Opaque1Ffffff<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SignatureSchemeListCombinator<'a> {
+    type Type = SignatureSchemeList;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -318,1203 +242,52 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque1FfffffCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type Opaque1FfffffCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U24Be, Predicate15036445817960576151>, Bytes, Opaque1FfffffCont0<'a>>, Opaque1FfffffMapper<'a>>;
+pub type SignatureSchemeListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<SignatureSchemeCombinator>>, SignatureSchemeListCont0<'a>>, SignatureSchemeListMapper>;
 
 
-pub closed spec fn spec_opaque_1_ffffff() -> SpecOpaque1FfffffCombinator {
-    SpecOpaque1FfffffCombinator(
+pub closed spec fn spec_signature_scheme_list() -> SpecSignatureSchemeListCombinator {
+    SpecSignatureSchemeListCombinator(
     Mapped {
-        inner: SpecDepend { fst: Refined { inner: U24Be, predicate: Predicate15036445817960576151 }, snd: |deps| spec_opaque1_ffffff_cont0(deps) },
-        mapper: Opaque1FfffffMapper::spec_new(),
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: |deps| spec_signature_scheme_list_cont0(deps) },
+        mapper: SignatureSchemeListMapper::spec_new(),
     })
 }
 
-pub open spec fn spec_opaque1_ffffff_cont0(deps: u24) -> Bytes {
+pub open spec fn spec_signature_scheme_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSignatureSchemeCombinator>> {
     let l = deps;
-    Bytes(l.spec_into())
+    AndThen(Bytes(l.spec_into()), Repeat(spec_signature_scheme()))
 }
                 
-pub fn opaque_1_ffffff<'a>() -> (o: Opaque1FfffffCombinator<'a>)
-    ensures o@ == spec_opaque_1_ffffff(),
+pub fn signature_scheme_list<'a>() -> (o: SignatureSchemeListCombinator<'a>)
+    ensures o@ == spec_signature_scheme_list(),
 {
-    Opaque1FfffffCombinator(
+    SignatureSchemeListCombinator(
     Mapped {
-        inner: Depend { fst: Refined { inner: U24Be, predicate: Predicate15036445817960576151 }, snd: Opaque1FfffffCont0::new(), spec_snd: Ghost(|deps| spec_opaque1_ffffff_cont0(deps)) },
-        mapper: Opaque1FfffffMapper::new(),
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: SignatureSchemeListCont0::new(), spec_snd: Ghost(|deps| spec_signature_scheme_list_cont0(deps)) },
+        mapper: SignatureSchemeListMapper::new(),
     })
 }
 
-pub struct Opaque1FfffffCont0<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque1FfffffCont0<'a> {
+pub struct SignatureSchemeListCont0<'a>(PhantomData<&'a ()>);
+impl<'a> SignatureSchemeListCont0<'a> {
     pub fn new() -> Self {
-        Opaque1FfffffCont0(PhantomData)
+        SignatureSchemeListCont0(PhantomData)
     }
 }
-impl<'a> Continuation<&u24> for Opaque1FfffffCont0<'a> {
-    type Output = Bytes;
+impl<'a> Continuation<&u16> for SignatureSchemeListCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<SignatureSchemeCombinator>>;
 
-    open spec fn requires(&self, deps: &u24) -> bool { true }
+    open spec fn requires(&self, deps: &u16) -> bool { true }
 
-    open spec fn ensures(&self, deps: &u24, o: Self::Output) -> bool {
-        o@ == spec_opaque1_ffffff_cont0(deps@)
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_signature_scheme_list_cont0(deps@)
     }
 
-    fn apply(&self, deps: &u24) -> Self::Output {
+    fn apply(&self, deps: &u16) -> Self::Output {
         let l = *deps;
-        Bytes(l.ex_into())
+        AndThen(Bytes(l.ex_into()), Repeat::new(signature_scheme()))
     }
 }
-                
-pub type SpecOcspResponse = SpecOpaque1Ffffff;
-pub type OcspResponse<'a> = Opaque1Ffffff<'a>;
-
-
-pub struct SpecOcspResponseCombinator(SpecOcspResponseCombinatorAlias);
-
-impl SpecCombinator for SpecOcspResponseCombinator {
-    type Type = SpecOcspResponse;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecOcspResponseCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecOcspResponseCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecOcspResponseCombinatorAlias = SpecOpaque1FfffffCombinator;
-
-pub struct OcspResponseCombinator<'a>(OcspResponseCombinatorAlias<'a>);
-
-impl<'a> View for OcspResponseCombinator<'a> {
-    type V = SpecOcspResponseCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOcspResponseCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for OcspResponseCombinator<'a> {
-    type Type = OcspResponse<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type OcspResponseCombinatorAlias<'a> = Opaque1FfffffCombinator<'a>;
-
-
-pub closed spec fn spec_ocsp_response() -> SpecOcspResponseCombinator {
-    SpecOcspResponseCombinator(spec_opaque_1_ffffff())
-}
-
-                
-pub fn ocsp_response<'a>() -> (o: OcspResponseCombinator<'a>)
-    ensures o@ == spec_ocsp_response(),
-{
-    OcspResponseCombinator(opaque_1_ffffff())
-}
-
-                
-pub type SpecExtensionType = u16;
-pub type ExtensionType = u16;
-
-
-pub struct SpecExtensionTypeCombinator(SpecExtensionTypeCombinatorAlias);
-
-impl SpecCombinator for SpecExtensionTypeCombinator {
-    type Type = SpecExtensionType;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecExtensionTypeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecExtensionTypeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecExtensionTypeCombinatorAlias = U16Be;
-
-pub struct ExtensionTypeCombinator(ExtensionTypeCombinatorAlias);
-
-impl View for ExtensionTypeCombinator {
-    type V = SpecExtensionTypeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecExtensionTypeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ExtensionTypeCombinator {
-    type Type = ExtensionType;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ExtensionTypeCombinatorAlias = U16Be;
-
-
-pub closed spec fn spec_extension_type() -> SpecExtensionTypeCombinator {
-    SpecExtensionTypeCombinator(U16Be)
-}
-
-                
-pub fn extension_type() -> (o: ExtensionTypeCombinator)
-    ensures o@ == spec_extension_type(),
-{
-    ExtensionTypeCombinator(U16Be)
-}
-
-                
-
-pub struct SpecPreSharedKeyServerExtension {
-    pub selected_identity: u16,
-}
-
-pub type SpecPreSharedKeyServerExtensionInner = u16;
-impl SpecFrom<SpecPreSharedKeyServerExtension> for SpecPreSharedKeyServerExtensionInner {
-    open spec fn spec_from(m: SpecPreSharedKeyServerExtension) -> SpecPreSharedKeyServerExtensionInner {
-        m.selected_identity
-    }
-}
-impl SpecFrom<SpecPreSharedKeyServerExtensionInner> for SpecPreSharedKeyServerExtension {
-    open spec fn spec_from(m: SpecPreSharedKeyServerExtensionInner) -> SpecPreSharedKeyServerExtension {
-        let selected_identity = m;
-        SpecPreSharedKeyServerExtension { selected_identity }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct PreSharedKeyServerExtension {
-    pub selected_identity: u16,
-}
-
-impl View for PreSharedKeyServerExtension {
-    type V = SpecPreSharedKeyServerExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecPreSharedKeyServerExtension {
-            selected_identity: self.selected_identity@,
-        }
-    }
-}
-pub type PreSharedKeyServerExtensionInner = u16;
-impl From<PreSharedKeyServerExtension> for PreSharedKeyServerExtensionInner {
-    fn ex_from(m: PreSharedKeyServerExtension) -> PreSharedKeyServerExtensionInner {
-        m.selected_identity
-    }
-}
-impl From<PreSharedKeyServerExtensionInner> for PreSharedKeyServerExtension {
-    fn ex_from(m: PreSharedKeyServerExtensionInner) -> PreSharedKeyServerExtension {
-        let selected_identity = m;
-        PreSharedKeyServerExtension { selected_identity }
-    }
-}
-
-pub struct PreSharedKeyServerExtensionMapper;
-impl PreSharedKeyServerExtensionMapper {
-    pub closed spec fn spec_new() -> Self {
-        PreSharedKeyServerExtensionMapper
-    }
-    pub fn new() -> Self {
-        PreSharedKeyServerExtensionMapper
-    }
-}
-impl View for PreSharedKeyServerExtensionMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for PreSharedKeyServerExtensionMapper {
-    type Src = SpecPreSharedKeyServerExtensionInner;
-    type Dst = SpecPreSharedKeyServerExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for PreSharedKeyServerExtensionMapper {
-    type Src = PreSharedKeyServerExtensionInner;
-    type Dst = PreSharedKeyServerExtension;
-}
-
-pub struct SpecPreSharedKeyServerExtensionCombinator(SpecPreSharedKeyServerExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecPreSharedKeyServerExtensionCombinator {
-    type Type = SpecPreSharedKeyServerExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecPreSharedKeyServerExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecPreSharedKeyServerExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecPreSharedKeyServerExtensionCombinatorAlias = Mapped<U16Be, PreSharedKeyServerExtensionMapper>;
-
-pub struct PreSharedKeyServerExtensionCombinator(PreSharedKeyServerExtensionCombinatorAlias);
-
-impl View for PreSharedKeyServerExtensionCombinator {
-    type V = SpecPreSharedKeyServerExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecPreSharedKeyServerExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for PreSharedKeyServerExtensionCombinator {
-    type Type = PreSharedKeyServerExtension;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type PreSharedKeyServerExtensionCombinatorAlias = Mapped<U16Be, PreSharedKeyServerExtensionMapper>;
-
-
-pub closed spec fn spec_pre_shared_key_server_extension() -> SpecPreSharedKeyServerExtensionCombinator {
-    SpecPreSharedKeyServerExtensionCombinator(
-    Mapped {
-        inner: U16Be,
-        mapper: PreSharedKeyServerExtensionMapper::spec_new(),
-    })
-}
-
-                
-pub fn pre_shared_key_server_extension() -> (o: PreSharedKeyServerExtensionCombinator)
-    ensures o@ == spec_pre_shared_key_server_extension(),
-{
-    PreSharedKeyServerExtensionCombinator(
-    Mapped {
-        inner: U16Be,
-        mapper: PreSharedKeyServerExtensionMapper::new(),
-    })
-}
-
-                
-pub type SpecProtocolVersion = u16;
-pub type ProtocolVersion = u16;
-
-
-pub struct SpecProtocolVersionCombinator(SpecProtocolVersionCombinatorAlias);
-
-impl SpecCombinator for SpecProtocolVersionCombinator {
-    type Type = SpecProtocolVersion;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecProtocolVersionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecProtocolVersionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecProtocolVersionCombinatorAlias = U16Be;
-
-pub struct ProtocolVersionCombinator(ProtocolVersionCombinatorAlias);
-
-impl View for ProtocolVersionCombinator {
-    type V = SpecProtocolVersionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecProtocolVersionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ProtocolVersionCombinator {
-    type Type = ProtocolVersion;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ProtocolVersionCombinatorAlias = U16Be;
-
-
-pub closed spec fn spec_protocol_version() -> SpecProtocolVersionCombinator {
-    SpecProtocolVersionCombinator(U16Be)
-}
-
-                
-pub fn protocol_version() -> (o: ProtocolVersionCombinator)
-    ensures o@ == spec_protocol_version(),
-{
-    ProtocolVersionCombinator(U16Be)
-}
-
-                
-pub type SpecSupportedVersionsServer = SpecProtocolVersion;
-pub type SupportedVersionsServer = ProtocolVersion;
-
-
-pub struct SpecSupportedVersionsServerCombinator(SpecSupportedVersionsServerCombinatorAlias);
-
-impl SpecCombinator for SpecSupportedVersionsServerCombinator {
-    type Type = SpecSupportedVersionsServer;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSupportedVersionsServerCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSupportedVersionsServerCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSupportedVersionsServerCombinatorAlias = SpecProtocolVersionCombinator;
-
-pub struct SupportedVersionsServerCombinator(SupportedVersionsServerCombinatorAlias);
-
-impl View for SupportedVersionsServerCombinator {
-    type V = SpecSupportedVersionsServerCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSupportedVersionsServerCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SupportedVersionsServerCombinator {
-    type Type = SupportedVersionsServer;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SupportedVersionsServerCombinatorAlias = ProtocolVersionCombinator;
-
-
-pub closed spec fn spec_supported_versions_server() -> SpecSupportedVersionsServerCombinator {
-    SpecSupportedVersionsServerCombinator(spec_protocol_version())
-}
-
-                
-pub fn supported_versions_server() -> (o: SupportedVersionsServerCombinator)
-    ensures o@ == spec_supported_versions_server(),
-{
-    SupportedVersionsServerCombinator(protocol_version())
-}
-
-                
-pub type SpecNamedGroup = u16;
-pub type NamedGroup = u16;
-
-
-pub struct SpecNamedGroupCombinator(SpecNamedGroupCombinatorAlias);
-
-impl SpecCombinator for SpecNamedGroupCombinator {
-    type Type = SpecNamedGroup;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecNamedGroupCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecNamedGroupCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecNamedGroupCombinatorAlias = U16Be;
-
-pub struct NamedGroupCombinator(NamedGroupCombinatorAlias);
-
-impl View for NamedGroupCombinator {
-    type V = SpecNamedGroupCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNamedGroupCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NamedGroupCombinator {
-    type Type = NamedGroup;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type NamedGroupCombinatorAlias = U16Be;
-
-
-pub closed spec fn spec_named_group() -> SpecNamedGroupCombinator {
-    SpecNamedGroupCombinator(U16Be)
-}
-
-                
-pub fn named_group() -> (o: NamedGroupCombinator)
-    ensures o@ == spec_named_group(),
-{
-    NamedGroupCombinator(U16Be)
-}
-
-                
-
-pub struct SpecKeyShareEntry {
-    pub group: SpecNamedGroup,
-    pub l: u16,
-    pub key_exchange: Seq<u8>,
-}
-
-pub type SpecKeyShareEntryInner = ((SpecNamedGroup, u16), Seq<u8>);
-impl SpecFrom<SpecKeyShareEntry> for SpecKeyShareEntryInner {
-    open spec fn spec_from(m: SpecKeyShareEntry) -> SpecKeyShareEntryInner {
-        ((m.group, m.l), m.key_exchange)
-    }
-}
-impl SpecFrom<SpecKeyShareEntryInner> for SpecKeyShareEntry {
-    open spec fn spec_from(m: SpecKeyShareEntryInner) -> SpecKeyShareEntry {
-        let ((group, l), key_exchange) = m;
-        SpecKeyShareEntry { group, l, key_exchange }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct KeyShareEntry<'a> {
-    pub group: NamedGroup,
-    pub l: u16,
-    pub key_exchange: &'a [u8],
-}
-
-impl View for KeyShareEntry<'_> {
-    type V = SpecKeyShareEntry;
-
-    open spec fn view(&self) -> Self::V {
-        SpecKeyShareEntry {
-            group: self.group@,
-            l: self.l@,
-            key_exchange: self.key_exchange@,
-        }
-    }
-}
-pub type KeyShareEntryInner<'a> = ((NamedGroup, u16), &'a [u8]);
-impl<'a> From<KeyShareEntry<'a>> for KeyShareEntryInner<'a> {
-    fn ex_from(m: KeyShareEntry) -> KeyShareEntryInner {
-        ((m.group, m.l), m.key_exchange)
-    }
-}
-impl<'a> From<KeyShareEntryInner<'a>> for KeyShareEntry<'a> {
-    fn ex_from(m: KeyShareEntryInner) -> KeyShareEntry {
-        let ((group, l), key_exchange) = m;
-        KeyShareEntry { group, l, key_exchange }
-    }
-}
-
-pub struct KeyShareEntryMapper<'a>(PhantomData<&'a ()>);
-impl<'a> KeyShareEntryMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        KeyShareEntryMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        KeyShareEntryMapper(PhantomData)
-    }
-}
-impl View for KeyShareEntryMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for KeyShareEntryMapper<'_> {
-    type Src = SpecKeyShareEntryInner;
-    type Dst = SpecKeyShareEntry;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for KeyShareEntryMapper<'a> {
-    type Src = KeyShareEntryInner<'a>;
-    type Dst = KeyShareEntry<'a>;
-}
-
-pub struct SpecKeyShareEntryCombinator(SpecKeyShareEntryCombinatorAlias);
-
-impl SpecCombinator for SpecKeyShareEntryCombinator {
-    type Type = SpecKeyShareEntry;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecKeyShareEntryCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecKeyShareEntryCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecKeyShareEntryCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecNamedGroupCombinator, Refined<U16Be, Predicate16977634203518580913>>, Bytes>, KeyShareEntryMapper<'static>>;
-pub struct Predicate16977634203518580913;
-impl View for Predicate16977634203518580913 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred for Predicate16977634203518580913 {
-    type Input = u16;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 1 && i <= 65535)
-    }
-}
-impl SpecPred for Predicate16977634203518580913 {
-    type Input = u16;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 1 && i <= 65535)
-    }
-}
-
-pub struct KeyShareEntryCombinator<'a>(KeyShareEntryCombinatorAlias<'a>);
-
-impl<'a> View for KeyShareEntryCombinator<'a> {
-    type V = SpecKeyShareEntryCombinator;
-    closed spec fn view(&self) -> Self::V { SpecKeyShareEntryCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for KeyShareEntryCombinator<'a> {
-    type Type = KeyShareEntry<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type KeyShareEntryCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, NamedGroupCombinator, Refined<U16Be, Predicate16977634203518580913>, KeyShareEntryCont1<'a>>, Bytes, KeyShareEntryCont0<'a>>, KeyShareEntryMapper<'a>>;
-
-
-pub closed spec fn spec_key_share_entry() -> SpecKeyShareEntryCombinator {
-    SpecKeyShareEntryCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_named_group(), snd: |deps| spec_key_share_entry_cont1(deps) }, snd: |deps| spec_key_share_entry_cont0(deps) },
-        mapper: KeyShareEntryMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_key_share_entry_cont1(deps: SpecNamedGroup) -> Refined<U16Be, Predicate16977634203518580913> {
-    let group = deps;
-    Refined { inner: U16Be, predicate: Predicate16977634203518580913 }
-}
-pub open spec fn spec_key_share_entry_cont0(deps: (SpecNamedGroup, u16)) -> Bytes {
-    let (group, l) = deps;
-    Bytes(l.spec_into())
-}
-                
-pub fn key_share_entry<'a>() -> (o: KeyShareEntryCombinator<'a>)
-    ensures o@ == spec_key_share_entry(),
-{
-    KeyShareEntryCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: named_group(), snd: KeyShareEntryCont1::new(), spec_snd: Ghost(|deps| spec_key_share_entry_cont1(deps)) }, snd: KeyShareEntryCont0::new(), spec_snd: Ghost(|deps| spec_key_share_entry_cont0(deps)) },
-        mapper: KeyShareEntryMapper::new(),
-    })
-}
-
-pub struct KeyShareEntryCont1<'a>(PhantomData<&'a ()>);
-impl<'a> KeyShareEntryCont1<'a> {
-    pub fn new() -> Self {
-        KeyShareEntryCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&NamedGroup> for KeyShareEntryCont1<'a> {
-    type Output = Refined<U16Be, Predicate16977634203518580913>;
-
-    open spec fn requires(&self, deps: &NamedGroup) -> bool { true }
-
-    open spec fn ensures(&self, deps: &NamedGroup, o: Self::Output) -> bool {
-        o@ == spec_key_share_entry_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &NamedGroup) -> Self::Output {
-        let group = *deps;
-        Refined { inner: U16Be, predicate: Predicate16977634203518580913 }
-    }
-}
-pub struct KeyShareEntryCont0<'a>(PhantomData<&'a ()>);
-impl<'a> KeyShareEntryCont0<'a> {
-    pub fn new() -> Self {
-        KeyShareEntryCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(NamedGroup, u16)> for KeyShareEntryCont0<'a> {
-    type Output = Bytes;
-
-    open spec fn requires(&self, deps: &(NamedGroup, u16)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(NamedGroup, u16), o: Self::Output) -> bool {
-        o@ == spec_key_share_entry_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(NamedGroup, u16)) -> Self::Output {
-        let (group, l) = *deps;
-        Bytes(l.ex_into())
-    }
-}
-                
-
-pub enum SpecSeverHelloExtensionExtensionData {
-    PreSharedKey(SpecPreSharedKeyServerExtension),
-    SupportedVersions(SpecSupportedVersionsServer),
-    KeyShare(SpecKeyShareEntry),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecSeverHelloExtensionExtensionDataInner = Either<SpecPreSharedKeyServerExtension, Either<SpecSupportedVersionsServer, Either<SpecKeyShareEntry, Seq<u8>>>>;
-
-
-
-impl SpecFrom<SpecSeverHelloExtensionExtensionData> for SpecSeverHelloExtensionExtensionDataInner {
-    open spec fn spec_from(m: SpecSeverHelloExtensionExtensionData) -> SpecSeverHelloExtensionExtensionDataInner {
-        match m {
-            SpecSeverHelloExtensionExtensionData::PreSharedKey(m) => Either::Left(m),
-            SpecSeverHelloExtensionExtensionData::SupportedVersions(m) => Either::Right(Either::Left(m)),
-            SpecSeverHelloExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
-            SpecSeverHelloExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecSeverHelloExtensionExtensionDataInner> for SpecSeverHelloExtensionExtensionData {
-    open spec fn spec_from(m: SpecSeverHelloExtensionExtensionDataInner) -> SpecSeverHelloExtensionExtensionData {
-        match m {
-            Either::Left(m) => SpecSeverHelloExtensionExtensionData::PreSharedKey(m),
-            Either::Right(Either::Left(m)) => SpecSeverHelloExtensionExtensionData::SupportedVersions(m),
-            Either::Right(Either::Right(Either::Left(m))) => SpecSeverHelloExtensionExtensionData::KeyShare(m),
-            Either::Right(Either::Right(Either::Right(m))) => SpecSeverHelloExtensionExtensionData::Unrecognized(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SeverHelloExtensionExtensionData<'a> {
-    PreSharedKey(PreSharedKeyServerExtension),
-    SupportedVersions(SupportedVersionsServer),
-    KeyShare(KeyShareEntry<'a>),
-    Unrecognized(&'a [u8]),
-}
-
-pub type SeverHelloExtensionExtensionDataInner<'a> = Either<PreSharedKeyServerExtension, Either<SupportedVersionsServer, Either<KeyShareEntry<'a>, &'a [u8]>>>;
-
-
-impl<'a> View for SeverHelloExtensionExtensionData<'a> {
-    type V = SpecSeverHelloExtensionExtensionData;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            SeverHelloExtensionExtensionData::PreSharedKey(m) => SpecSeverHelloExtensionExtensionData::PreSharedKey(m@),
-            SeverHelloExtensionExtensionData::SupportedVersions(m) => SpecSeverHelloExtensionExtensionData::SupportedVersions(m@),
-            SeverHelloExtensionExtensionData::KeyShare(m) => SpecSeverHelloExtensionExtensionData::KeyShare(m@),
-            SeverHelloExtensionExtensionData::Unrecognized(m) => SpecSeverHelloExtensionExtensionData::Unrecognized(m@),
-        }
-    }
-}
-
-
-impl<'a> From<SeverHelloExtensionExtensionData<'a>> for SeverHelloExtensionExtensionDataInner<'a> {
-    fn ex_from(m: SeverHelloExtensionExtensionData<'a>) -> SeverHelloExtensionExtensionDataInner<'a> {
-        match m {
-            SeverHelloExtensionExtensionData::PreSharedKey(m) => Either::Left(m),
-            SeverHelloExtensionExtensionData::SupportedVersions(m) => Either::Right(Either::Left(m)),
-            SeverHelloExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
-            SeverHelloExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl<'a> From<SeverHelloExtensionExtensionDataInner<'a>> for SeverHelloExtensionExtensionData<'a> {
-    fn ex_from(m: SeverHelloExtensionExtensionDataInner<'a>) -> SeverHelloExtensionExtensionData<'a> {
-        match m {
-            Either::Left(m) => SeverHelloExtensionExtensionData::PreSharedKey(m),
-            Either::Right(Either::Left(m)) => SeverHelloExtensionExtensionData::SupportedVersions(m),
-            Either::Right(Either::Right(Either::Left(m))) => SeverHelloExtensionExtensionData::KeyShare(m),
-            Either::Right(Either::Right(Either::Right(m))) => SeverHelloExtensionExtensionData::Unrecognized(m),
-        }
-    }
-    
-}
-
-
-pub struct SeverHelloExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> SeverHelloExtensionExtensionDataMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        SeverHelloExtensionExtensionDataMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        SeverHelloExtensionExtensionDataMapper(PhantomData)
-    }
-}
-impl View for SeverHelloExtensionExtensionDataMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for SeverHelloExtensionExtensionDataMapper<'_> {
-    type Src = SpecSeverHelloExtensionExtensionDataInner;
-    type Dst = SpecSeverHelloExtensionExtensionData;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for SeverHelloExtensionExtensionDataMapper<'a> {
-    type Src = SeverHelloExtensionExtensionDataInner<'a>;
-    type Dst = SeverHelloExtensionExtensionData<'a>;
-}
-
-
-pub struct SpecSeverHelloExtensionExtensionDataCombinator(SpecSeverHelloExtensionExtensionDataCombinatorAlias);
-
-impl SpecCombinator for SpecSeverHelloExtensionExtensionDataCombinator {
-    type Type = SpecSeverHelloExtensionExtensionData;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSeverHelloExtensionExtensionDataCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSeverHelloExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSeverHelloExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecPreSharedKeyServerExtensionCombinator>, OrdChoice<Cond<SpecSupportedVersionsServerCombinator>, OrdChoice<Cond<SpecKeyShareEntryCombinator>, Cond<Bytes>>>>, SeverHelloExtensionExtensionDataMapper<'static>>>;
-
-pub struct SeverHelloExtensionExtensionDataCombinator<'a>(SeverHelloExtensionExtensionDataCombinatorAlias<'a>);
-
-impl<'a> View for SeverHelloExtensionExtensionDataCombinator<'a> {
-    type V = SpecSeverHelloExtensionExtensionDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSeverHelloExtensionExtensionDataCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SeverHelloExtensionExtensionDataCombinator<'a> {
-    type Type = SeverHelloExtensionExtensionData<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SeverHelloExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<PreSharedKeyServerExtensionCombinator>, OrdChoice<Cond<SupportedVersionsServerCombinator>, OrdChoice<Cond<KeyShareEntryCombinator<'a>>, Cond<Bytes>>>>, SeverHelloExtensionExtensionDataMapper<'a>>>;
-
-
-pub closed spec fn spec_sever_hello_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecSeverHelloExtensionExtensionDataCombinator {
-    SpecSeverHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 41, inner: spec_pre_shared_key_server_extension() }, OrdChoice(Cond { cond: extension_type == 43, inner: spec_supported_versions_server() }, OrdChoice(Cond { cond: extension_type == 51, inner: spec_key_share_entry() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) }))), mapper: SeverHelloExtensionExtensionDataMapper::spec_new() }))
-}
-
-pub fn sever_hello_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: SeverHelloExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_sever_hello_extension_extension_data(ext_len@, extension_type@),
-{
-    SeverHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 41, inner: pre_shared_key_server_extension() }, OrdChoice::new(Cond { cond: extension_type == 43, inner: supported_versions_server() }, OrdChoice::new(Cond { cond: extension_type == 51, inner: key_share_entry() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) }))), mapper: SeverHelloExtensionExtensionDataMapper::new() }))
-}
-
-
-pub struct SpecSeverHelloExtension {
-    pub extension_type: SpecExtensionType,
-    pub ext_len: u16,
-    pub extension_data: SpecSeverHelloExtensionExtensionData,
-}
-
-pub type SpecSeverHelloExtensionInner = ((SpecExtensionType, u16), SpecSeverHelloExtensionExtensionData);
-impl SpecFrom<SpecSeverHelloExtension> for SpecSeverHelloExtensionInner {
-    open spec fn spec_from(m: SpecSeverHelloExtension) -> SpecSeverHelloExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl SpecFrom<SpecSeverHelloExtensionInner> for SpecSeverHelloExtension {
-    open spec fn spec_from(m: SpecSeverHelloExtensionInner) -> SpecSeverHelloExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        SpecSeverHelloExtension { extension_type, ext_len, extension_data }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct SeverHelloExtension<'a> {
-    pub extension_type: ExtensionType,
-    pub ext_len: u16,
-    pub extension_data: SeverHelloExtensionExtensionData<'a>,
-}
-
-impl View for SeverHelloExtension<'_> {
-    type V = SpecSeverHelloExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecSeverHelloExtension {
-            extension_type: self.extension_type@,
-            ext_len: self.ext_len@,
-            extension_data: self.extension_data@,
-        }
-    }
-}
-pub type SeverHelloExtensionInner<'a> = ((ExtensionType, u16), SeverHelloExtensionExtensionData<'a>);
-impl<'a> From<SeverHelloExtension<'a>> for SeverHelloExtensionInner<'a> {
-    fn ex_from(m: SeverHelloExtension) -> SeverHelloExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl<'a> From<SeverHelloExtensionInner<'a>> for SeverHelloExtension<'a> {
-    fn ex_from(m: SeverHelloExtensionInner) -> SeverHelloExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        SeverHelloExtension { extension_type, ext_len, extension_data }
-    }
-}
-
-pub struct SeverHelloExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> SeverHelloExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        SeverHelloExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        SeverHelloExtensionMapper(PhantomData)
-    }
-}
-impl View for SeverHelloExtensionMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for SeverHelloExtensionMapper<'_> {
-    type Src = SpecSeverHelloExtensionInner;
-    type Dst = SpecSeverHelloExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for SeverHelloExtensionMapper<'a> {
-    type Src = SeverHelloExtensionInner<'a>;
-    type Dst = SeverHelloExtension<'a>;
-}
-
-pub struct SpecSeverHelloExtensionCombinator(SpecSeverHelloExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecSeverHelloExtensionCombinator {
-    type Type = SpecSeverHelloExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSeverHelloExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSeverHelloExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSeverHelloExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecSeverHelloExtensionExtensionDataCombinator>, SeverHelloExtensionMapper<'static>>;
-
-pub struct SeverHelloExtensionCombinator<'a>(SeverHelloExtensionCombinatorAlias<'a>);
-
-impl<'a> View for SeverHelloExtensionCombinator<'a> {
-    type V = SpecSeverHelloExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSeverHelloExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SeverHelloExtensionCombinator<'a> {
-    type Type = SeverHelloExtension<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SeverHelloExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, SeverHelloExtensionCont1<'a>>, SeverHelloExtensionExtensionDataCombinator<'a>, SeverHelloExtensionCont0<'a>>, SeverHelloExtensionMapper<'a>>;
-
-
-pub closed spec fn spec_sever_hello_extension() -> SpecSeverHelloExtensionCombinator {
-    SpecSeverHelloExtensionCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_sever_hello_extension_cont1(deps) }, snd: |deps| spec_sever_hello_extension_cont0(deps) },
-        mapper: SeverHelloExtensionMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_sever_hello_extension_cont1(deps: SpecExtensionType) -> U16Be {
-    let extension_type = deps;
-    U16Be
-}
-pub open spec fn spec_sever_hello_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecSeverHelloExtensionExtensionDataCombinator {
-    let (extension_type, ext_len) = deps;
-    spec_sever_hello_extension_extension_data(ext_len, extension_type)
-}
-                
-pub fn sever_hello_extension<'a>() -> (o: SeverHelloExtensionCombinator<'a>)
-    ensures o@ == spec_sever_hello_extension(),
-{
-    SeverHelloExtensionCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: extension_type(), snd: SeverHelloExtensionCont1::new(), spec_snd: Ghost(|deps| spec_sever_hello_extension_cont1(deps)) }, snd: SeverHelloExtensionCont0::new(), spec_snd: Ghost(|deps| spec_sever_hello_extension_cont0(deps)) },
-        mapper: SeverHelloExtensionMapper::new(),
-    })
-}
-
-pub struct SeverHelloExtensionCont1<'a>(PhantomData<&'a ()>);
-impl<'a> SeverHelloExtensionCont1<'a> {
-    pub fn new() -> Self {
-        SeverHelloExtensionCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&ExtensionType> for SeverHelloExtensionCont1<'a> {
-    type Output = U16Be;
-
-    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
-        o@ == spec_sever_hello_extension_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &ExtensionType) -> Self::Output {
-        let extension_type = *deps;
-        U16Be
-    }
-}
-pub struct SeverHelloExtensionCont0<'a>(PhantomData<&'a ()>);
-impl<'a> SeverHelloExtensionCont0<'a> {
-    pub fn new() -> Self {
-        SeverHelloExtensionCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(ExtensionType, u16)> for SeverHelloExtensionCont0<'a> {
-    type Output = SeverHelloExtensionExtensionDataCombinator<'a>;
-
-    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
-        o@ == spec_sever_hello_extension_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
-        let (extension_type, ext_len) = *deps;
-        sever_hello_extension_extension_data(ext_len, extension_type)
-    }
-}
-                
-pub type SpecNameType = u8;
-pub type NameType = u8;
-
-
-pub struct SpecNameTypeCombinator(SpecNameTypeCombinatorAlias);
-
-impl SpecCombinator for SpecNameTypeCombinator {
-    type Type = SpecNameType;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecNameTypeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecNameTypeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecNameTypeCombinatorAlias = U8;
-
-pub struct NameTypeCombinator(NameTypeCombinatorAlias);
-
-impl View for NameTypeCombinator {
-    type V = SpecNameTypeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNameTypeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NameTypeCombinator {
-    type Type = NameType;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type NameTypeCombinatorAlias = U8;
-
-
-pub closed spec fn spec_name_type() -> SpecNameTypeCombinator {
-    SpecNameTypeCombinator(U8)
-}
-
-                
-pub fn name_type() -> (o: NameTypeCombinator)
-    ensures o@ == spec_name_type(),
-{
-    NameTypeCombinator(U8)
-}
-
                 
 
 pub struct SpecOpaque1Ffff {
@@ -1582,6 +355,8 @@ impl View for Opaque1FfffMapper<'_> {
 impl SpecIso for Opaque1FfffMapper<'_> {
     type Src = SpecOpaque1FfffInner;
     type Dst = SpecOpaque1Ffff;
+}
+impl SpecIsoProof for Opaque1FfffMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -1713,22 +488,22 @@ impl<'a> Continuation<&u16> for Opaque1FfffCont0<'a> {
     }
 }
                 
-pub type SpecHostName = SpecOpaque1Ffff;
-pub type HostName<'a> = Opaque1Ffff<'a>;
+pub type SpecDistinguishedName = SpecOpaque1Ffff;
+pub type DistinguishedName<'a> = Opaque1Ffff<'a>;
 
 
-pub struct SpecHostNameCombinator(SpecHostNameCombinatorAlias);
+pub struct SpecDistinguishedNameCombinator(SpecDistinguishedNameCombinatorAlias);
 
-impl SpecCombinator for SpecHostNameCombinator {
-    type Type = SpecHostName;
+impl SpecCombinator for SpecDistinguishedNameCombinator {
+    type Type = SpecDistinguishedName;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecHostNameCombinator {
+impl SecureSpecCombinator for SpecDistinguishedNameCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecHostNameCombinatorAlias::is_prefix_secure() }
+    { SpecDistinguishedNameCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -1742,16 +517,16 @@ impl SecureSpecCombinator for SpecHostNameCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecHostNameCombinatorAlias = SpecOpaque1FfffCombinator;
+pub type SpecDistinguishedNameCombinatorAlias = SpecOpaque1FfffCombinator;
 
-pub struct HostNameCombinator<'a>(HostNameCombinatorAlias<'a>);
+pub struct DistinguishedNameCombinator<'a>(DistinguishedNameCombinatorAlias<'a>);
 
-impl<'a> View for HostNameCombinator<'a> {
-    type V = SpecHostNameCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHostNameCombinator(self.0@) }
+impl<'a> View for DistinguishedNameCombinator<'a> {
+    type V = SpecDistinguishedNameCombinator;
+    closed spec fn view(&self) -> Self::V { SpecDistinguishedNameCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HostNameCombinator<'a> {
-    type Type = HostName<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for DistinguishedNameCombinator<'a> {
+    type Type = DistinguishedName<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -1765,492 +540,89 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for HostNameCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type HostNameCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
+pub type DistinguishedNameCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
 
 
-pub closed spec fn spec_host_name() -> SpecHostNameCombinator {
-    SpecHostNameCombinator(spec_opaque_1_ffff())
+pub closed spec fn spec_distinguished_name() -> SpecDistinguishedNameCombinator {
+    SpecDistinguishedNameCombinator(spec_opaque_1_ffff())
 }
 
                 
-pub fn host_name<'a>() -> (o: HostNameCombinator<'a>)
-    ensures o@ == spec_host_name(),
+pub fn distinguished_name<'a>() -> (o: DistinguishedNameCombinator<'a>)
+    ensures o@ == spec_distinguished_name(),
 {
-    HostNameCombinator(opaque_1_ffff())
-}
-
-                
-pub type SpecUnknownName = SpecOpaque1Ffff;
-pub type UnknownName<'a> = Opaque1Ffff<'a>;
-
-
-pub struct SpecUnknownNameCombinator(SpecUnknownNameCombinatorAlias);
-
-impl SpecCombinator for SpecUnknownNameCombinator {
-    type Type = SpecUnknownName;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecUnknownNameCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecUnknownNameCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecUnknownNameCombinatorAlias = SpecOpaque1FfffCombinator;
-
-pub struct UnknownNameCombinator<'a>(UnknownNameCombinatorAlias<'a>);
-
-impl<'a> View for UnknownNameCombinator<'a> {
-    type V = SpecUnknownNameCombinator;
-    closed spec fn view(&self) -> Self::V { SpecUnknownNameCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for UnknownNameCombinator<'a> {
-    type Type = UnknownName<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type UnknownNameCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
-
-
-pub closed spec fn spec_unknown_name() -> SpecUnknownNameCombinator {
-    SpecUnknownNameCombinator(spec_opaque_1_ffff())
-}
-
-                
-pub fn unknown_name<'a>() -> (o: UnknownNameCombinator<'a>)
-    ensures o@ == spec_unknown_name(),
-{
-    UnknownNameCombinator(opaque_1_ffff())
+    DistinguishedNameCombinator(opaque_1_ffff())
 }
 
                 
 
-pub enum SpecServerNameName {
-    HostName(SpecHostName),
-    Unrecognized(SpecUnknownName),
-}
-
-pub type SpecServerNameNameInner = Either<SpecHostName, SpecUnknownName>;
-
-
-
-impl SpecFrom<SpecServerNameName> for SpecServerNameNameInner {
-    open spec fn spec_from(m: SpecServerNameName) -> SpecServerNameNameInner {
-        match m {
-            SpecServerNameName::HostName(m) => Either::Left(m),
-            SpecServerNameName::Unrecognized(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecServerNameNameInner> for SpecServerNameName {
-    open spec fn spec_from(m: SpecServerNameNameInner) -> SpecServerNameName {
-        match m {
-            Either::Left(m) => SpecServerNameName::HostName(m),
-            Either::Right(m) => SpecServerNameName::Unrecognized(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ServerNameName<'a> {
-    HostName(HostName<'a>),
-    Unrecognized(UnknownName<'a>),
-}
-
-pub type ServerNameNameInner<'a> = Either<HostName<'a>, UnknownName<'a>>;
-
-
-impl<'a> View for ServerNameName<'a> {
-    type V = SpecServerNameName;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            ServerNameName::HostName(m) => SpecServerNameName::HostName(m@),
-            ServerNameName::Unrecognized(m) => SpecServerNameName::Unrecognized(m@),
-        }
-    }
-}
-
-
-impl<'a> From<ServerNameName<'a>> for ServerNameNameInner<'a> {
-    fn ex_from(m: ServerNameName<'a>) -> ServerNameNameInner<'a> {
-        match m {
-            ServerNameName::HostName(m) => Either::Left(m),
-            ServerNameName::Unrecognized(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl<'a> From<ServerNameNameInner<'a>> for ServerNameName<'a> {
-    fn ex_from(m: ServerNameNameInner<'a>) -> ServerNameName<'a> {
-        match m {
-            Either::Left(m) => ServerNameName::HostName(m),
-            Either::Right(m) => ServerNameName::Unrecognized(m),
-        }
-    }
-    
-}
-
-
-pub struct ServerNameNameMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ServerNameNameMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ServerNameNameMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ServerNameNameMapper(PhantomData)
-    }
-}
-impl View for ServerNameNameMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ServerNameNameMapper<'_> {
-    type Src = SpecServerNameNameInner;
-    type Dst = SpecServerNameName;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for ServerNameNameMapper<'a> {
-    type Src = ServerNameNameInner<'a>;
-    type Dst = ServerNameName<'a>;
-}
-
-
-pub struct SpecServerNameNameCombinator(SpecServerNameNameCombinatorAlias);
-
-impl SpecCombinator for SpecServerNameNameCombinator {
-    type Type = SpecServerNameName;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecServerNameNameCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecServerNameNameCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecServerNameNameCombinatorAlias = Mapped<OrdChoice<Cond<SpecHostNameCombinator>, Cond<SpecUnknownNameCombinator>>, ServerNameNameMapper<'static>>;
-
-pub struct ServerNameNameCombinator<'a>(ServerNameNameCombinatorAlias<'a>);
-
-impl<'a> View for ServerNameNameCombinator<'a> {
-    type V = SpecServerNameNameCombinator;
-    closed spec fn view(&self) -> Self::V { SpecServerNameNameCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameNameCombinator<'a> {
-    type Type = ServerNameName<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ServerNameNameCombinatorAlias<'a> = Mapped<OrdChoice<Cond<HostNameCombinator<'a>>, Cond<UnknownNameCombinator<'a>>>, ServerNameNameMapper<'a>>;
-
-
-pub closed spec fn spec_server_name_name(name_type: SpecNameType) -> SpecServerNameNameCombinator {
-    SpecServerNameNameCombinator(Mapped { inner: OrdChoice(Cond { cond: name_type == 0, inner: spec_host_name() }, Cond { cond: !(name_type == 0), inner: spec_unknown_name() }), mapper: ServerNameNameMapper::spec_new() })
-}
-
-pub fn server_name_name<'a>(name_type: NameType) -> (o: ServerNameNameCombinator<'a>)
-    ensures o@ == spec_server_name_name(name_type@),
-{
-    ServerNameNameCombinator(Mapped { inner: OrdChoice::new(Cond { cond: name_type == 0, inner: host_name() }, Cond { cond: !(name_type == 0), inner: unknown_name() }), mapper: ServerNameNameMapper::new() })
-}
-
-
-pub struct SpecServerName {
-    pub name_type: SpecNameType,
-    pub name: SpecServerNameName,
-}
-
-pub type SpecServerNameInner = (SpecNameType, SpecServerNameName);
-impl SpecFrom<SpecServerName> for SpecServerNameInner {
-    open spec fn spec_from(m: SpecServerName) -> SpecServerNameInner {
-        (m.name_type, m.name)
-    }
-}
-impl SpecFrom<SpecServerNameInner> for SpecServerName {
-    open spec fn spec_from(m: SpecServerNameInner) -> SpecServerName {
-        let (name_type, name) = m;
-        SpecServerName { name_type, name }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct ServerName<'a> {
-    pub name_type: NameType,
-    pub name: ServerNameName<'a>,
-}
-
-impl View for ServerName<'_> {
-    type V = SpecServerName;
-
-    open spec fn view(&self) -> Self::V {
-        SpecServerName {
-            name_type: self.name_type@,
-            name: self.name@,
-        }
-    }
-}
-pub type ServerNameInner<'a> = (NameType, ServerNameName<'a>);
-impl<'a> From<ServerName<'a>> for ServerNameInner<'a> {
-    fn ex_from(m: ServerName) -> ServerNameInner {
-        (m.name_type, m.name)
-    }
-}
-impl<'a> From<ServerNameInner<'a>> for ServerName<'a> {
-    fn ex_from(m: ServerNameInner) -> ServerName {
-        let (name_type, name) = m;
-        ServerName { name_type, name }
-    }
-}
-
-pub struct ServerNameMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ServerNameMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ServerNameMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ServerNameMapper(PhantomData)
-    }
-}
-impl View for ServerNameMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ServerNameMapper<'_> {
-    type Src = SpecServerNameInner;
-    type Dst = SpecServerName;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for ServerNameMapper<'a> {
-    type Src = ServerNameInner<'a>;
-    type Dst = ServerName<'a>;
-}
-
-pub struct SpecServerNameCombinator(SpecServerNameCombinatorAlias);
-
-impl SpecCombinator for SpecServerNameCombinator {
-    type Type = SpecServerName;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecServerNameCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecServerNameCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecServerNameCombinatorAlias = Mapped<SpecDepend<SpecNameTypeCombinator, SpecServerNameNameCombinator>, ServerNameMapper<'static>>;
-
-pub struct ServerNameCombinator<'a>(ServerNameCombinatorAlias<'a>);
-
-impl<'a> View for ServerNameCombinator<'a> {
-    type V = SpecServerNameCombinator;
-    closed spec fn view(&self) -> Self::V { SpecServerNameCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameCombinator<'a> {
-    type Type = ServerName<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ServerNameCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, NameTypeCombinator, ServerNameNameCombinator<'a>, ServerNameCont0<'a>>, ServerNameMapper<'a>>;
-
-
-pub closed spec fn spec_server_name() -> SpecServerNameCombinator {
-    SpecServerNameCombinator(
-    Mapped {
-        inner: SpecDepend { fst: spec_name_type(), snd: |deps| spec_server_name_cont0(deps) },
-        mapper: ServerNameMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_server_name_cont0(deps: SpecNameType) -> SpecServerNameNameCombinator {
-    let name_type = deps;
-    spec_server_name_name(name_type)
-}
-                
-pub fn server_name<'a>() -> (o: ServerNameCombinator<'a>)
-    ensures o@ == spec_server_name(),
-{
-    ServerNameCombinator(
-    Mapped {
-        inner: Depend { fst: name_type(), snd: ServerNameCont0::new(), spec_snd: Ghost(|deps| spec_server_name_cont0(deps)) },
-        mapper: ServerNameMapper::new(),
-    })
-}
-
-pub struct ServerNameCont0<'a>(PhantomData<&'a ()>);
-impl<'a> ServerNameCont0<'a> {
-    pub fn new() -> Self {
-        ServerNameCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&NameType> for ServerNameCont0<'a> {
-    type Output = ServerNameNameCombinator<'a>;
-
-    open spec fn requires(&self, deps: &NameType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &NameType, o: Self::Output) -> bool {
-        o@ == spec_server_name_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &NameType) -> Self::Output {
-        let name_type = *deps;
-        server_name_name(name_type)
-    }
-}
-                
-
-pub struct SpecServerNameList {
+pub struct SpecCertificateAuthoritiesExtension {
     pub l: u16,
-    pub list: Seq<SpecServerName>,
+    pub list: Seq<SpecDistinguishedName>,
 }
 
-pub type SpecServerNameListInner = (u16, Seq<SpecServerName>);
-impl SpecFrom<SpecServerNameList> for SpecServerNameListInner {
-    open spec fn spec_from(m: SpecServerNameList) -> SpecServerNameListInner {
+pub type SpecCertificateAuthoritiesExtensionInner = (u16, Seq<SpecDistinguishedName>);
+impl SpecFrom<SpecCertificateAuthoritiesExtension> for SpecCertificateAuthoritiesExtensionInner {
+    open spec fn spec_from(m: SpecCertificateAuthoritiesExtension) -> SpecCertificateAuthoritiesExtensionInner {
         (m.l, m.list)
     }
 }
-impl SpecFrom<SpecServerNameListInner> for SpecServerNameList {
-    open spec fn spec_from(m: SpecServerNameListInner) -> SpecServerNameList {
+impl SpecFrom<SpecCertificateAuthoritiesExtensionInner> for SpecCertificateAuthoritiesExtension {
+    open spec fn spec_from(m: SpecCertificateAuthoritiesExtensionInner) -> SpecCertificateAuthoritiesExtension {
         let (l, list) = m;
-        SpecServerNameList { l, list }
+        SpecCertificateAuthoritiesExtension { l, list }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 
-pub struct ServerNameList<'a> {
+pub struct CertificateAuthoritiesExtension<'a> {
     pub l: u16,
-    pub list: RepeatResult<ServerName<'a>>,
+    pub list: RepeatResult<DistinguishedName<'a>>,
 }
 
-impl View for ServerNameList<'_> {
-    type V = SpecServerNameList;
+impl View for CertificateAuthoritiesExtension<'_> {
+    type V = SpecCertificateAuthoritiesExtension;
 
     open spec fn view(&self) -> Self::V {
-        SpecServerNameList {
+        SpecCertificateAuthoritiesExtension {
             l: self.l@,
             list: self.list@,
         }
     }
 }
-pub type ServerNameListInner<'a> = (u16, RepeatResult<ServerName<'a>>);
-impl<'a> From<ServerNameList<'a>> for ServerNameListInner<'a> {
-    fn ex_from(m: ServerNameList) -> ServerNameListInner {
+pub type CertificateAuthoritiesExtensionInner<'a> = (u16, RepeatResult<DistinguishedName<'a>>);
+impl<'a> From<CertificateAuthoritiesExtension<'a>> for CertificateAuthoritiesExtensionInner<'a> {
+    fn ex_from(m: CertificateAuthoritiesExtension) -> CertificateAuthoritiesExtensionInner {
         (m.l, m.list)
     }
 }
-impl<'a> From<ServerNameListInner<'a>> for ServerNameList<'a> {
-    fn ex_from(m: ServerNameListInner) -> ServerNameList {
+impl<'a> From<CertificateAuthoritiesExtensionInner<'a>> for CertificateAuthoritiesExtension<'a> {
+    fn ex_from(m: CertificateAuthoritiesExtensionInner) -> CertificateAuthoritiesExtension {
         let (l, list) = m;
-        ServerNameList { l, list }
+        CertificateAuthoritiesExtension { l, list }
     }
 }
 
-pub struct ServerNameListMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ServerNameListMapper<'a> {
+pub struct CertificateAuthoritiesExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> CertificateAuthoritiesExtensionMapper<'a> {
     pub closed spec fn spec_new() -> Self {
-        ServerNameListMapper(PhantomData)
+        CertificateAuthoritiesExtensionMapper(PhantomData)
     }
     pub fn new() -> Self {
-        ServerNameListMapper(PhantomData)
+        CertificateAuthoritiesExtensionMapper(PhantomData)
     }
 }
-impl View for ServerNameListMapper<'_> {
+impl View for CertificateAuthoritiesExtensionMapper<'_> {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for ServerNameListMapper<'_> {
-    type Src = SpecServerNameListInner;
-    type Dst = SpecServerNameList;
+impl SpecIso for CertificateAuthoritiesExtensionMapper<'_> {
+    type Src = SpecCertificateAuthoritiesExtensionInner;
+    type Dst = SpecCertificateAuthoritiesExtension;
+}
+impl SpecIsoProof for CertificateAuthoritiesExtensionMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -2258,23 +630,23 @@ impl SpecIso for ServerNameListMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for ServerNameListMapper<'a> {
-    type Src = ServerNameListInner<'a>;
-    type Dst = ServerNameList<'a>;
+impl<'a> Iso for CertificateAuthoritiesExtensionMapper<'a> {
+    type Src = CertificateAuthoritiesExtensionInner<'a>;
+    type Dst = CertificateAuthoritiesExtension<'a>;
 }
 
-pub struct SpecServerNameListCombinator(SpecServerNameListCombinatorAlias);
+pub struct SpecCertificateAuthoritiesExtensionCombinator(SpecCertificateAuthoritiesExtensionCombinatorAlias);
 
-impl SpecCombinator for SpecServerNameListCombinator {
-    type Type = SpecServerNameList;
+impl SpecCombinator for SpecCertificateAuthoritiesExtensionCombinator {
+    type Type = SpecCertificateAuthoritiesExtension;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecServerNameListCombinator {
+impl SecureSpecCombinator for SpecCertificateAuthoritiesExtensionCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecServerNameListCombinatorAlias::is_prefix_secure() }
+    { SpecCertificateAuthoritiesExtensionCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -2288,16 +660,40 @@ impl SecureSpecCombinator for SpecServerNameListCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecServerNameListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<SpecServerNameCombinator>>>, ServerNameListMapper<'static>>;
+pub type SpecCertificateAuthoritiesExtensionCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate7402808336413996182>, AndThen<Bytes, Repeat<SpecDistinguishedNameCombinator>>>, CertificateAuthoritiesExtensionMapper<'static>>;
+pub struct Predicate7402808336413996182;
+impl View for Predicate7402808336413996182 {
+    type V = Self;
 
-pub struct ServerNameListCombinator<'a>(ServerNameListCombinatorAlias<'a>);
-
-impl<'a> View for ServerNameListCombinator<'a> {
-    type V = SpecServerNameListCombinator;
-    closed spec fn view(&self) -> Self::V { SpecServerNameListCombinator(self.0@) }
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameListCombinator<'a> {
-    type Type = ServerNameList<'a>;
+impl Pred for Predicate7402808336413996182 {
+    type Input = u16;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 3 && i <= 65535)
+    }
+}
+impl SpecPred for Predicate7402808336413996182 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 3 && i <= 65535)
+    }
+}
+
+pub struct CertificateAuthoritiesExtensionCombinator<'a>(CertificateAuthoritiesExtensionCombinatorAlias<'a>);
+
+impl<'a> View for CertificateAuthoritiesExtensionCombinator<'a> {
+    type V = SpecCertificateAuthoritiesExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCertificateAuthoritiesExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateAuthoritiesExtensionCombinator<'a> {
+    type Type = CertificateAuthoritiesExtension<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -2311,119 +707,52 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameListCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type ServerNameListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<ServerNameCombinator<'a>>>, ServerNameListCont0<'a>>, ServerNameListMapper<'a>>;
+pub type CertificateAuthoritiesExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate7402808336413996182>, AndThen<Bytes, Repeat<DistinguishedNameCombinator<'a>>>, CertificateAuthoritiesExtensionCont0<'a>>, CertificateAuthoritiesExtensionMapper<'a>>;
 
 
-pub closed spec fn spec_server_name_list() -> SpecServerNameListCombinator {
-    SpecServerNameListCombinator(
+pub closed spec fn spec_certificate_authorities_extension() -> SpecCertificateAuthoritiesExtensionCombinator {
+    SpecCertificateAuthoritiesExtensionCombinator(
     Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: |deps| spec_server_name_list_cont0(deps) },
-        mapper: ServerNameListMapper::spec_new(),
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate7402808336413996182 }, snd: |deps| spec_certificate_authorities_extension_cont0(deps) },
+        mapper: CertificateAuthoritiesExtensionMapper::spec_new(),
     })
 }
 
-pub open spec fn spec_server_name_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecServerNameCombinator>> {
+pub open spec fn spec_certificate_authorities_extension_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecDistinguishedNameCombinator>> {
     let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_server_name()))
+    AndThen(Bytes(l.spec_into()), Repeat(spec_distinguished_name()))
 }
                 
-pub fn server_name_list<'a>() -> (o: ServerNameListCombinator<'a>)
-    ensures o@ == spec_server_name_list(),
+pub fn certificate_authorities_extension<'a>() -> (o: CertificateAuthoritiesExtensionCombinator<'a>)
+    ensures o@ == spec_certificate_authorities_extension(),
 {
-    ServerNameListCombinator(
+    CertificateAuthoritiesExtensionCombinator(
     Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: ServerNameListCont0::new(), spec_snd: Ghost(|deps| spec_server_name_list_cont0(deps)) },
-        mapper: ServerNameListMapper::new(),
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate7402808336413996182 }, snd: CertificateAuthoritiesExtensionCont0::new(), spec_snd: Ghost(|deps| spec_certificate_authorities_extension_cont0(deps)) },
+        mapper: CertificateAuthoritiesExtensionMapper::new(),
     })
 }
 
-pub struct ServerNameListCont0<'a>(PhantomData<&'a ()>);
-impl<'a> ServerNameListCont0<'a> {
+pub struct CertificateAuthoritiesExtensionCont0<'a>(PhantomData<&'a ()>);
+impl<'a> CertificateAuthoritiesExtensionCont0<'a> {
     pub fn new() -> Self {
-        ServerNameListCont0(PhantomData)
+        CertificateAuthoritiesExtensionCont0(PhantomData)
     }
 }
-impl<'a> Continuation<&u16> for ServerNameListCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<ServerNameCombinator<'a>>>;
+impl<'a> Continuation<&u16> for CertificateAuthoritiesExtensionCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<DistinguishedNameCombinator<'a>>>;
 
     open spec fn requires(&self, deps: &u16) -> bool { true }
 
     open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_server_name_list_cont0(deps@)
+        o@ == spec_certificate_authorities_extension_cont0(deps@)
     }
 
     fn apply(&self, deps: &u16) -> Self::Output {
         let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(server_name()))
+        AndThen(Bytes(l.ex_into()), Repeat::new(distinguished_name()))
     }
 }
-                
-pub type SpecMaxFragmentLength = u8;
-pub type MaxFragmentLength = u8;
-
-
-pub struct SpecMaxFragmentLengthCombinator(SpecMaxFragmentLengthCombinatorAlias);
-
-impl SpecCombinator for SpecMaxFragmentLengthCombinator {
-    type Type = SpecMaxFragmentLength;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMaxFragmentLengthCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMaxFragmentLengthCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMaxFragmentLengthCombinatorAlias = U8;
-
-pub struct MaxFragmentLengthCombinator(MaxFragmentLengthCombinatorAlias);
-
-impl View for MaxFragmentLengthCombinator {
-    type V = SpecMaxFragmentLengthCombinator;
-    closed spec fn view(&self) -> Self::V { SpecMaxFragmentLengthCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for MaxFragmentLengthCombinator {
-    type Type = MaxFragmentLength;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type MaxFragmentLengthCombinatorAlias = U8;
-
-
-pub closed spec fn spec_max_fragment_length() -> SpecMaxFragmentLengthCombinator {
-    SpecMaxFragmentLengthCombinator(U8)
-}
-
-                
-pub fn max_fragment_length() -> (o: MaxFragmentLengthCombinator)
-    ensures o@ == spec_max_fragment_length(),
-{
-    MaxFragmentLengthCombinator(U8)
-}
-
                 
 pub type SpecResponderId = SpecOpaque1Ffff;
 pub type ResponderId<'a> = Opaque1Ffff<'a>;
@@ -2558,6 +887,8 @@ impl View for ResponderIdListMapper<'_> {
 impl SpecIso for ResponderIdListMapper<'_> {
     type Src = SpecResponderIdListInner;
     type Dst = SpecResponderIdList;
+}
+impl SpecIsoProof for ResponderIdListMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -2731,6 +1062,8 @@ impl View for Opaque0FfffMapper<'_> {
 impl SpecIso for Opaque0FfffMapper<'_> {
     type Src = SpecOpaque0FfffInner;
     type Dst = SpecOpaque0Ffff;
+}
+impl SpecIsoProof for Opaque0FfffMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -2971,6 +1304,8 @@ impl View for OscpStatusRequestMapper<'_> {
 impl SpecIso for OscpStatusRequestMapper<'_> {
     type Src = SpecOscpStatusRequestInner;
     type Dst = SpecOscpStatusRequest;
+}
+impl SpecIsoProof for OscpStatusRequestMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -3120,6 +1455,8 @@ impl View for CertificateStatusRequestMapper<'_> {
 impl SpecIso for CertificateStatusRequestMapper<'_> {
     type Src = SpecCertificateStatusRequestInner;
     type Dst = SpecCertificateStatusRequest;
+}
+impl SpecIsoProof for CertificateStatusRequestMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -3204,96 +1541,22 @@ pub fn certificate_status_request<'a>() -> (o: CertificateStatusRequestCombinato
 }
 
                 
+pub type SpecSerializedSct = SpecOpaque1Ffff;
+pub type SerializedSct<'a> = Opaque1Ffff<'a>;
 
-pub struct SpecNamedGroupList {
-    pub l: u16,
-    pub list: Seq<SpecNamedGroup>,
-}
 
-pub type SpecNamedGroupListInner = (u16, Seq<SpecNamedGroup>);
-impl SpecFrom<SpecNamedGroupList> for SpecNamedGroupListInner {
-    open spec fn spec_from(m: SpecNamedGroupList) -> SpecNamedGroupListInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecNamedGroupListInner> for SpecNamedGroupList {
-    open spec fn spec_from(m: SpecNamedGroupListInner) -> SpecNamedGroupList {
-        let (l, list) = m;
-        SpecNamedGroupList { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecSerializedSctCombinator(SpecSerializedSctCombinatorAlias);
 
-pub struct NamedGroupList {
-    pub l: u16,
-    pub list: RepeatResult<NamedGroup>,
-}
-
-impl View for NamedGroupList {
-    type V = SpecNamedGroupList;
-
-    open spec fn view(&self) -> Self::V {
-        SpecNamedGroupList {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type NamedGroupListInner = (u16, RepeatResult<NamedGroup>);
-impl From<NamedGroupList> for NamedGroupListInner {
-    fn ex_from(m: NamedGroupList) -> NamedGroupListInner {
-        (m.l, m.list)
-    }
-}
-impl From<NamedGroupListInner> for NamedGroupList {
-    fn ex_from(m: NamedGroupListInner) -> NamedGroupList {
-        let (l, list) = m;
-        NamedGroupList { l, list }
-    }
-}
-
-pub struct NamedGroupListMapper;
-impl NamedGroupListMapper {
-    pub closed spec fn spec_new() -> Self {
-        NamedGroupListMapper
-    }
-    pub fn new() -> Self {
-        NamedGroupListMapper
-    }
-}
-impl View for NamedGroupListMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for NamedGroupListMapper {
-    type Src = SpecNamedGroupListInner;
-    type Dst = SpecNamedGroupList;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for NamedGroupListMapper {
-    type Src = NamedGroupListInner;
-    type Dst = NamedGroupList;
-}
-
-pub struct SpecNamedGroupListCombinator(SpecNamedGroupListCombinatorAlias);
-
-impl SpecCombinator for SpecNamedGroupListCombinator {
-    type Type = SpecNamedGroupList;
+impl SpecCombinator for SpecSerializedSctCombinator {
+    type Type = SpecSerializedSct;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecNamedGroupListCombinator {
+impl SecureSpecCombinator for SpecSerializedSctCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecNamedGroupListCombinatorAlias::is_prefix_secure() }
+    { SpecSerializedSctCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -3307,40 +1570,16 @@ impl SecureSpecCombinator for SpecNamedGroupListCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecNamedGroupListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<SpecNamedGroupCombinator>>>, NamedGroupListMapper>;
-pub struct Predicate8195707947578446211;
-impl View for Predicate8195707947578446211 {
-    type V = Self;
+pub type SpecSerializedSctCombinatorAlias = SpecOpaque1FfffCombinator;
 
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
+pub struct SerializedSctCombinator<'a>(SerializedSctCombinatorAlias<'a>);
+
+impl<'a> View for SerializedSctCombinator<'a> {
+    type V = SpecSerializedSctCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSerializedSctCombinator(self.0@) }
 }
-impl Pred for Predicate8195707947578446211 {
-    type Input = u16;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 2 && i <= 65535)
-    }
-}
-impl SpecPred for Predicate8195707947578446211 {
-    type Input = u16;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 2 && i <= 65535)
-    }
-}
-
-pub struct NamedGroupListCombinator<'a>(NamedGroupListCombinatorAlias<'a>);
-
-impl<'a> View for NamedGroupListCombinator<'a> {
-    type V = SpecNamedGroupListCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNamedGroupListCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NamedGroupListCombinator<'a> {
-    type Type = NamedGroupList;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SerializedSctCombinator<'a> {
+    type Type = SerializedSct<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -3354,647 +1593,219 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for NamedGroupListCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type NamedGroupListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<NamedGroupCombinator>>, NamedGroupListCont0<'a>>, NamedGroupListMapper>;
+pub type SerializedSctCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
 
 
-pub closed spec fn spec_named_group_list() -> SpecNamedGroupListCombinator {
-    SpecNamedGroupListCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: |deps| spec_named_group_list_cont0(deps) },
-        mapper: NamedGroupListMapper::spec_new(),
-    })
+pub closed spec fn spec_serialized_sct() -> SpecSerializedSctCombinator {
+    SpecSerializedSctCombinator(spec_opaque_1_ffff())
 }
 
-pub open spec fn spec_named_group_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecNamedGroupCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_named_group()))
-}
                 
-pub fn named_group_list<'a>() -> (o: NamedGroupListCombinator<'a>)
-    ensures o@ == spec_named_group_list(),
+pub fn serialized_sct<'a>() -> (o: SerializedSctCombinator<'a>)
+    ensures o@ == spec_serialized_sct(),
 {
-    NamedGroupListCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: NamedGroupListCont0::new(), spec_snd: Ghost(|deps| spec_named_group_list_cont0(deps)) },
-        mapper: NamedGroupListMapper::new(),
-    })
+    SerializedSctCombinator(opaque_1_ffff())
 }
 
-pub struct NamedGroupListCont0<'a>(PhantomData<&'a ()>);
-impl<'a> NamedGroupListCont0<'a> {
-    pub fn new() -> Self {
-        NamedGroupListCont0(PhantomData)
+                
+
+pub struct SpecSignedCertificateTimestampList {
+    pub l: u16,
+    pub list: Seq<SpecSerializedSct>,
+}
+
+pub type SpecSignedCertificateTimestampListInner = (u16, Seq<SpecSerializedSct>);
+impl SpecFrom<SpecSignedCertificateTimestampList> for SpecSignedCertificateTimestampListInner {
+    open spec fn spec_from(m: SpecSignedCertificateTimestampList) -> SpecSignedCertificateTimestampListInner {
+        (m.l, m.list)
     }
 }
-impl<'a> Continuation<&u16> for NamedGroupListCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<NamedGroupCombinator>>;
+impl SpecFrom<SpecSignedCertificateTimestampListInner> for SpecSignedCertificateTimestampList {
+    open spec fn spec_from(m: SpecSignedCertificateTimestampListInner) -> SpecSignedCertificateTimestampList {
+        let (l, list) = m;
+        SpecSignedCertificateTimestampList { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct SignedCertificateTimestampList<'a> {
+    pub l: u16,
+    pub list: RepeatResult<SerializedSct<'a>>,
+}
+
+impl View for SignedCertificateTimestampList<'_> {
+    type V = SpecSignedCertificateTimestampList;
+
+    open spec fn view(&self) -> Self::V {
+        SpecSignedCertificateTimestampList {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type SignedCertificateTimestampListInner<'a> = (u16, RepeatResult<SerializedSct<'a>>);
+impl<'a> From<SignedCertificateTimestampList<'a>> for SignedCertificateTimestampListInner<'a> {
+    fn ex_from(m: SignedCertificateTimestampList) -> SignedCertificateTimestampListInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<SignedCertificateTimestampListInner<'a>> for SignedCertificateTimestampList<'a> {
+    fn ex_from(m: SignedCertificateTimestampListInner) -> SignedCertificateTimestampList {
+        let (l, list) = m;
+        SignedCertificateTimestampList { l, list }
+    }
+}
+
+pub struct SignedCertificateTimestampListMapper<'a>(PhantomData<&'a ()>);
+impl<'a> SignedCertificateTimestampListMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        SignedCertificateTimestampListMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        SignedCertificateTimestampListMapper(PhantomData)
+    }
+}
+impl View for SignedCertificateTimestampListMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for SignedCertificateTimestampListMapper<'_> {
+    type Src = SpecSignedCertificateTimestampListInner;
+    type Dst = SpecSignedCertificateTimestampList;
+}
+impl SpecIsoProof for SignedCertificateTimestampListMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for SignedCertificateTimestampListMapper<'a> {
+    type Src = SignedCertificateTimestampListInner<'a>;
+    type Dst = SignedCertificateTimestampList<'a>;
+}
+
+pub struct SpecSignedCertificateTimestampListCombinator(SpecSignedCertificateTimestampListCombinatorAlias);
+
+impl SpecCombinator for SpecSignedCertificateTimestampListCombinator {
+    type Type = SpecSignedCertificateTimestampList;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSignedCertificateTimestampListCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSignedCertificateTimestampListCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSignedCertificateTimestampListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<SpecSerializedSctCombinator>>>, SignedCertificateTimestampListMapper<'static>>;
+pub struct Predicate16977634203518580913;
+impl View for Predicate16977634203518580913 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate16977634203518580913 {
+    type Input = u16;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 1 && i <= 65535)
+    }
+}
+impl SpecPred for Predicate16977634203518580913 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 1 && i <= 65535)
+    }
+}
+
+pub struct SignedCertificateTimestampListCombinator<'a>(SignedCertificateTimestampListCombinatorAlias<'a>);
+
+impl<'a> View for SignedCertificateTimestampListCombinator<'a> {
+    type V = SpecSignedCertificateTimestampListCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSignedCertificateTimestampListCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SignedCertificateTimestampListCombinator<'a> {
+    type Type = SignedCertificateTimestampList<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SignedCertificateTimestampListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<SerializedSctCombinator<'a>>>, SignedCertificateTimestampListCont0<'a>>, SignedCertificateTimestampListMapper<'a>>;
+
+
+pub closed spec fn spec_signed_certificate_timestamp_list() -> SpecSignedCertificateTimestampListCombinator {
+    SpecSignedCertificateTimestampListCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: |deps| spec_signed_certificate_timestamp_list_cont0(deps) },
+        mapper: SignedCertificateTimestampListMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_signed_certificate_timestamp_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSerializedSctCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_serialized_sct()))
+}
+                
+pub fn signed_certificate_timestamp_list<'a>() -> (o: SignedCertificateTimestampListCombinator<'a>)
+    ensures o@ == spec_signed_certificate_timestamp_list(),
+{
+    SignedCertificateTimestampListCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: SignedCertificateTimestampListCont0::new(), spec_snd: Ghost(|deps| spec_signed_certificate_timestamp_list_cont0(deps)) },
+        mapper: SignedCertificateTimestampListMapper::new(),
+    })
+}
+
+pub struct SignedCertificateTimestampListCont0<'a>(PhantomData<&'a ()>);
+impl<'a> SignedCertificateTimestampListCont0<'a> {
+    pub fn new() -> Self {
+        SignedCertificateTimestampListCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for SignedCertificateTimestampListCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<SerializedSctCombinator<'a>>>;
 
     open spec fn requires(&self, deps: &u16) -> bool { true }
 
     open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_named_group_list_cont0(deps@)
+        o@ == spec_signed_certificate_timestamp_list_cont0(deps@)
     }
 
     fn apply(&self, deps: &u16) -> Self::Output {
         let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(named_group()))
+        AndThen(Bytes(l.ex_into()), Repeat::new(serialized_sct()))
     }
 }
-                
-pub type SpecEcPointFormat = u8;
-pub type EcPointFormat = u8;
-
-
-pub struct SpecEcPointFormatCombinator(SpecEcPointFormatCombinatorAlias);
-
-impl SpecCombinator for SpecEcPointFormatCombinator {
-    type Type = SpecEcPointFormat;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecEcPointFormatCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecEcPointFormatCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecEcPointFormatCombinatorAlias = U8;
-
-pub struct EcPointFormatCombinator(EcPointFormatCombinatorAlias);
-
-impl View for EcPointFormatCombinator {
-    type V = SpecEcPointFormatCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEcPointFormatCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EcPointFormatCombinator {
-    type Type = EcPointFormat;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type EcPointFormatCombinatorAlias = U8;
-
-
-pub closed spec fn spec_ec_point_format() -> SpecEcPointFormatCombinator {
-    SpecEcPointFormatCombinator(U8)
-}
-
-                
-pub fn ec_point_format() -> (o: EcPointFormatCombinator)
-    ensures o@ == spec_ec_point_format(),
-{
-    EcPointFormatCombinator(U8)
-}
-
-                
-
-pub struct SpecEcPointFormatList {
-    pub l: u8,
-    pub list: Seq<SpecEcPointFormat>,
-}
-
-pub type SpecEcPointFormatListInner = (u8, Seq<SpecEcPointFormat>);
-impl SpecFrom<SpecEcPointFormatList> for SpecEcPointFormatListInner {
-    open spec fn spec_from(m: SpecEcPointFormatList) -> SpecEcPointFormatListInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecEcPointFormatListInner> for SpecEcPointFormatList {
-    open spec fn spec_from(m: SpecEcPointFormatListInner) -> SpecEcPointFormatList {
-        let (l, list) = m;
-        SpecEcPointFormatList { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct EcPointFormatList {
-    pub l: u8,
-    pub list: RepeatResult<EcPointFormat>,
-}
-
-impl View for EcPointFormatList {
-    type V = SpecEcPointFormatList;
-
-    open spec fn view(&self) -> Self::V {
-        SpecEcPointFormatList {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type EcPointFormatListInner = (u8, RepeatResult<EcPointFormat>);
-impl From<EcPointFormatList> for EcPointFormatListInner {
-    fn ex_from(m: EcPointFormatList) -> EcPointFormatListInner {
-        (m.l, m.list)
-    }
-}
-impl From<EcPointFormatListInner> for EcPointFormatList {
-    fn ex_from(m: EcPointFormatListInner) -> EcPointFormatList {
-        let (l, list) = m;
-        EcPointFormatList { l, list }
-    }
-}
-
-pub struct EcPointFormatListMapper;
-impl EcPointFormatListMapper {
-    pub closed spec fn spec_new() -> Self {
-        EcPointFormatListMapper
-    }
-    pub fn new() -> Self {
-        EcPointFormatListMapper
-    }
-}
-impl View for EcPointFormatListMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for EcPointFormatListMapper {
-    type Src = SpecEcPointFormatListInner;
-    type Dst = SpecEcPointFormatList;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for EcPointFormatListMapper {
-    type Src = EcPointFormatListInner;
-    type Dst = EcPointFormatList;
-}
-
-pub struct SpecEcPointFormatListCombinator(SpecEcPointFormatListCombinatorAlias);
-
-impl SpecCombinator for SpecEcPointFormatListCombinator {
-    type Type = SpecEcPointFormatList;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecEcPointFormatListCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecEcPointFormatListCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecEcPointFormatListCombinatorAlias = Mapped<SpecDepend<Refined<U8, Predicate13984338198318635021>, AndThen<Bytes, Repeat<SpecEcPointFormatCombinator>>>, EcPointFormatListMapper>;
-pub struct Predicate13984338198318635021;
-impl View for Predicate13984338198318635021 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred for Predicate13984338198318635021 {
-    type Input = u8;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 1 && i <= 255)
-    }
-}
-impl SpecPred for Predicate13984338198318635021 {
-    type Input = u8;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 1 && i <= 255)
-    }
-}
-
-pub struct EcPointFormatListCombinator<'a>(EcPointFormatListCombinatorAlias<'a>);
-
-impl<'a> View for EcPointFormatListCombinator<'a> {
-    type V = SpecEcPointFormatListCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEcPointFormatListCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EcPointFormatListCombinator<'a> {
-    type Type = EcPointFormatList;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type EcPointFormatListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U8, Predicate13984338198318635021>, AndThen<Bytes, Repeat<EcPointFormatCombinator>>, EcPointFormatListCont0<'a>>, EcPointFormatListMapper>;
-
-
-pub closed spec fn spec_ec_point_format_list() -> SpecEcPointFormatListCombinator {
-    SpecEcPointFormatListCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U8, predicate: Predicate13984338198318635021 }, snd: |deps| spec_ec_point_format_list_cont0(deps) },
-        mapper: EcPointFormatListMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_ec_point_format_list_cont0(deps: u8) -> AndThen<Bytes, Repeat<SpecEcPointFormatCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_ec_point_format()))
-}
-                
-pub fn ec_point_format_list<'a>() -> (o: EcPointFormatListCombinator<'a>)
-    ensures o@ == spec_ec_point_format_list(),
-{
-    EcPointFormatListCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U8, predicate: Predicate13984338198318635021 }, snd: EcPointFormatListCont0::new(), spec_snd: Ghost(|deps| spec_ec_point_format_list_cont0(deps)) },
-        mapper: EcPointFormatListMapper::new(),
-    })
-}
-
-pub struct EcPointFormatListCont0<'a>(PhantomData<&'a ()>);
-impl<'a> EcPointFormatListCont0<'a> {
-    pub fn new() -> Self {
-        EcPointFormatListCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u8> for EcPointFormatListCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<EcPointFormatCombinator>>;
-
-    open spec fn requires(&self, deps: &u8) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u8, o: Self::Output) -> bool {
-        o@ == spec_ec_point_format_list_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u8) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(ec_point_format()))
-    }
-}
-                
-pub type SpecSignatureScheme = u16;
-pub type SignatureScheme = u16;
-
-
-pub struct SpecSignatureSchemeCombinator(SpecSignatureSchemeCombinatorAlias);
-
-impl SpecCombinator for SpecSignatureSchemeCombinator {
-    type Type = SpecSignatureScheme;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSignatureSchemeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSignatureSchemeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSignatureSchemeCombinatorAlias = U16Be;
-
-pub struct SignatureSchemeCombinator(SignatureSchemeCombinatorAlias);
-
-impl View for SignatureSchemeCombinator {
-    type V = SpecSignatureSchemeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSignatureSchemeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SignatureSchemeCombinator {
-    type Type = SignatureScheme;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SignatureSchemeCombinatorAlias = U16Be;
-
-
-pub closed spec fn spec_signature_scheme() -> SpecSignatureSchemeCombinator {
-    SpecSignatureSchemeCombinator(U16Be)
-}
-
-                
-pub fn signature_scheme() -> (o: SignatureSchemeCombinator)
-    ensures o@ == spec_signature_scheme(),
-{
-    SignatureSchemeCombinator(U16Be)
-}
-
-                
-
-pub struct SpecSignatureSchemeList {
-    pub l: u16,
-    pub list: Seq<SpecSignatureScheme>,
-}
-
-pub type SpecSignatureSchemeListInner = (u16, Seq<SpecSignatureScheme>);
-impl SpecFrom<SpecSignatureSchemeList> for SpecSignatureSchemeListInner {
-    open spec fn spec_from(m: SpecSignatureSchemeList) -> SpecSignatureSchemeListInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecSignatureSchemeListInner> for SpecSignatureSchemeList {
-    open spec fn spec_from(m: SpecSignatureSchemeListInner) -> SpecSignatureSchemeList {
-        let (l, list) = m;
-        SpecSignatureSchemeList { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct SignatureSchemeList {
-    pub l: u16,
-    pub list: RepeatResult<SignatureScheme>,
-}
-
-impl View for SignatureSchemeList {
-    type V = SpecSignatureSchemeList;
-
-    open spec fn view(&self) -> Self::V {
-        SpecSignatureSchemeList {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type SignatureSchemeListInner = (u16, RepeatResult<SignatureScheme>);
-impl From<SignatureSchemeList> for SignatureSchemeListInner {
-    fn ex_from(m: SignatureSchemeList) -> SignatureSchemeListInner {
-        (m.l, m.list)
-    }
-}
-impl From<SignatureSchemeListInner> for SignatureSchemeList {
-    fn ex_from(m: SignatureSchemeListInner) -> SignatureSchemeList {
-        let (l, list) = m;
-        SignatureSchemeList { l, list }
-    }
-}
-
-pub struct SignatureSchemeListMapper;
-impl SignatureSchemeListMapper {
-    pub closed spec fn spec_new() -> Self {
-        SignatureSchemeListMapper
-    }
-    pub fn new() -> Self {
-        SignatureSchemeListMapper
-    }
-}
-impl View for SignatureSchemeListMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for SignatureSchemeListMapper {
-    type Src = SpecSignatureSchemeListInner;
-    type Dst = SpecSignatureSchemeList;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for SignatureSchemeListMapper {
-    type Src = SignatureSchemeListInner;
-    type Dst = SignatureSchemeList;
-}
-
-pub struct SpecSignatureSchemeListCombinator(SpecSignatureSchemeListCombinatorAlias);
-
-impl SpecCombinator for SpecSignatureSchemeListCombinator {
-    type Type = SpecSignatureSchemeList;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSignatureSchemeListCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSignatureSchemeListCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSignatureSchemeListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<SpecSignatureSchemeCombinator>>>, SignatureSchemeListMapper>;
-pub struct Predicate15206902916018849611;
-impl View for Predicate15206902916018849611 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred for Predicate15206902916018849611 {
-    type Input = u16;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 2 && i <= 65534)
-    }
-}
-impl SpecPred for Predicate15206902916018849611 {
-    type Input = u16;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 2 && i <= 65534)
-    }
-}
-
-pub struct SignatureSchemeListCombinator<'a>(SignatureSchemeListCombinatorAlias<'a>);
-
-impl<'a> View for SignatureSchemeListCombinator<'a> {
-    type V = SpecSignatureSchemeListCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSignatureSchemeListCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SignatureSchemeListCombinator<'a> {
-    type Type = SignatureSchemeList;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SignatureSchemeListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<SignatureSchemeCombinator>>, SignatureSchemeListCont0<'a>>, SignatureSchemeListMapper>;
-
-
-pub closed spec fn spec_signature_scheme_list() -> SpecSignatureSchemeListCombinator {
-    SpecSignatureSchemeListCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: |deps| spec_signature_scheme_list_cont0(deps) },
-        mapper: SignatureSchemeListMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_signature_scheme_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSignatureSchemeCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_signature_scheme()))
-}
-                
-pub fn signature_scheme_list<'a>() -> (o: SignatureSchemeListCombinator<'a>)
-    ensures o@ == spec_signature_scheme_list(),
-{
-    SignatureSchemeListCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: SignatureSchemeListCont0::new(), spec_snd: Ghost(|deps| spec_signature_scheme_list_cont0(deps)) },
-        mapper: SignatureSchemeListMapper::new(),
-    })
-}
-
-pub struct SignatureSchemeListCont0<'a>(PhantomData<&'a ()>);
-impl<'a> SignatureSchemeListCont0<'a> {
-    pub fn new() -> Self {
-        SignatureSchemeListCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for SignatureSchemeListCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<SignatureSchemeCombinator>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_signature_scheme_list_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(signature_scheme()))
-    }
-}
-                
-pub type SpecHeartbeatMode = u8;
-pub type HeartbeatMode = u8;
-
-
-pub struct SpecHeartbeatModeCombinator(SpecHeartbeatModeCombinatorAlias);
-
-impl SpecCombinator for SpecHeartbeatModeCombinator {
-    type Type = SpecHeartbeatMode;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecHeartbeatModeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecHeartbeatModeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecHeartbeatModeCombinatorAlias = U8;
-
-pub struct HeartbeatModeCombinator(HeartbeatModeCombinatorAlias);
-
-impl View for HeartbeatModeCombinator {
-    type V = SpecHeartbeatModeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHeartbeatModeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HeartbeatModeCombinator {
-    type Type = HeartbeatMode;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type HeartbeatModeCombinatorAlias = U8;
-
-
-pub closed spec fn spec_heartbeat_mode() -> SpecHeartbeatModeCombinator {
-    SpecHeartbeatModeCombinator(U8)
-}
-
-                
-pub fn heartbeat_mode() -> (o: HeartbeatModeCombinator)
-    ensures o@ == spec_heartbeat_mode(),
-{
-    HeartbeatModeCombinator(U8)
-}
-
                 
 
 pub struct SpecOpaque1Ff {
@@ -4062,6 +1873,8 @@ impl View for Opaque1FfMapper<'_> {
 impl SpecIso for Opaque1FfMapper<'_> {
     type Src = SpecOpaque1FfInner;
     type Dst = SpecOpaque1Ff;
+}
+impl SpecIsoProof for Opaque1FfMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -4190,6 +2003,4774 @@ impl<'a> Continuation<&u8> for Opaque1FfCont0<'a> {
     fn apply(&self, deps: &u8) -> Self::Output {
         let l = *deps;
         Bytes(l.ex_into())
+    }
+}
+                
+
+pub struct SpecOidFilter {
+    pub certificate_extension_oid: SpecOpaque1Ff,
+    pub certificate_extension_values: SpecOpaque0Ffff,
+}
+
+pub type SpecOidFilterInner = (SpecOpaque1Ff, SpecOpaque0Ffff);
+impl SpecFrom<SpecOidFilter> for SpecOidFilterInner {
+    open spec fn spec_from(m: SpecOidFilter) -> SpecOidFilterInner {
+        (m.certificate_extension_oid, m.certificate_extension_values)
+    }
+}
+impl SpecFrom<SpecOidFilterInner> for SpecOidFilter {
+    open spec fn spec_from(m: SpecOidFilterInner) -> SpecOidFilter {
+        let (certificate_extension_oid, certificate_extension_values) = m;
+        SpecOidFilter { certificate_extension_oid, certificate_extension_values }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct OidFilter<'a> {
+    pub certificate_extension_oid: Opaque1Ff<'a>,
+    pub certificate_extension_values: Opaque0Ffff<'a>,
+}
+
+impl View for OidFilter<'_> {
+    type V = SpecOidFilter;
+
+    open spec fn view(&self) -> Self::V {
+        SpecOidFilter {
+            certificate_extension_oid: self.certificate_extension_oid@,
+            certificate_extension_values: self.certificate_extension_values@,
+        }
+    }
+}
+pub type OidFilterInner<'a> = (Opaque1Ff<'a>, Opaque0Ffff<'a>);
+impl<'a> From<OidFilter<'a>> for OidFilterInner<'a> {
+    fn ex_from(m: OidFilter) -> OidFilterInner {
+        (m.certificate_extension_oid, m.certificate_extension_values)
+    }
+}
+impl<'a> From<OidFilterInner<'a>> for OidFilter<'a> {
+    fn ex_from(m: OidFilterInner) -> OidFilter {
+        let (certificate_extension_oid, certificate_extension_values) = m;
+        OidFilter { certificate_extension_oid, certificate_extension_values }
+    }
+}
+
+pub struct OidFilterMapper<'a>(PhantomData<&'a ()>);
+impl<'a> OidFilterMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        OidFilterMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        OidFilterMapper(PhantomData)
+    }
+}
+impl View for OidFilterMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for OidFilterMapper<'_> {
+    type Src = SpecOidFilterInner;
+    type Dst = SpecOidFilter;
+}
+impl SpecIsoProof for OidFilterMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for OidFilterMapper<'a> {
+    type Src = OidFilterInner<'a>;
+    type Dst = OidFilter<'a>;
+}
+
+pub struct SpecOidFilterCombinator(SpecOidFilterCombinatorAlias);
+
+impl SpecCombinator for SpecOidFilterCombinator {
+    type Type = SpecOidFilter;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecOidFilterCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecOidFilterCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecOidFilterCombinatorAlias = Mapped<(SpecOpaque1FfCombinator, SpecOpaque0FfffCombinator), OidFilterMapper<'static>>;
+
+pub struct OidFilterCombinator<'a>(OidFilterCombinatorAlias<'a>);
+
+impl<'a> View for OidFilterCombinator<'a> {
+    type V = SpecOidFilterCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOidFilterCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for OidFilterCombinator<'a> {
+    type Type = OidFilter<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type OidFilterCombinatorAlias<'a> = Mapped<(Opaque1FfCombinator<'a>, Opaque0FfffCombinator<'a>), OidFilterMapper<'a>>;
+
+
+pub closed spec fn spec_oid_filter() -> SpecOidFilterCombinator {
+    SpecOidFilterCombinator(
+    Mapped {
+        inner: (spec_opaque_1_ff(), spec_opaque_0_ffff()),
+        mapper: OidFilterMapper::spec_new(),
+    })
+}
+
+                
+pub fn oid_filter<'a>() -> (o: OidFilterCombinator<'a>)
+    ensures o@ == spec_oid_filter(),
+{
+    OidFilterCombinator(
+    Mapped {
+        inner: (opaque_1_ff(), opaque_0_ffff()),
+        mapper: OidFilterMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecOidFilterExtension {
+    pub l: u16,
+    pub list: Seq<SpecOidFilter>,
+}
+
+pub type SpecOidFilterExtensionInner = (u16, Seq<SpecOidFilter>);
+impl SpecFrom<SpecOidFilterExtension> for SpecOidFilterExtensionInner {
+    open spec fn spec_from(m: SpecOidFilterExtension) -> SpecOidFilterExtensionInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecOidFilterExtensionInner> for SpecOidFilterExtension {
+    open spec fn spec_from(m: SpecOidFilterExtensionInner) -> SpecOidFilterExtension {
+        let (l, list) = m;
+        SpecOidFilterExtension { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct OidFilterExtension<'a> {
+    pub l: u16,
+    pub list: RepeatResult<OidFilter<'a>>,
+}
+
+impl View for OidFilterExtension<'_> {
+    type V = SpecOidFilterExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecOidFilterExtension {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type OidFilterExtensionInner<'a> = (u16, RepeatResult<OidFilter<'a>>);
+impl<'a> From<OidFilterExtension<'a>> for OidFilterExtensionInner<'a> {
+    fn ex_from(m: OidFilterExtension) -> OidFilterExtensionInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<OidFilterExtensionInner<'a>> for OidFilterExtension<'a> {
+    fn ex_from(m: OidFilterExtensionInner) -> OidFilterExtension {
+        let (l, list) = m;
+        OidFilterExtension { l, list }
+    }
+}
+
+pub struct OidFilterExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> OidFilterExtensionMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        OidFilterExtensionMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        OidFilterExtensionMapper(PhantomData)
+    }
+}
+impl View for OidFilterExtensionMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for OidFilterExtensionMapper<'_> {
+    type Src = SpecOidFilterExtensionInner;
+    type Dst = SpecOidFilterExtension;
+}
+impl SpecIsoProof for OidFilterExtensionMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for OidFilterExtensionMapper<'a> {
+    type Src = OidFilterExtensionInner<'a>;
+    type Dst = OidFilterExtension<'a>;
+}
+
+pub struct SpecOidFilterExtensionCombinator(SpecOidFilterExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecOidFilterExtensionCombinator {
+    type Type = SpecOidFilterExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecOidFilterExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecOidFilterExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecOidFilterExtensionCombinatorAlias = Mapped<SpecDepend<U16Be, AndThen<Bytes, Repeat<SpecOidFilterCombinator>>>, OidFilterExtensionMapper<'static>>;
+
+pub struct OidFilterExtensionCombinator<'a>(OidFilterExtensionCombinatorAlias<'a>);
+
+impl<'a> View for OidFilterExtensionCombinator<'a> {
+    type V = SpecOidFilterExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOidFilterExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for OidFilterExtensionCombinator<'a> {
+    type Type = OidFilterExtension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type OidFilterExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U16Be, AndThen<Bytes, Repeat<OidFilterCombinator<'a>>>, OidFilterExtensionCont0<'a>>, OidFilterExtensionMapper<'a>>;
+
+
+pub closed spec fn spec_oid_filter_extension() -> SpecOidFilterExtensionCombinator {
+    SpecOidFilterExtensionCombinator(
+    Mapped {
+        inner: SpecDepend { fst: U16Be, snd: |deps| spec_oid_filter_extension_cont0(deps) },
+        mapper: OidFilterExtensionMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_oid_filter_extension_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecOidFilterCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_oid_filter()))
+}
+                
+pub fn oid_filter_extension<'a>() -> (o: OidFilterExtensionCombinator<'a>)
+    ensures o@ == spec_oid_filter_extension(),
+{
+    OidFilterExtensionCombinator(
+    Mapped {
+        inner: Depend { fst: U16Be, snd: OidFilterExtensionCont0::new(), spec_snd: Ghost(|deps| spec_oid_filter_extension_cont0(deps)) },
+        mapper: OidFilterExtensionMapper::new(),
+    })
+}
+
+pub struct OidFilterExtensionCont0<'a>(PhantomData<&'a ()>);
+impl<'a> OidFilterExtensionCont0<'a> {
+    pub fn new() -> Self {
+        OidFilterExtensionCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for OidFilterExtensionCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<OidFilterCombinator<'a>>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_oid_filter_extension_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(oid_filter()))
+    }
+}
+                
+
+pub enum SpecCertificateRequestExtensionExtensionData {
+    SignatureAlgorithms(SpecSignatureSchemeList),
+    CertificateAuthorities(SpecCertificateAuthoritiesExtension),
+    SignatureAlgorithmsCert(SpecSignatureSchemeList),
+    StatusRequest(SpecCertificateStatusRequest),
+    SignedCertificateTimeStamp(SpecSignedCertificateTimestampList),
+    OidFilters(SpecOidFilterExtension),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecCertificateRequestExtensionExtensionDataInner = Either<SpecSignatureSchemeList, Either<SpecCertificateAuthoritiesExtension, Either<SpecSignatureSchemeList, Either<SpecCertificateStatusRequest, Either<SpecSignedCertificateTimestampList, Either<SpecOidFilterExtension, Seq<u8>>>>>>>;
+
+
+
+impl SpecFrom<SpecCertificateRequestExtensionExtensionData> for SpecCertificateRequestExtensionExtensionDataInner {
+    open spec fn spec_from(m: SpecCertificateRequestExtensionExtensionData) -> SpecCertificateRequestExtensionExtensionDataInner {
+        match m {
+            SpecCertificateRequestExtensionExtensionData::SignatureAlgorithms(m) => Either::Left(m),
+            SpecCertificateRequestExtensionExtensionData::CertificateAuthorities(m) => Either::Right(Either::Left(m)),
+            SpecCertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecCertificateRequestExtensionExtensionData::StatusRequest(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
+            SpecCertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
+            SpecCertificateRequestExtensionExtensionData::OidFilters(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
+            SpecCertificateRequestExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecCertificateRequestExtensionExtensionDataInner> for SpecCertificateRequestExtensionExtensionData {
+    open spec fn spec_from(m: SpecCertificateRequestExtensionExtensionDataInner) -> SpecCertificateRequestExtensionExtensionData {
+        match m {
+            Either::Left(m) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithms(m),
+            Either::Right(Either::Left(m)) => SpecCertificateRequestExtensionExtensionData::CertificateAuthorities(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m),
+            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => SpecCertificateRequestExtensionExtensionData::StatusRequest(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => SpecCertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => SpecCertificateRequestExtensionExtensionData::OidFilters(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))) => SpecCertificateRequestExtensionExtensionData::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CertificateRequestExtensionExtensionData<'a> {
+    SignatureAlgorithms(SignatureSchemeList),
+    CertificateAuthorities(CertificateAuthoritiesExtension<'a>),
+    SignatureAlgorithmsCert(SignatureSchemeList),
+    StatusRequest(CertificateStatusRequest<'a>),
+    SignedCertificateTimeStamp(SignedCertificateTimestampList<'a>),
+    OidFilters(OidFilterExtension<'a>),
+    Unrecognized(&'a [u8]),
+}
+
+pub type CertificateRequestExtensionExtensionDataInner<'a> = Either<SignatureSchemeList, Either<CertificateAuthoritiesExtension<'a>, Either<SignatureSchemeList, Either<CertificateStatusRequest<'a>, Either<SignedCertificateTimestampList<'a>, Either<OidFilterExtension<'a>, &'a [u8]>>>>>>;
+
+
+impl<'a> View for CertificateRequestExtensionExtensionData<'a> {
+    type V = SpecCertificateRequestExtensionExtensionData;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            CertificateRequestExtensionExtensionData::SignatureAlgorithms(m) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithms(m@),
+            CertificateRequestExtensionExtensionData::CertificateAuthorities(m) => SpecCertificateRequestExtensionExtensionData::CertificateAuthorities(m@),
+            CertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m@),
+            CertificateRequestExtensionExtensionData::StatusRequest(m) => SpecCertificateRequestExtensionExtensionData::StatusRequest(m@),
+            CertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m) => SpecCertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m@),
+            CertificateRequestExtensionExtensionData::OidFilters(m) => SpecCertificateRequestExtensionExtensionData::OidFilters(m@),
+            CertificateRequestExtensionExtensionData::Unrecognized(m) => SpecCertificateRequestExtensionExtensionData::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<CertificateRequestExtensionExtensionData<'a>> for CertificateRequestExtensionExtensionDataInner<'a> {
+    fn ex_from(m: CertificateRequestExtensionExtensionData<'a>) -> CertificateRequestExtensionExtensionDataInner<'a> {
+        match m {
+            CertificateRequestExtensionExtensionData::SignatureAlgorithms(m) => Either::Left(m),
+            CertificateRequestExtensionExtensionData::CertificateAuthorities(m) => Either::Right(Either::Left(m)),
+            CertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m) => Either::Right(Either::Right(Either::Left(m))),
+            CertificateRequestExtensionExtensionData::StatusRequest(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
+            CertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
+            CertificateRequestExtensionExtensionData::OidFilters(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
+            CertificateRequestExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))),
+        }
+    }
+
+}
+
+impl<'a> From<CertificateRequestExtensionExtensionDataInner<'a>> for CertificateRequestExtensionExtensionData<'a> {
+    fn ex_from(m: CertificateRequestExtensionExtensionDataInner<'a>) -> CertificateRequestExtensionExtensionData<'a> {
+        match m {
+            Either::Left(m) => CertificateRequestExtensionExtensionData::SignatureAlgorithms(m),
+            Either::Right(Either::Left(m)) => CertificateRequestExtensionExtensionData::CertificateAuthorities(m),
+            Either::Right(Either::Right(Either::Left(m))) => CertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m),
+            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => CertificateRequestExtensionExtensionData::StatusRequest(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => CertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => CertificateRequestExtensionExtensionData::OidFilters(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))) => CertificateRequestExtensionExtensionData::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct CertificateRequestExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> CertificateRequestExtensionExtensionDataMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        CertificateRequestExtensionExtensionDataMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        CertificateRequestExtensionExtensionDataMapper(PhantomData)
+    }
+}
+impl View for CertificateRequestExtensionExtensionDataMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for CertificateRequestExtensionExtensionDataMapper<'_> {
+    type Src = SpecCertificateRequestExtensionExtensionDataInner;
+    type Dst = SpecCertificateRequestExtensionExtensionData;
+}
+impl SpecIsoProof for CertificateRequestExtensionExtensionDataMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for CertificateRequestExtensionExtensionDataMapper<'a> {
+    type Src = CertificateRequestExtensionExtensionDataInner<'a>;
+    type Dst = CertificateRequestExtensionExtensionData<'a>;
+}
+
+
+pub struct SpecCertificateRequestExtensionExtensionDataCombinator(SpecCertificateRequestExtensionExtensionDataCombinatorAlias);
+
+impl SpecCombinator for SpecCertificateRequestExtensionExtensionDataCombinator {
+    type Type = SpecCertificateRequestExtensionExtensionData;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecCertificateRequestExtensionExtensionDataCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecCertificateRequestExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecCertificateRequestExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecSignatureSchemeListCombinator>, OrdChoice<Cond<SpecCertificateAuthoritiesExtensionCombinator>, OrdChoice<Cond<SpecSignatureSchemeListCombinator>, OrdChoice<Cond<SpecCertificateStatusRequestCombinator>, OrdChoice<Cond<SpecSignedCertificateTimestampListCombinator>, OrdChoice<Cond<SpecOidFilterExtensionCombinator>, Cond<Bytes>>>>>>>, CertificateRequestExtensionExtensionDataMapper<'static>>>;
+
+pub struct CertificateRequestExtensionExtensionDataCombinator<'a>(CertificateRequestExtensionExtensionDataCombinatorAlias<'a>);
+
+impl<'a> View for CertificateRequestExtensionExtensionDataCombinator<'a> {
+    type V = SpecCertificateRequestExtensionExtensionDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCertificateRequestExtensionExtensionDataCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateRequestExtensionExtensionDataCombinator<'a> {
+    type Type = CertificateRequestExtensionExtensionData<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type CertificateRequestExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<SignatureSchemeListCombinator<'a>>, OrdChoice<Cond<CertificateAuthoritiesExtensionCombinator<'a>>, OrdChoice<Cond<SignatureSchemeListCombinator<'a>>, OrdChoice<Cond<CertificateStatusRequestCombinator<'a>>, OrdChoice<Cond<SignedCertificateTimestampListCombinator<'a>>, OrdChoice<Cond<OidFilterExtensionCombinator<'a>>, Cond<Bytes>>>>>>>, CertificateRequestExtensionExtensionDataMapper<'a>>>;
+
+
+pub closed spec fn spec_certificate_request_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecCertificateRequestExtensionExtensionDataCombinator {
+    SpecCertificateRequestExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 13, inner: spec_signature_scheme_list() }, OrdChoice(Cond { cond: extension_type == 47, inner: spec_certificate_authorities_extension() }, OrdChoice(Cond { cond: extension_type == 50, inner: spec_signature_scheme_list() }, OrdChoice(Cond { cond: extension_type == 5, inner: spec_certificate_status_request() }, OrdChoice(Cond { cond: extension_type == 18, inner: spec_signed_certificate_timestamp_list() }, OrdChoice(Cond { cond: extension_type == 48, inner: spec_oid_filter_extension() }, Cond { cond: !(extension_type == 13 || extension_type == 47 || extension_type == 50 || extension_type == 5 || extension_type == 18 || extension_type == 48), inner: Bytes(ext_len.spec_into()) })))))), mapper: CertificateRequestExtensionExtensionDataMapper::spec_new() }))
+}
+
+pub fn certificate_request_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: CertificateRequestExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_certificate_request_extension_extension_data(ext_len@, extension_type@),
+{
+    CertificateRequestExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 13, inner: signature_scheme_list() }, OrdChoice::new(Cond { cond: extension_type == 47, inner: certificate_authorities_extension() }, OrdChoice::new(Cond { cond: extension_type == 50, inner: signature_scheme_list() }, OrdChoice::new(Cond { cond: extension_type == 5, inner: certificate_status_request() }, OrdChoice::new(Cond { cond: extension_type == 18, inner: signed_certificate_timestamp_list() }, OrdChoice::new(Cond { cond: extension_type == 48, inner: oid_filter_extension() }, Cond { cond: !(extension_type == 13 || extension_type == 47 || extension_type == 50 || extension_type == 5 || extension_type == 18 || extension_type == 48), inner: Bytes(ext_len.ex_into()) })))))), mapper: CertificateRequestExtensionExtensionDataMapper::new() }))
+}
+
+
+pub struct SpecOpaque0Ff {
+    pub l: u8,
+    pub data: Seq<u8>,
+}
+
+pub type SpecOpaque0FfInner = (u8, Seq<u8>);
+impl SpecFrom<SpecOpaque0Ff> for SpecOpaque0FfInner {
+    open spec fn spec_from(m: SpecOpaque0Ff) -> SpecOpaque0FfInner {
+        (m.l, m.data)
+    }
+}
+impl SpecFrom<SpecOpaque0FfInner> for SpecOpaque0Ff {
+    open spec fn spec_from(m: SpecOpaque0FfInner) -> SpecOpaque0Ff {
+        let (l, data) = m;
+        SpecOpaque0Ff { l, data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct Opaque0Ff<'a> {
+    pub l: u8,
+    pub data: &'a [u8],
+}
+
+impl View for Opaque0Ff<'_> {
+    type V = SpecOpaque0Ff;
+
+    open spec fn view(&self) -> Self::V {
+        SpecOpaque0Ff {
+            l: self.l@,
+            data: self.data@,
+        }
+    }
+}
+pub type Opaque0FfInner<'a> = (u8, &'a [u8]);
+impl<'a> From<Opaque0Ff<'a>> for Opaque0FfInner<'a> {
+    fn ex_from(m: Opaque0Ff) -> Opaque0FfInner {
+        (m.l, m.data)
+    }
+}
+impl<'a> From<Opaque0FfInner<'a>> for Opaque0Ff<'a> {
+    fn ex_from(m: Opaque0FfInner) -> Opaque0Ff {
+        let (l, data) = m;
+        Opaque0Ff { l, data }
+    }
+}
+
+pub struct Opaque0FfMapper<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque0FfMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        Opaque0FfMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        Opaque0FfMapper(PhantomData)
+    }
+}
+impl View for Opaque0FfMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Opaque0FfMapper<'_> {
+    type Src = SpecOpaque0FfInner;
+    type Dst = SpecOpaque0Ff;
+}
+impl SpecIsoProof for Opaque0FfMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for Opaque0FfMapper<'a> {
+    type Src = Opaque0FfInner<'a>;
+    type Dst = Opaque0Ff<'a>;
+}
+
+pub struct SpecOpaque0FfCombinator(SpecOpaque0FfCombinatorAlias);
+
+impl SpecCombinator for SpecOpaque0FfCombinator {
+    type Type = SpecOpaque0Ff;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecOpaque0FfCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecOpaque0FfCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecOpaque0FfCombinatorAlias = Mapped<SpecDepend<U8, Bytes>, Opaque0FfMapper<'static>>;
+
+pub struct Opaque0FfCombinator<'a>(Opaque0FfCombinatorAlias<'a>);
+
+impl<'a> View for Opaque0FfCombinator<'a> {
+    type V = SpecOpaque0FfCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOpaque0FfCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque0FfCombinator<'a> {
+    type Type = Opaque0Ff<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Opaque0FfCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U8, Bytes, Opaque0FfCont0<'a>>, Opaque0FfMapper<'a>>;
+
+
+pub closed spec fn spec_opaque_0_ff() -> SpecOpaque0FfCombinator {
+    SpecOpaque0FfCombinator(
+    Mapped {
+        inner: SpecDepend { fst: U8, snd: |deps| spec_opaque0_ff_cont0(deps) },
+        mapper: Opaque0FfMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_opaque0_ff_cont0(deps: u8) -> Bytes {
+    let l = deps;
+    Bytes(l.spec_into())
+}
+                
+pub fn opaque_0_ff<'a>() -> (o: Opaque0FfCombinator<'a>)
+    ensures o@ == spec_opaque_0_ff(),
+{
+    Opaque0FfCombinator(
+    Mapped {
+        inner: Depend { fst: U8, snd: Opaque0FfCont0::new(), spec_snd: Ghost(|deps| spec_opaque0_ff_cont0(deps)) },
+        mapper: Opaque0FfMapper::new(),
+    })
+}
+
+pub struct Opaque0FfCont0<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque0FfCont0<'a> {
+    pub fn new() -> Self {
+        Opaque0FfCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u8> for Opaque0FfCont0<'a> {
+    type Output = Bytes;
+
+    open spec fn requires(&self, deps: &u8) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u8, o: Self::Output) -> bool {
+        o@ == spec_opaque0_ff_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u8) -> Self::Output {
+        let l = *deps;
+        Bytes(l.ex_into())
+    }
+}
+                
+pub type SpecExtensionType = u16;
+pub type ExtensionType = u16;
+
+
+pub struct SpecExtensionTypeCombinator(SpecExtensionTypeCombinatorAlias);
+
+impl SpecCombinator for SpecExtensionTypeCombinator {
+    type Type = SpecExtensionType;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecExtensionTypeCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecExtensionTypeCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecExtensionTypeCombinatorAlias = U16Be;
+
+pub struct ExtensionTypeCombinator(ExtensionTypeCombinatorAlias);
+
+impl View for ExtensionTypeCombinator {
+    type V = SpecExtensionTypeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecExtensionTypeCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ExtensionTypeCombinator {
+    type Type = ExtensionType;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ExtensionTypeCombinatorAlias = U16Be;
+
+
+pub closed spec fn spec_extension_type() -> SpecExtensionTypeCombinator {
+    SpecExtensionTypeCombinator(U16Be)
+}
+
+                
+pub fn extension_type() -> (o: ExtensionTypeCombinator)
+    ensures o@ == spec_extension_type(),
+{
+    ExtensionTypeCombinator(U16Be)
+}
+
+                
+
+pub struct SpecEarlyDataIndicationNewSessionTicket {
+    pub max_early_data_size: u32,
+}
+
+pub type SpecEarlyDataIndicationNewSessionTicketInner = u32;
+impl SpecFrom<SpecEarlyDataIndicationNewSessionTicket> for SpecEarlyDataIndicationNewSessionTicketInner {
+    open spec fn spec_from(m: SpecEarlyDataIndicationNewSessionTicket) -> SpecEarlyDataIndicationNewSessionTicketInner {
+        m.max_early_data_size
+    }
+}
+impl SpecFrom<SpecEarlyDataIndicationNewSessionTicketInner> for SpecEarlyDataIndicationNewSessionTicket {
+    open spec fn spec_from(m: SpecEarlyDataIndicationNewSessionTicketInner) -> SpecEarlyDataIndicationNewSessionTicket {
+        let max_early_data_size = m;
+        SpecEarlyDataIndicationNewSessionTicket { max_early_data_size }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct EarlyDataIndicationNewSessionTicket {
+    pub max_early_data_size: u32,
+}
+
+impl View for EarlyDataIndicationNewSessionTicket {
+    type V = SpecEarlyDataIndicationNewSessionTicket;
+
+    open spec fn view(&self) -> Self::V {
+        SpecEarlyDataIndicationNewSessionTicket {
+            max_early_data_size: self.max_early_data_size@,
+        }
+    }
+}
+pub type EarlyDataIndicationNewSessionTicketInner = u32;
+impl From<EarlyDataIndicationNewSessionTicket> for EarlyDataIndicationNewSessionTicketInner {
+    fn ex_from(m: EarlyDataIndicationNewSessionTicket) -> EarlyDataIndicationNewSessionTicketInner {
+        m.max_early_data_size
+    }
+}
+impl From<EarlyDataIndicationNewSessionTicketInner> for EarlyDataIndicationNewSessionTicket {
+    fn ex_from(m: EarlyDataIndicationNewSessionTicketInner) -> EarlyDataIndicationNewSessionTicket {
+        let max_early_data_size = m;
+        EarlyDataIndicationNewSessionTicket { max_early_data_size }
+    }
+}
+
+pub struct EarlyDataIndicationNewSessionTicketMapper;
+impl EarlyDataIndicationNewSessionTicketMapper {
+    pub closed spec fn spec_new() -> Self {
+        EarlyDataIndicationNewSessionTicketMapper
+    }
+    pub fn new() -> Self {
+        EarlyDataIndicationNewSessionTicketMapper
+    }
+}
+impl View for EarlyDataIndicationNewSessionTicketMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for EarlyDataIndicationNewSessionTicketMapper {
+    type Src = SpecEarlyDataIndicationNewSessionTicketInner;
+    type Dst = SpecEarlyDataIndicationNewSessionTicket;
+}
+impl SpecIsoProof for EarlyDataIndicationNewSessionTicketMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for EarlyDataIndicationNewSessionTicketMapper {
+    type Src = EarlyDataIndicationNewSessionTicketInner;
+    type Dst = EarlyDataIndicationNewSessionTicket;
+}
+
+pub struct SpecEarlyDataIndicationNewSessionTicketCombinator(SpecEarlyDataIndicationNewSessionTicketCombinatorAlias);
+
+impl SpecCombinator for SpecEarlyDataIndicationNewSessionTicketCombinator {
+    type Type = SpecEarlyDataIndicationNewSessionTicket;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEarlyDataIndicationNewSessionTicketCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEarlyDataIndicationNewSessionTicketCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEarlyDataIndicationNewSessionTicketCombinatorAlias = Mapped<U32Be, EarlyDataIndicationNewSessionTicketMapper>;
+
+pub struct EarlyDataIndicationNewSessionTicketCombinator(EarlyDataIndicationNewSessionTicketCombinatorAlias);
+
+impl View for EarlyDataIndicationNewSessionTicketCombinator {
+    type V = SpecEarlyDataIndicationNewSessionTicketCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEarlyDataIndicationNewSessionTicketCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EarlyDataIndicationNewSessionTicketCombinator {
+    type Type = EarlyDataIndicationNewSessionTicket;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EarlyDataIndicationNewSessionTicketCombinatorAlias = Mapped<U32Be, EarlyDataIndicationNewSessionTicketMapper>;
+
+
+pub closed spec fn spec_early_data_indication_new_session_ticket() -> SpecEarlyDataIndicationNewSessionTicketCombinator {
+    SpecEarlyDataIndicationNewSessionTicketCombinator(
+    Mapped {
+        inner: U32Be,
+        mapper: EarlyDataIndicationNewSessionTicketMapper::spec_new(),
+    })
+}
+
+                
+pub fn early_data_indication_new_session_ticket() -> (o: EarlyDataIndicationNewSessionTicketCombinator)
+    ensures o@ == spec_early_data_indication_new_session_ticket(),
+{
+    EarlyDataIndicationNewSessionTicketCombinator(
+    Mapped {
+        inner: U32Be,
+        mapper: EarlyDataIndicationNewSessionTicketMapper::new(),
+    })
+}
+
+                
+
+pub enum SpecNewSessionTicketExtensionExtensionData {
+    EarlyData(SpecEarlyDataIndicationNewSessionTicket),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecNewSessionTicketExtensionExtensionDataInner = Either<SpecEarlyDataIndicationNewSessionTicket, Seq<u8>>;
+
+
+
+impl SpecFrom<SpecNewSessionTicketExtensionExtensionData> for SpecNewSessionTicketExtensionExtensionDataInner {
+    open spec fn spec_from(m: SpecNewSessionTicketExtensionExtensionData) -> SpecNewSessionTicketExtensionExtensionDataInner {
+        match m {
+            SpecNewSessionTicketExtensionExtensionData::EarlyData(m) => Either::Left(m),
+            SpecNewSessionTicketExtensionExtensionData::Unrecognized(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecNewSessionTicketExtensionExtensionDataInner> for SpecNewSessionTicketExtensionExtensionData {
+    open spec fn spec_from(m: SpecNewSessionTicketExtensionExtensionDataInner) -> SpecNewSessionTicketExtensionExtensionData {
+        match m {
+            Either::Left(m) => SpecNewSessionTicketExtensionExtensionData::EarlyData(m),
+            Either::Right(m) => SpecNewSessionTicketExtensionExtensionData::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NewSessionTicketExtensionExtensionData<'a> {
+    EarlyData(EarlyDataIndicationNewSessionTicket),
+    Unrecognized(&'a [u8]),
+}
+
+pub type NewSessionTicketExtensionExtensionDataInner<'a> = Either<EarlyDataIndicationNewSessionTicket, &'a [u8]>;
+
+
+impl<'a> View for NewSessionTicketExtensionExtensionData<'a> {
+    type V = SpecNewSessionTicketExtensionExtensionData;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            NewSessionTicketExtensionExtensionData::EarlyData(m) => SpecNewSessionTicketExtensionExtensionData::EarlyData(m@),
+            NewSessionTicketExtensionExtensionData::Unrecognized(m) => SpecNewSessionTicketExtensionExtensionData::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<NewSessionTicketExtensionExtensionData<'a>> for NewSessionTicketExtensionExtensionDataInner<'a> {
+    fn ex_from(m: NewSessionTicketExtensionExtensionData<'a>) -> NewSessionTicketExtensionExtensionDataInner<'a> {
+        match m {
+            NewSessionTicketExtensionExtensionData::EarlyData(m) => Either::Left(m),
+            NewSessionTicketExtensionExtensionData::Unrecognized(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl<'a> From<NewSessionTicketExtensionExtensionDataInner<'a>> for NewSessionTicketExtensionExtensionData<'a> {
+    fn ex_from(m: NewSessionTicketExtensionExtensionDataInner<'a>) -> NewSessionTicketExtensionExtensionData<'a> {
+        match m {
+            Either::Left(m) => NewSessionTicketExtensionExtensionData::EarlyData(m),
+            Either::Right(m) => NewSessionTicketExtensionExtensionData::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct NewSessionTicketExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketExtensionExtensionDataMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        NewSessionTicketExtensionExtensionDataMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        NewSessionTicketExtensionExtensionDataMapper(PhantomData)
+    }
+}
+impl View for NewSessionTicketExtensionExtensionDataMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for NewSessionTicketExtensionExtensionDataMapper<'_> {
+    type Src = SpecNewSessionTicketExtensionExtensionDataInner;
+    type Dst = SpecNewSessionTicketExtensionExtensionData;
+}
+impl SpecIsoProof for NewSessionTicketExtensionExtensionDataMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for NewSessionTicketExtensionExtensionDataMapper<'a> {
+    type Src = NewSessionTicketExtensionExtensionDataInner<'a>;
+    type Dst = NewSessionTicketExtensionExtensionData<'a>;
+}
+
+
+pub struct SpecNewSessionTicketExtensionExtensionDataCombinator(SpecNewSessionTicketExtensionExtensionDataCombinatorAlias);
+
+impl SpecCombinator for SpecNewSessionTicketExtensionExtensionDataCombinator {
+    type Type = SpecNewSessionTicketExtensionExtensionData;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNewSessionTicketExtensionExtensionDataCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNewSessionTicketExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNewSessionTicketExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecEarlyDataIndicationNewSessionTicketCombinator>, Cond<Bytes>>, NewSessionTicketExtensionExtensionDataMapper<'static>>>;
+
+pub struct NewSessionTicketExtensionExtensionDataCombinator<'a>(NewSessionTicketExtensionExtensionDataCombinatorAlias<'a>);
+
+impl<'a> View for NewSessionTicketExtensionExtensionDataCombinator<'a> {
+    type V = SpecNewSessionTicketExtensionExtensionDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketExtensionExtensionDataCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionExtensionDataCombinator<'a> {
+    type Type = NewSessionTicketExtensionExtensionData<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NewSessionTicketExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<EarlyDataIndicationNewSessionTicketCombinator>, Cond<Bytes>>, NewSessionTicketExtensionExtensionDataMapper<'a>>>;
+
+
+pub closed spec fn spec_new_session_ticket_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
+    SpecNewSessionTicketExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 42, inner: spec_early_data_indication_new_session_ticket() }, Cond { cond: !(extension_type == 42), inner: Bytes(ext_len.spec_into()) }), mapper: NewSessionTicketExtensionExtensionDataMapper::spec_new() }))
+}
+
+pub fn new_session_ticket_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: NewSessionTicketExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@),
+{
+    NewSessionTicketExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 42, inner: early_data_indication_new_session_ticket() }, Cond { cond: !(extension_type == 42), inner: Bytes(ext_len.ex_into()) }), mapper: NewSessionTicketExtensionExtensionDataMapper::new() }))
+}
+
+
+pub struct SpecNewSessionTicketExtension {
+    pub extension_type: SpecExtensionType,
+    pub ext_len: u16,
+    pub extension_data: SpecNewSessionTicketExtensionExtensionData,
+}
+
+pub type SpecNewSessionTicketExtensionInner = ((SpecExtensionType, u16), SpecNewSessionTicketExtensionExtensionData);
+impl SpecFrom<SpecNewSessionTicketExtension> for SpecNewSessionTicketExtensionInner {
+    open spec fn spec_from(m: SpecNewSessionTicketExtension) -> SpecNewSessionTicketExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl SpecFrom<SpecNewSessionTicketExtensionInner> for SpecNewSessionTicketExtension {
+    open spec fn spec_from(m: SpecNewSessionTicketExtensionInner) -> SpecNewSessionTicketExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        SpecNewSessionTicketExtension { extension_type, ext_len, extension_data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct NewSessionTicketExtension<'a> {
+    pub extension_type: ExtensionType,
+    pub ext_len: u16,
+    pub extension_data: NewSessionTicketExtensionExtensionData<'a>,
+}
+
+impl View for NewSessionTicketExtension<'_> {
+    type V = SpecNewSessionTicketExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecNewSessionTicketExtension {
+            extension_type: self.extension_type@,
+            ext_len: self.ext_len@,
+            extension_data: self.extension_data@,
+        }
+    }
+}
+pub type NewSessionTicketExtensionInner<'a> = ((ExtensionType, u16), NewSessionTicketExtensionExtensionData<'a>);
+impl<'a> From<NewSessionTicketExtension<'a>> for NewSessionTicketExtensionInner<'a> {
+    fn ex_from(m: NewSessionTicketExtension) -> NewSessionTicketExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl<'a> From<NewSessionTicketExtensionInner<'a>> for NewSessionTicketExtension<'a> {
+    fn ex_from(m: NewSessionTicketExtensionInner) -> NewSessionTicketExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        NewSessionTicketExtension { extension_type, ext_len, extension_data }
+    }
+}
+
+pub struct NewSessionTicketExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketExtensionMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        NewSessionTicketExtensionMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        NewSessionTicketExtensionMapper(PhantomData)
+    }
+}
+impl View for NewSessionTicketExtensionMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for NewSessionTicketExtensionMapper<'_> {
+    type Src = SpecNewSessionTicketExtensionInner;
+    type Dst = SpecNewSessionTicketExtension;
+}
+impl SpecIsoProof for NewSessionTicketExtensionMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for NewSessionTicketExtensionMapper<'a> {
+    type Src = NewSessionTicketExtensionInner<'a>;
+    type Dst = NewSessionTicketExtension<'a>;
+}
+
+pub struct SpecNewSessionTicketExtensionCombinator(SpecNewSessionTicketExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecNewSessionTicketExtensionCombinator {
+    type Type = SpecNewSessionTicketExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNewSessionTicketExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNewSessionTicketExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNewSessionTicketExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecNewSessionTicketExtensionExtensionDataCombinator>, NewSessionTicketExtensionMapper<'static>>;
+
+pub struct NewSessionTicketExtensionCombinator<'a>(NewSessionTicketExtensionCombinatorAlias<'a>);
+
+impl<'a> View for NewSessionTicketExtensionCombinator<'a> {
+    type V = SpecNewSessionTicketExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionCombinator<'a> {
+    type Type = NewSessionTicketExtension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NewSessionTicketExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, NewSessionTicketExtensionCont1<'a>>, NewSessionTicketExtensionExtensionDataCombinator<'a>, NewSessionTicketExtensionCont0<'a>>, NewSessionTicketExtensionMapper<'a>>;
+
+
+pub closed spec fn spec_new_session_ticket_extension() -> SpecNewSessionTicketExtensionCombinator {
+    SpecNewSessionTicketExtensionCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_new_session_ticket_extension_cont1(deps) }, snd: |deps| spec_new_session_ticket_extension_cont0(deps) },
+        mapper: NewSessionTicketExtensionMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_new_session_ticket_extension_cont1(deps: SpecExtensionType) -> U16Be {
+    let extension_type = deps;
+    U16Be
+}
+pub open spec fn spec_new_session_ticket_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
+    let (extension_type, ext_len) = deps;
+    spec_new_session_ticket_extension_extension_data(ext_len, extension_type)
+}
+                
+pub fn new_session_ticket_extension<'a>() -> (o: NewSessionTicketExtensionCombinator<'a>)
+    ensures o@ == spec_new_session_ticket_extension(),
+{
+    NewSessionTicketExtensionCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: extension_type(), snd: NewSessionTicketExtensionCont1::new(), spec_snd: Ghost(|deps| spec_new_session_ticket_extension_cont1(deps)) }, snd: NewSessionTicketExtensionCont0::new(), spec_snd: Ghost(|deps| spec_new_session_ticket_extension_cont0(deps)) },
+        mapper: NewSessionTicketExtensionMapper::new(),
+    })
+}
+
+pub struct NewSessionTicketExtensionCont1<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketExtensionCont1<'a> {
+    pub fn new() -> Self {
+        NewSessionTicketExtensionCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&ExtensionType> for NewSessionTicketExtensionCont1<'a> {
+    type Output = U16Be;
+
+    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
+        o@ == spec_new_session_ticket_extension_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &ExtensionType) -> Self::Output {
+        let extension_type = *deps;
+        U16Be
+    }
+}
+pub struct NewSessionTicketExtensionCont0<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketExtensionCont0<'a> {
+    pub fn new() -> Self {
+        NewSessionTicketExtensionCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(ExtensionType, u16)> for NewSessionTicketExtensionCont0<'a> {
+    type Output = NewSessionTicketExtensionExtensionDataCombinator<'a>;
+
+    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
+        o@ == spec_new_session_ticket_extension_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
+        let (extension_type, ext_len) = *deps;
+        new_session_ticket_extension_extension_data(ext_len, extension_type)
+    }
+}
+                
+
+pub struct SpecNewSessionTicketExtensions {
+    pub l: u16,
+    pub list: Seq<SpecNewSessionTicketExtension>,
+}
+
+pub type SpecNewSessionTicketExtensionsInner = (u16, Seq<SpecNewSessionTicketExtension>);
+impl SpecFrom<SpecNewSessionTicketExtensions> for SpecNewSessionTicketExtensionsInner {
+    open spec fn spec_from(m: SpecNewSessionTicketExtensions) -> SpecNewSessionTicketExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecNewSessionTicketExtensionsInner> for SpecNewSessionTicketExtensions {
+    open spec fn spec_from(m: SpecNewSessionTicketExtensionsInner) -> SpecNewSessionTicketExtensions {
+        let (l, list) = m;
+        SpecNewSessionTicketExtensions { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct NewSessionTicketExtensions<'a> {
+    pub l: u16,
+    pub list: RepeatResult<NewSessionTicketExtension<'a>>,
+}
+
+impl View for NewSessionTicketExtensions<'_> {
+    type V = SpecNewSessionTicketExtensions;
+
+    open spec fn view(&self) -> Self::V {
+        SpecNewSessionTicketExtensions {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type NewSessionTicketExtensionsInner<'a> = (u16, RepeatResult<NewSessionTicketExtension<'a>>);
+impl<'a> From<NewSessionTicketExtensions<'a>> for NewSessionTicketExtensionsInner<'a> {
+    fn ex_from(m: NewSessionTicketExtensions) -> NewSessionTicketExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<NewSessionTicketExtensionsInner<'a>> for NewSessionTicketExtensions<'a> {
+    fn ex_from(m: NewSessionTicketExtensionsInner) -> NewSessionTicketExtensions {
+        let (l, list) = m;
+        NewSessionTicketExtensions { l, list }
+    }
+}
+
+pub struct NewSessionTicketExtensionsMapper<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketExtensionsMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        NewSessionTicketExtensionsMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        NewSessionTicketExtensionsMapper(PhantomData)
+    }
+}
+impl View for NewSessionTicketExtensionsMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for NewSessionTicketExtensionsMapper<'_> {
+    type Src = SpecNewSessionTicketExtensionsInner;
+    type Dst = SpecNewSessionTicketExtensions;
+}
+impl SpecIsoProof for NewSessionTicketExtensionsMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for NewSessionTicketExtensionsMapper<'a> {
+    type Src = NewSessionTicketExtensionsInner<'a>;
+    type Dst = NewSessionTicketExtensions<'a>;
+}
+
+pub struct SpecNewSessionTicketExtensionsCombinator(SpecNewSessionTicketExtensionsCombinatorAlias);
+
+impl SpecCombinator for SpecNewSessionTicketExtensionsCombinator {
+    type Type = SpecNewSessionTicketExtensions;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNewSessionTicketExtensionsCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNewSessionTicketExtensionsCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNewSessionTicketExtensionsCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate14514213152276180162>, AndThen<Bytes, Repeat<SpecNewSessionTicketExtensionCombinator>>>, NewSessionTicketExtensionsMapper<'static>>;
+pub struct Predicate14514213152276180162;
+impl View for Predicate14514213152276180162 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate14514213152276180162 {
+    type Input = u16;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 0 && i <= 65534)
+    }
+}
+impl SpecPred for Predicate14514213152276180162 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 0 && i <= 65534)
+    }
+}
+
+pub struct NewSessionTicketExtensionsCombinator<'a>(NewSessionTicketExtensionsCombinatorAlias<'a>);
+
+impl<'a> View for NewSessionTicketExtensionsCombinator<'a> {
+    type V = SpecNewSessionTicketExtensionsCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketExtensionsCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionsCombinator<'a> {
+    type Type = NewSessionTicketExtensions<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NewSessionTicketExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate14514213152276180162>, AndThen<Bytes, Repeat<NewSessionTicketExtensionCombinator<'a>>>, NewSessionTicketExtensionsCont0<'a>>, NewSessionTicketExtensionsMapper<'a>>;
+
+
+pub closed spec fn spec_new_session_ticket_extensions() -> SpecNewSessionTicketExtensionsCombinator {
+    SpecNewSessionTicketExtensionsCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate14514213152276180162 }, snd: |deps| spec_new_session_ticket_extensions_cont0(deps) },
+        mapper: NewSessionTicketExtensionsMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_new_session_ticket_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecNewSessionTicketExtensionCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_new_session_ticket_extension()))
+}
+                
+pub fn new_session_ticket_extensions<'a>() -> (o: NewSessionTicketExtensionsCombinator<'a>)
+    ensures o@ == spec_new_session_ticket_extensions(),
+{
+    NewSessionTicketExtensionsCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate14514213152276180162 }, snd: NewSessionTicketExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_new_session_ticket_extensions_cont0(deps)) },
+        mapper: NewSessionTicketExtensionsMapper::new(),
+    })
+}
+
+pub struct NewSessionTicketExtensionsCont0<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketExtensionsCont0<'a> {
+    pub fn new() -> Self {
+        NewSessionTicketExtensionsCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for NewSessionTicketExtensionsCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<NewSessionTicketExtensionCombinator<'a>>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_new_session_ticket_extensions_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(new_session_ticket_extension()))
+    }
+}
+                
+
+pub struct SpecNewSessionTicket {
+    pub ticket_lifetime: u32,
+    pub ticket_age_add: u32,
+    pub ticket_nonce: SpecOpaque0Ff,
+    pub ticket: SpecOpaque1Ffff,
+    pub extensions: SpecNewSessionTicketExtensions,
+}
+
+pub type SpecNewSessionTicketInner = (u32, (u32, (SpecOpaque0Ff, (SpecOpaque1Ffff, SpecNewSessionTicketExtensions))));
+impl SpecFrom<SpecNewSessionTicket> for SpecNewSessionTicketInner {
+    open spec fn spec_from(m: SpecNewSessionTicket) -> SpecNewSessionTicketInner {
+        (m.ticket_lifetime, (m.ticket_age_add, (m.ticket_nonce, (m.ticket, m.extensions))))
+    }
+}
+impl SpecFrom<SpecNewSessionTicketInner> for SpecNewSessionTicket {
+    open spec fn spec_from(m: SpecNewSessionTicketInner) -> SpecNewSessionTicket {
+        let (ticket_lifetime, (ticket_age_add, (ticket_nonce, (ticket, extensions)))) = m;
+        SpecNewSessionTicket { ticket_lifetime, ticket_age_add, ticket_nonce, ticket, extensions }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct NewSessionTicket<'a> {
+    pub ticket_lifetime: u32,
+    pub ticket_age_add: u32,
+    pub ticket_nonce: Opaque0Ff<'a>,
+    pub ticket: Opaque1Ffff<'a>,
+    pub extensions: NewSessionTicketExtensions<'a>,
+}
+
+impl View for NewSessionTicket<'_> {
+    type V = SpecNewSessionTicket;
+
+    open spec fn view(&self) -> Self::V {
+        SpecNewSessionTicket {
+            ticket_lifetime: self.ticket_lifetime@,
+            ticket_age_add: self.ticket_age_add@,
+            ticket_nonce: self.ticket_nonce@,
+            ticket: self.ticket@,
+            extensions: self.extensions@,
+        }
+    }
+}
+pub type NewSessionTicketInner<'a> = (u32, (u32, (Opaque0Ff<'a>, (Opaque1Ffff<'a>, NewSessionTicketExtensions<'a>))));
+impl<'a> From<NewSessionTicket<'a>> for NewSessionTicketInner<'a> {
+    fn ex_from(m: NewSessionTicket) -> NewSessionTicketInner {
+        (m.ticket_lifetime, (m.ticket_age_add, (m.ticket_nonce, (m.ticket, m.extensions))))
+    }
+}
+impl<'a> From<NewSessionTicketInner<'a>> for NewSessionTicket<'a> {
+    fn ex_from(m: NewSessionTicketInner) -> NewSessionTicket {
+        let (ticket_lifetime, (ticket_age_add, (ticket_nonce, (ticket, extensions)))) = m;
+        NewSessionTicket { ticket_lifetime, ticket_age_add, ticket_nonce, ticket, extensions }
+    }
+}
+
+pub struct NewSessionTicketMapper<'a>(PhantomData<&'a ()>);
+impl<'a> NewSessionTicketMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        NewSessionTicketMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        NewSessionTicketMapper(PhantomData)
+    }
+}
+impl View for NewSessionTicketMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for NewSessionTicketMapper<'_> {
+    type Src = SpecNewSessionTicketInner;
+    type Dst = SpecNewSessionTicket;
+}
+impl SpecIsoProof for NewSessionTicketMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for NewSessionTicketMapper<'a> {
+    type Src = NewSessionTicketInner<'a>;
+    type Dst = NewSessionTicket<'a>;
+}
+
+pub struct SpecNewSessionTicketCombinator(SpecNewSessionTicketCombinatorAlias);
+
+impl SpecCombinator for SpecNewSessionTicketCombinator {
+    type Type = SpecNewSessionTicket;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNewSessionTicketCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNewSessionTicketCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNewSessionTicketCombinatorAlias = Mapped<(U32Be, (U32Be, (SpecOpaque0FfCombinator, (SpecOpaque1FfffCombinator, SpecNewSessionTicketExtensionsCombinator)))), NewSessionTicketMapper<'static>>;
+
+pub struct NewSessionTicketCombinator<'a>(NewSessionTicketCombinatorAlias<'a>);
+
+impl<'a> View for NewSessionTicketCombinator<'a> {
+    type V = SpecNewSessionTicketCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketCombinator<'a> {
+    type Type = NewSessionTicket<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NewSessionTicketCombinatorAlias<'a> = Mapped<(U32Be, (U32Be, (Opaque0FfCombinator<'a>, (Opaque1FfffCombinator<'a>, NewSessionTicketExtensionsCombinator<'a>)))), NewSessionTicketMapper<'a>>;
+
+
+pub closed spec fn spec_new_session_ticket() -> SpecNewSessionTicketCombinator {
+    SpecNewSessionTicketCombinator(
+    Mapped {
+        inner: (U32Be, (U32Be, (spec_opaque_0_ff(), (spec_opaque_1_ffff(), spec_new_session_ticket_extensions())))),
+        mapper: NewSessionTicketMapper::spec_new(),
+    })
+}
+
+                
+pub fn new_session_ticket<'a>() -> (o: NewSessionTicketCombinator<'a>)
+    ensures o@ == spec_new_session_ticket(),
+{
+    NewSessionTicketCombinator(
+    Mapped {
+        inner: (U32Be, (U32Be, (opaque_0_ff(), (opaque_1_ffff(), new_session_ticket_extensions())))),
+        mapper: NewSessionTicketMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecSessionId {
+    pub l: u8,
+    pub id: Seq<u8>,
+}
+
+pub type SpecSessionIdInner = (u8, Seq<u8>);
+impl SpecFrom<SpecSessionId> for SpecSessionIdInner {
+    open spec fn spec_from(m: SpecSessionId) -> SpecSessionIdInner {
+        (m.l, m.id)
+    }
+}
+impl SpecFrom<SpecSessionIdInner> for SpecSessionId {
+    open spec fn spec_from(m: SpecSessionIdInner) -> SpecSessionId {
+        let (l, id) = m;
+        SpecSessionId { l, id }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct SessionId<'a> {
+    pub l: u8,
+    pub id: &'a [u8],
+}
+
+impl View for SessionId<'_> {
+    type V = SpecSessionId;
+
+    open spec fn view(&self) -> Self::V {
+        SpecSessionId {
+            l: self.l@,
+            id: self.id@,
+        }
+    }
+}
+pub type SessionIdInner<'a> = (u8, &'a [u8]);
+impl<'a> From<SessionId<'a>> for SessionIdInner<'a> {
+    fn ex_from(m: SessionId) -> SessionIdInner {
+        (m.l, m.id)
+    }
+}
+impl<'a> From<SessionIdInner<'a>> for SessionId<'a> {
+    fn ex_from(m: SessionIdInner) -> SessionId {
+        let (l, id) = m;
+        SessionId { l, id }
+    }
+}
+
+pub struct SessionIdMapper<'a>(PhantomData<&'a ()>);
+impl<'a> SessionIdMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        SessionIdMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        SessionIdMapper(PhantomData)
+    }
+}
+impl View for SessionIdMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for SessionIdMapper<'_> {
+    type Src = SpecSessionIdInner;
+    type Dst = SpecSessionId;
+}
+impl SpecIsoProof for SessionIdMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for SessionIdMapper<'a> {
+    type Src = SessionIdInner<'a>;
+    type Dst = SessionId<'a>;
+}
+
+pub struct SpecSessionIdCombinator(SpecSessionIdCombinatorAlias);
+
+impl SpecCombinator for SpecSessionIdCombinator {
+    type Type = SpecSessionId;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSessionIdCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSessionIdCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSessionIdCombinatorAlias = Mapped<SpecDepend<Refined<U8, Predicate14254733753739482027>, Bytes>, SessionIdMapper<'static>>;
+pub struct Predicate14254733753739482027;
+impl View for Predicate14254733753739482027 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate14254733753739482027 {
+    type Input = u8;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 0 && i <= 32)
+    }
+}
+impl SpecPred for Predicate14254733753739482027 {
+    type Input = u8;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 0 && i <= 32)
+    }
+}
+
+pub struct SessionIdCombinator<'a>(SessionIdCombinatorAlias<'a>);
+
+impl<'a> View for SessionIdCombinator<'a> {
+    type V = SpecSessionIdCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSessionIdCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SessionIdCombinator<'a> {
+    type Type = SessionId<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SessionIdCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U8, Predicate14254733753739482027>, Bytes, SessionIdCont0<'a>>, SessionIdMapper<'a>>;
+
+
+pub closed spec fn spec_session_id() -> SpecSessionIdCombinator {
+    SpecSessionIdCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U8, predicate: Predicate14254733753739482027 }, snd: |deps| spec_session_id_cont0(deps) },
+        mapper: SessionIdMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_session_id_cont0(deps: u8) -> Bytes {
+    let l = deps;
+    Bytes(l.spec_into())
+}
+                
+pub fn session_id<'a>() -> (o: SessionIdCombinator<'a>)
+    ensures o@ == spec_session_id(),
+{
+    SessionIdCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U8, predicate: Predicate14254733753739482027 }, snd: SessionIdCont0::new(), spec_snd: Ghost(|deps| spec_session_id_cont0(deps)) },
+        mapper: SessionIdMapper::new(),
+    })
+}
+
+pub struct SessionIdCont0<'a>(PhantomData<&'a ()>);
+impl<'a> SessionIdCont0<'a> {
+    pub fn new() -> Self {
+        SessionIdCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u8> for SessionIdCont0<'a> {
+    type Output = Bytes;
+
+    open spec fn requires(&self, deps: &u8) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u8, o: Self::Output) -> bool {
+        o@ == spec_session_id_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u8) -> Self::Output {
+        let l = *deps;
+        Bytes(l.ex_into())
+    }
+}
+                
+pub type SpecCipherSuite = u16;
+pub type CipherSuite = u16;
+
+
+pub struct SpecCipherSuiteCombinator(SpecCipherSuiteCombinatorAlias);
+
+impl SpecCombinator for SpecCipherSuiteCombinator {
+    type Type = SpecCipherSuite;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecCipherSuiteCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecCipherSuiteCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecCipherSuiteCombinatorAlias = U16Be;
+
+pub struct CipherSuiteCombinator(CipherSuiteCombinatorAlias);
+
+impl View for CipherSuiteCombinator {
+    type V = SpecCipherSuiteCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCipherSuiteCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CipherSuiteCombinator {
+    type Type = CipherSuite;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type CipherSuiteCombinatorAlias = U16Be;
+
+
+pub closed spec fn spec_cipher_suite() -> SpecCipherSuiteCombinator {
+    SpecCipherSuiteCombinator(U16Be)
+}
+
+                
+pub fn cipher_suite() -> (o: CipherSuiteCombinator)
+    ensures o@ == spec_cipher_suite(),
+{
+    CipherSuiteCombinator(U16Be)
+}
+
+                
+pub type SpecProtocolVersion = u16;
+pub type ProtocolVersion = u16;
+
+
+pub struct SpecProtocolVersionCombinator(SpecProtocolVersionCombinatorAlias);
+
+impl SpecCombinator for SpecProtocolVersionCombinator {
+    type Type = SpecProtocolVersion;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecProtocolVersionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecProtocolVersionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecProtocolVersionCombinatorAlias = U16Be;
+
+pub struct ProtocolVersionCombinator(ProtocolVersionCombinatorAlias);
+
+impl View for ProtocolVersionCombinator {
+    type V = SpecProtocolVersionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecProtocolVersionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ProtocolVersionCombinator {
+    type Type = ProtocolVersion;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ProtocolVersionCombinatorAlias = U16Be;
+
+
+pub closed spec fn spec_protocol_version() -> SpecProtocolVersionCombinator {
+    SpecProtocolVersionCombinator(U16Be)
+}
+
+                
+pub fn protocol_version() -> (o: ProtocolVersionCombinator)
+    ensures o@ == spec_protocol_version(),
+{
+    ProtocolVersionCombinator(U16Be)
+}
+
+                
+pub type SpecSupportedVersionsServer = SpecProtocolVersion;
+pub type SupportedVersionsServer = ProtocolVersion;
+
+
+pub struct SpecSupportedVersionsServerCombinator(SpecSupportedVersionsServerCombinatorAlias);
+
+impl SpecCombinator for SpecSupportedVersionsServerCombinator {
+    type Type = SpecSupportedVersionsServer;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSupportedVersionsServerCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSupportedVersionsServerCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSupportedVersionsServerCombinatorAlias = SpecProtocolVersionCombinator;
+
+pub struct SupportedVersionsServerCombinator(SupportedVersionsServerCombinatorAlias);
+
+impl View for SupportedVersionsServerCombinator {
+    type V = SpecSupportedVersionsServerCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSupportedVersionsServerCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SupportedVersionsServerCombinator {
+    type Type = SupportedVersionsServer;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SupportedVersionsServerCombinatorAlias = ProtocolVersionCombinator;
+
+
+pub closed spec fn spec_supported_versions_server() -> SpecSupportedVersionsServerCombinator {
+    SpecSupportedVersionsServerCombinator(spec_protocol_version())
+}
+
+                
+pub fn supported_versions_server() -> (o: SupportedVersionsServerCombinator)
+    ensures o@ == spec_supported_versions_server(),
+{
+    SupportedVersionsServerCombinator(protocol_version())
+}
+
+                
+pub type SpecCookie = SpecOpaque1Ffff;
+pub type Cookie<'a> = Opaque1Ffff<'a>;
+
+
+pub struct SpecCookieCombinator(SpecCookieCombinatorAlias);
+
+impl SpecCombinator for SpecCookieCombinator {
+    type Type = SpecCookie;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecCookieCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecCookieCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecCookieCombinatorAlias = SpecOpaque1FfffCombinator;
+
+pub struct CookieCombinator<'a>(CookieCombinatorAlias<'a>);
+
+impl<'a> View for CookieCombinator<'a> {
+    type V = SpecCookieCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCookieCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CookieCombinator<'a> {
+    type Type = Cookie<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type CookieCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
+
+
+pub closed spec fn spec_cookie() -> SpecCookieCombinator {
+    SpecCookieCombinator(spec_opaque_1_ffff())
+}
+
+                
+pub fn cookie<'a>() -> (o: CookieCombinator<'a>)
+    ensures o@ == spec_cookie(),
+{
+    CookieCombinator(opaque_1_ffff())
+}
+
+                
+pub type SpecNamedGroup = u16;
+pub type NamedGroup = u16;
+
+
+pub struct SpecNamedGroupCombinator(SpecNamedGroupCombinatorAlias);
+
+impl SpecCombinator for SpecNamedGroupCombinator {
+    type Type = SpecNamedGroup;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNamedGroupCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNamedGroupCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNamedGroupCombinatorAlias = U16Be;
+
+pub struct NamedGroupCombinator(NamedGroupCombinatorAlias);
+
+impl View for NamedGroupCombinator {
+    type V = SpecNamedGroupCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNamedGroupCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NamedGroupCombinator {
+    type Type = NamedGroup;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NamedGroupCombinatorAlias = U16Be;
+
+
+pub closed spec fn spec_named_group() -> SpecNamedGroupCombinator {
+    SpecNamedGroupCombinator(U16Be)
+}
+
+                
+pub fn named_group() -> (o: NamedGroupCombinator)
+    ensures o@ == spec_named_group(),
+{
+    NamedGroupCombinator(U16Be)
+}
+
+                
+
+pub enum SpecHelloRetryExtensionExtensionData {
+    SupportedVersions(SpecSupportedVersionsServer),
+    Cookie(SpecCookie),
+    KeyShare(SpecNamedGroup),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecHelloRetryExtensionExtensionDataInner = Either<SpecSupportedVersionsServer, Either<SpecCookie, Either<SpecNamedGroup, Seq<u8>>>>;
+
+
+
+impl SpecFrom<SpecHelloRetryExtensionExtensionData> for SpecHelloRetryExtensionExtensionDataInner {
+    open spec fn spec_from(m: SpecHelloRetryExtensionExtensionData) -> SpecHelloRetryExtensionExtensionDataInner {
+        match m {
+            SpecHelloRetryExtensionExtensionData::SupportedVersions(m) => Either::Left(m),
+            SpecHelloRetryExtensionExtensionData::Cookie(m) => Either::Right(Either::Left(m)),
+            SpecHelloRetryExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecHelloRetryExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecHelloRetryExtensionExtensionDataInner> for SpecHelloRetryExtensionExtensionData {
+    open spec fn spec_from(m: SpecHelloRetryExtensionExtensionDataInner) -> SpecHelloRetryExtensionExtensionData {
+        match m {
+            Either::Left(m) => SpecHelloRetryExtensionExtensionData::SupportedVersions(m),
+            Either::Right(Either::Left(m)) => SpecHelloRetryExtensionExtensionData::Cookie(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecHelloRetryExtensionExtensionData::KeyShare(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecHelloRetryExtensionExtensionData::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelloRetryExtensionExtensionData<'a> {
+    SupportedVersions(SupportedVersionsServer),
+    Cookie(Cookie<'a>),
+    KeyShare(NamedGroup),
+    Unrecognized(&'a [u8]),
+}
+
+pub type HelloRetryExtensionExtensionDataInner<'a> = Either<SupportedVersionsServer, Either<Cookie<'a>, Either<NamedGroup, &'a [u8]>>>;
+
+
+impl<'a> View for HelloRetryExtensionExtensionData<'a> {
+    type V = SpecHelloRetryExtensionExtensionData;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            HelloRetryExtensionExtensionData::SupportedVersions(m) => SpecHelloRetryExtensionExtensionData::SupportedVersions(m@),
+            HelloRetryExtensionExtensionData::Cookie(m) => SpecHelloRetryExtensionExtensionData::Cookie(m@),
+            HelloRetryExtensionExtensionData::KeyShare(m) => SpecHelloRetryExtensionExtensionData::KeyShare(m@),
+            HelloRetryExtensionExtensionData::Unrecognized(m) => SpecHelloRetryExtensionExtensionData::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<HelloRetryExtensionExtensionData<'a>> for HelloRetryExtensionExtensionDataInner<'a> {
+    fn ex_from(m: HelloRetryExtensionExtensionData<'a>) -> HelloRetryExtensionExtensionDataInner<'a> {
+        match m {
+            HelloRetryExtensionExtensionData::SupportedVersions(m) => Either::Left(m),
+            HelloRetryExtensionExtensionData::Cookie(m) => Either::Right(Either::Left(m)),
+            HelloRetryExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
+            HelloRetryExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl<'a> From<HelloRetryExtensionExtensionDataInner<'a>> for HelloRetryExtensionExtensionData<'a> {
+    fn ex_from(m: HelloRetryExtensionExtensionDataInner<'a>) -> HelloRetryExtensionExtensionData<'a> {
+        match m {
+            Either::Left(m) => HelloRetryExtensionExtensionData::SupportedVersions(m),
+            Either::Right(Either::Left(m)) => HelloRetryExtensionExtensionData::Cookie(m),
+            Either::Right(Either::Right(Either::Left(m))) => HelloRetryExtensionExtensionData::KeyShare(m),
+            Either::Right(Either::Right(Either::Right(m))) => HelloRetryExtensionExtensionData::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct HelloRetryExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryExtensionExtensionDataMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        HelloRetryExtensionExtensionDataMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        HelloRetryExtensionExtensionDataMapper(PhantomData)
+    }
+}
+impl View for HelloRetryExtensionExtensionDataMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for HelloRetryExtensionExtensionDataMapper<'_> {
+    type Src = SpecHelloRetryExtensionExtensionDataInner;
+    type Dst = SpecHelloRetryExtensionExtensionData;
+}
+impl SpecIsoProof for HelloRetryExtensionExtensionDataMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for HelloRetryExtensionExtensionDataMapper<'a> {
+    type Src = HelloRetryExtensionExtensionDataInner<'a>;
+    type Dst = HelloRetryExtensionExtensionData<'a>;
+}
+
+
+pub struct SpecHelloRetryExtensionExtensionDataCombinator(SpecHelloRetryExtensionExtensionDataCombinatorAlias);
+
+impl SpecCombinator for SpecHelloRetryExtensionExtensionDataCombinator {
+    type Type = SpecHelloRetryExtensionExtensionData;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHelloRetryExtensionExtensionDataCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHelloRetryExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHelloRetryExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecSupportedVersionsServerCombinator>, OrdChoice<Cond<SpecCookieCombinator>, OrdChoice<Cond<SpecNamedGroupCombinator>, Cond<Bytes>>>>, HelloRetryExtensionExtensionDataMapper<'static>>>;
+
+pub struct HelloRetryExtensionExtensionDataCombinator<'a>(HelloRetryExtensionExtensionDataCombinatorAlias<'a>);
+
+impl<'a> View for HelloRetryExtensionExtensionDataCombinator<'a> {
+    type V = SpecHelloRetryExtensionExtensionDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHelloRetryExtensionExtensionDataCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryExtensionExtensionDataCombinator<'a> {
+    type Type = HelloRetryExtensionExtensionData<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HelloRetryExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<SupportedVersionsServerCombinator>, OrdChoice<Cond<CookieCombinator<'a>>, OrdChoice<Cond<NamedGroupCombinator>, Cond<Bytes>>>>, HelloRetryExtensionExtensionDataMapper<'a>>>;
+
+
+pub closed spec fn spec_hello_retry_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecHelloRetryExtensionExtensionDataCombinator {
+    SpecHelloRetryExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 43, inner: spec_supported_versions_server() }, OrdChoice(Cond { cond: extension_type == 44, inner: spec_cookie() }, OrdChoice(Cond { cond: extension_type == 51, inner: spec_named_group() }, Cond { cond: !(extension_type == 43 || extension_type == 44 || extension_type == 51), inner: Bytes(ext_len.spec_into()) }))), mapper: HelloRetryExtensionExtensionDataMapper::spec_new() }))
+}
+
+pub fn hello_retry_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: HelloRetryExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_hello_retry_extension_extension_data(extension_type@, ext_len@),
+{
+    HelloRetryExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 43, inner: supported_versions_server() }, OrdChoice::new(Cond { cond: extension_type == 44, inner: cookie() }, OrdChoice::new(Cond { cond: extension_type == 51, inner: named_group() }, Cond { cond: !(extension_type == 43 || extension_type == 44 || extension_type == 51), inner: Bytes(ext_len.ex_into()) }))), mapper: HelloRetryExtensionExtensionDataMapper::new() }))
+}
+
+
+pub struct SpecHelloRetryExtension {
+    pub extension_type: SpecExtensionType,
+    pub ext_len: u16,
+    pub extension_data: SpecHelloRetryExtensionExtensionData,
+}
+
+pub type SpecHelloRetryExtensionInner = ((SpecExtensionType, u16), SpecHelloRetryExtensionExtensionData);
+impl SpecFrom<SpecHelloRetryExtension> for SpecHelloRetryExtensionInner {
+    open spec fn spec_from(m: SpecHelloRetryExtension) -> SpecHelloRetryExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl SpecFrom<SpecHelloRetryExtensionInner> for SpecHelloRetryExtension {
+    open spec fn spec_from(m: SpecHelloRetryExtensionInner) -> SpecHelloRetryExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        SpecHelloRetryExtension { extension_type, ext_len, extension_data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct HelloRetryExtension<'a> {
+    pub extension_type: ExtensionType,
+    pub ext_len: u16,
+    pub extension_data: HelloRetryExtensionExtensionData<'a>,
+}
+
+impl View for HelloRetryExtension<'_> {
+    type V = SpecHelloRetryExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecHelloRetryExtension {
+            extension_type: self.extension_type@,
+            ext_len: self.ext_len@,
+            extension_data: self.extension_data@,
+        }
+    }
+}
+pub type HelloRetryExtensionInner<'a> = ((ExtensionType, u16), HelloRetryExtensionExtensionData<'a>);
+impl<'a> From<HelloRetryExtension<'a>> for HelloRetryExtensionInner<'a> {
+    fn ex_from(m: HelloRetryExtension) -> HelloRetryExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl<'a> From<HelloRetryExtensionInner<'a>> for HelloRetryExtension<'a> {
+    fn ex_from(m: HelloRetryExtensionInner) -> HelloRetryExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        HelloRetryExtension { extension_type, ext_len, extension_data }
+    }
+}
+
+pub struct HelloRetryExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryExtensionMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        HelloRetryExtensionMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        HelloRetryExtensionMapper(PhantomData)
+    }
+}
+impl View for HelloRetryExtensionMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for HelloRetryExtensionMapper<'_> {
+    type Src = SpecHelloRetryExtensionInner;
+    type Dst = SpecHelloRetryExtension;
+}
+impl SpecIsoProof for HelloRetryExtensionMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for HelloRetryExtensionMapper<'a> {
+    type Src = HelloRetryExtensionInner<'a>;
+    type Dst = HelloRetryExtension<'a>;
+}
+
+pub struct SpecHelloRetryExtensionCombinator(SpecHelloRetryExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecHelloRetryExtensionCombinator {
+    type Type = SpecHelloRetryExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHelloRetryExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHelloRetryExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHelloRetryExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecHelloRetryExtensionExtensionDataCombinator>, HelloRetryExtensionMapper<'static>>;
+
+pub struct HelloRetryExtensionCombinator<'a>(HelloRetryExtensionCombinatorAlias<'a>);
+
+impl<'a> View for HelloRetryExtensionCombinator<'a> {
+    type V = SpecHelloRetryExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHelloRetryExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryExtensionCombinator<'a> {
+    type Type = HelloRetryExtension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HelloRetryExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, HelloRetryExtensionCont1<'a>>, HelloRetryExtensionExtensionDataCombinator<'a>, HelloRetryExtensionCont0<'a>>, HelloRetryExtensionMapper<'a>>;
+
+
+pub closed spec fn spec_hello_retry_extension() -> SpecHelloRetryExtensionCombinator {
+    SpecHelloRetryExtensionCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_hello_retry_extension_cont1(deps) }, snd: |deps| spec_hello_retry_extension_cont0(deps) },
+        mapper: HelloRetryExtensionMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_hello_retry_extension_cont1(deps: SpecExtensionType) -> U16Be {
+    let extension_type = deps;
+    U16Be
+}
+pub open spec fn spec_hello_retry_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecHelloRetryExtensionExtensionDataCombinator {
+    let (extension_type, ext_len) = deps;
+    spec_hello_retry_extension_extension_data(extension_type, ext_len)
+}
+                
+pub fn hello_retry_extension<'a>() -> (o: HelloRetryExtensionCombinator<'a>)
+    ensures o@ == spec_hello_retry_extension(),
+{
+    HelloRetryExtensionCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: extension_type(), snd: HelloRetryExtensionCont1::new(), spec_snd: Ghost(|deps| spec_hello_retry_extension_cont1(deps)) }, snd: HelloRetryExtensionCont0::new(), spec_snd: Ghost(|deps| spec_hello_retry_extension_cont0(deps)) },
+        mapper: HelloRetryExtensionMapper::new(),
+    })
+}
+
+pub struct HelloRetryExtensionCont1<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryExtensionCont1<'a> {
+    pub fn new() -> Self {
+        HelloRetryExtensionCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&ExtensionType> for HelloRetryExtensionCont1<'a> {
+    type Output = U16Be;
+
+    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
+        o@ == spec_hello_retry_extension_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &ExtensionType) -> Self::Output {
+        let extension_type = *deps;
+        U16Be
+    }
+}
+pub struct HelloRetryExtensionCont0<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryExtensionCont0<'a> {
+    pub fn new() -> Self {
+        HelloRetryExtensionCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(ExtensionType, u16)> for HelloRetryExtensionCont0<'a> {
+    type Output = HelloRetryExtensionExtensionDataCombinator<'a>;
+
+    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
+        o@ == spec_hello_retry_extension_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
+        let (extension_type, ext_len) = *deps;
+        hello_retry_extension_extension_data(extension_type, ext_len)
+    }
+}
+                
+
+pub struct SpecHelloRetryExtensions {
+    pub l: u16,
+    pub list: Seq<SpecHelloRetryExtension>,
+}
+
+pub type SpecHelloRetryExtensionsInner = (u16, Seq<SpecHelloRetryExtension>);
+impl SpecFrom<SpecHelloRetryExtensions> for SpecHelloRetryExtensionsInner {
+    open spec fn spec_from(m: SpecHelloRetryExtensions) -> SpecHelloRetryExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecHelloRetryExtensionsInner> for SpecHelloRetryExtensions {
+    open spec fn spec_from(m: SpecHelloRetryExtensionsInner) -> SpecHelloRetryExtensions {
+        let (l, list) = m;
+        SpecHelloRetryExtensions { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct HelloRetryExtensions<'a> {
+    pub l: u16,
+    pub list: RepeatResult<HelloRetryExtension<'a>>,
+}
+
+impl View for HelloRetryExtensions<'_> {
+    type V = SpecHelloRetryExtensions;
+
+    open spec fn view(&self) -> Self::V {
+        SpecHelloRetryExtensions {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type HelloRetryExtensionsInner<'a> = (u16, RepeatResult<HelloRetryExtension<'a>>);
+impl<'a> From<HelloRetryExtensions<'a>> for HelloRetryExtensionsInner<'a> {
+    fn ex_from(m: HelloRetryExtensions) -> HelloRetryExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<HelloRetryExtensionsInner<'a>> for HelloRetryExtensions<'a> {
+    fn ex_from(m: HelloRetryExtensionsInner) -> HelloRetryExtensions {
+        let (l, list) = m;
+        HelloRetryExtensions { l, list }
+    }
+}
+
+pub struct HelloRetryExtensionsMapper<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryExtensionsMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        HelloRetryExtensionsMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        HelloRetryExtensionsMapper(PhantomData)
+    }
+}
+impl View for HelloRetryExtensionsMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for HelloRetryExtensionsMapper<'_> {
+    type Src = SpecHelloRetryExtensionsInner;
+    type Dst = SpecHelloRetryExtensions;
+}
+impl SpecIsoProof for HelloRetryExtensionsMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for HelloRetryExtensionsMapper<'a> {
+    type Src = HelloRetryExtensionsInner<'a>;
+    type Dst = HelloRetryExtensions<'a>;
+}
+
+pub struct SpecHelloRetryExtensionsCombinator(SpecHelloRetryExtensionsCombinatorAlias);
+
+impl SpecCombinator for SpecHelloRetryExtensionsCombinator {
+    type Type = SpecHelloRetryExtensions;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHelloRetryExtensionsCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHelloRetryExtensionsCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHelloRetryExtensionsCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<SpecHelloRetryExtensionCombinator>>>, HelloRetryExtensionsMapper<'static>>;
+pub struct Predicate14496530480760116989;
+impl View for Predicate14496530480760116989 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate14496530480760116989 {
+    type Input = u16;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 6 && i <= 65535)
+    }
+}
+impl SpecPred for Predicate14496530480760116989 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 6 && i <= 65535)
+    }
+}
+
+pub struct HelloRetryExtensionsCombinator<'a>(HelloRetryExtensionsCombinatorAlias<'a>);
+
+impl<'a> View for HelloRetryExtensionsCombinator<'a> {
+    type V = SpecHelloRetryExtensionsCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHelloRetryExtensionsCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryExtensionsCombinator<'a> {
+    type Type = HelloRetryExtensions<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HelloRetryExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<HelloRetryExtensionCombinator<'a>>>, HelloRetryExtensionsCont0<'a>>, HelloRetryExtensionsMapper<'a>>;
+
+
+pub closed spec fn spec_hello_retry_extensions() -> SpecHelloRetryExtensionsCombinator {
+    SpecHelloRetryExtensionsCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: |deps| spec_hello_retry_extensions_cont0(deps) },
+        mapper: HelloRetryExtensionsMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_hello_retry_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecHelloRetryExtensionCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_hello_retry_extension()))
+}
+                
+pub fn hello_retry_extensions<'a>() -> (o: HelloRetryExtensionsCombinator<'a>)
+    ensures o@ == spec_hello_retry_extensions(),
+{
+    HelloRetryExtensionsCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: HelloRetryExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_hello_retry_extensions_cont0(deps)) },
+        mapper: HelloRetryExtensionsMapper::new(),
+    })
+}
+
+pub struct HelloRetryExtensionsCont0<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryExtensionsCont0<'a> {
+    pub fn new() -> Self {
+        HelloRetryExtensionsCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for HelloRetryExtensionsCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<HelloRetryExtensionCombinator<'a>>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_hello_retry_extensions_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(hello_retry_extension()))
+    }
+}
+                
+
+pub struct SpecHelloRetryRequest {
+    pub legacy_session_id_echo: SpecSessionId,
+    pub cipher_suite: SpecCipherSuite,
+    pub legacy_compression_method: u8,
+    pub extensions: SpecHelloRetryExtensions,
+}
+
+pub type SpecHelloRetryRequestInner = (SpecSessionId, (SpecCipherSuite, (u8, SpecHelloRetryExtensions)));
+impl SpecFrom<SpecHelloRetryRequest> for SpecHelloRetryRequestInner {
+    open spec fn spec_from(m: SpecHelloRetryRequest) -> SpecHelloRetryRequestInner {
+        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
+    }
+}
+impl SpecFrom<SpecHelloRetryRequestInner> for SpecHelloRetryRequest {
+    open spec fn spec_from(m: SpecHelloRetryRequestInner) -> SpecHelloRetryRequest {
+        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
+        SpecHelloRetryRequest { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct HelloRetryRequest<'a> {
+    pub legacy_session_id_echo: SessionId<'a>,
+    pub cipher_suite: CipherSuite,
+    pub legacy_compression_method: u8,
+    pub extensions: HelloRetryExtensions<'a>,
+}
+
+impl View for HelloRetryRequest<'_> {
+    type V = SpecHelloRetryRequest;
+
+    open spec fn view(&self) -> Self::V {
+        SpecHelloRetryRequest {
+            legacy_session_id_echo: self.legacy_session_id_echo@,
+            cipher_suite: self.cipher_suite@,
+            legacy_compression_method: self.legacy_compression_method@,
+            extensions: self.extensions@,
+        }
+    }
+}
+pub type HelloRetryRequestInner<'a> = (SessionId<'a>, (CipherSuite, (u8, HelloRetryExtensions<'a>)));
+impl<'a> From<HelloRetryRequest<'a>> for HelloRetryRequestInner<'a> {
+    fn ex_from(m: HelloRetryRequest) -> HelloRetryRequestInner {
+        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
+    }
+}
+impl<'a> From<HelloRetryRequestInner<'a>> for HelloRetryRequest<'a> {
+    fn ex_from(m: HelloRetryRequestInner) -> HelloRetryRequest {
+        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
+        HelloRetryRequest { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
+    }
+}
+
+pub struct HelloRetryRequestMapper<'a>(PhantomData<&'a ()>);
+impl<'a> HelloRetryRequestMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        HelloRetryRequestMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        HelloRetryRequestMapper(PhantomData)
+    }
+}
+impl View for HelloRetryRequestMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for HelloRetryRequestMapper<'_> {
+    type Src = SpecHelloRetryRequestInner;
+    type Dst = SpecHelloRetryRequest;
+}
+impl SpecIsoProof for HelloRetryRequestMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for HelloRetryRequestMapper<'a> {
+    type Src = HelloRetryRequestInner<'a>;
+    type Dst = HelloRetryRequest<'a>;
+}
+pub const HELLORETRYREQUESTLEGACY_COMPRESSION_METHOD_CONST: u8 = 0;
+
+pub struct SpecHelloRetryRequestCombinator(SpecHelloRetryRequestCombinatorAlias);
+
+impl SpecCombinator for SpecHelloRetryRequestCombinator {
+    type Type = SpecHelloRetryRequest;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHelloRetryRequestCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHelloRetryRequestCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHelloRetryRequestCombinatorAlias = Mapped<(SpecSessionIdCombinator, (SpecCipherSuiteCombinator, (Refined<U8, TagPred<u8>>, SpecHelloRetryExtensionsCombinator))), HelloRetryRequestMapper<'static>>;
+
+pub struct HelloRetryRequestCombinator<'a>(HelloRetryRequestCombinatorAlias<'a>);
+
+impl<'a> View for HelloRetryRequestCombinator<'a> {
+    type V = SpecHelloRetryRequestCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHelloRetryRequestCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryRequestCombinator<'a> {
+    type Type = HelloRetryRequest<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HelloRetryRequestCombinatorAlias<'a> = Mapped<(SessionIdCombinator<'a>, (CipherSuiteCombinator, (Refined<U8, TagPred<u8>>, HelloRetryExtensionsCombinator<'a>))), HelloRetryRequestMapper<'a>>;
+
+
+pub closed spec fn spec_hello_retry_request() -> SpecHelloRetryRequestCombinator {
+    SpecHelloRetryRequestCombinator(
+    Mapped {
+        inner: (spec_session_id(), (spec_cipher_suite(), (Refined { inner: U8, predicate: TagPred(HELLORETRYREQUESTLEGACY_COMPRESSION_METHOD_CONST) }, spec_hello_retry_extensions()))),
+        mapper: HelloRetryRequestMapper::spec_new(),
+    })
+}
+
+                
+pub fn hello_retry_request<'a>() -> (o: HelloRetryRequestCombinator<'a>)
+    ensures o@ == spec_hello_retry_request(),
+{
+    HelloRetryRequestCombinator(
+    Mapped {
+        inner: (session_id(), (cipher_suite(), (Refined { inner: U8, predicate: TagPred(HELLORETRYREQUESTLEGACY_COMPRESSION_METHOD_CONST) }, hello_retry_extensions()))),
+        mapper: HelloRetryRequestMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecPreSharedKeyServerExtension {
+    pub selected_identity: u16,
+}
+
+pub type SpecPreSharedKeyServerExtensionInner = u16;
+impl SpecFrom<SpecPreSharedKeyServerExtension> for SpecPreSharedKeyServerExtensionInner {
+    open spec fn spec_from(m: SpecPreSharedKeyServerExtension) -> SpecPreSharedKeyServerExtensionInner {
+        m.selected_identity
+    }
+}
+impl SpecFrom<SpecPreSharedKeyServerExtensionInner> for SpecPreSharedKeyServerExtension {
+    open spec fn spec_from(m: SpecPreSharedKeyServerExtensionInner) -> SpecPreSharedKeyServerExtension {
+        let selected_identity = m;
+        SpecPreSharedKeyServerExtension { selected_identity }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct PreSharedKeyServerExtension {
+    pub selected_identity: u16,
+}
+
+impl View for PreSharedKeyServerExtension {
+    type V = SpecPreSharedKeyServerExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecPreSharedKeyServerExtension {
+            selected_identity: self.selected_identity@,
+        }
+    }
+}
+pub type PreSharedKeyServerExtensionInner = u16;
+impl From<PreSharedKeyServerExtension> for PreSharedKeyServerExtensionInner {
+    fn ex_from(m: PreSharedKeyServerExtension) -> PreSharedKeyServerExtensionInner {
+        m.selected_identity
+    }
+}
+impl From<PreSharedKeyServerExtensionInner> for PreSharedKeyServerExtension {
+    fn ex_from(m: PreSharedKeyServerExtensionInner) -> PreSharedKeyServerExtension {
+        let selected_identity = m;
+        PreSharedKeyServerExtension { selected_identity }
+    }
+}
+
+pub struct PreSharedKeyServerExtensionMapper;
+impl PreSharedKeyServerExtensionMapper {
+    pub closed spec fn spec_new() -> Self {
+        PreSharedKeyServerExtensionMapper
+    }
+    pub fn new() -> Self {
+        PreSharedKeyServerExtensionMapper
+    }
+}
+impl View for PreSharedKeyServerExtensionMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for PreSharedKeyServerExtensionMapper {
+    type Src = SpecPreSharedKeyServerExtensionInner;
+    type Dst = SpecPreSharedKeyServerExtension;
+}
+impl SpecIsoProof for PreSharedKeyServerExtensionMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for PreSharedKeyServerExtensionMapper {
+    type Src = PreSharedKeyServerExtensionInner;
+    type Dst = PreSharedKeyServerExtension;
+}
+
+pub struct SpecPreSharedKeyServerExtensionCombinator(SpecPreSharedKeyServerExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecPreSharedKeyServerExtensionCombinator {
+    type Type = SpecPreSharedKeyServerExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecPreSharedKeyServerExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecPreSharedKeyServerExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecPreSharedKeyServerExtensionCombinatorAlias = Mapped<U16Be, PreSharedKeyServerExtensionMapper>;
+
+pub struct PreSharedKeyServerExtensionCombinator(PreSharedKeyServerExtensionCombinatorAlias);
+
+impl View for PreSharedKeyServerExtensionCombinator {
+    type V = SpecPreSharedKeyServerExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecPreSharedKeyServerExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for PreSharedKeyServerExtensionCombinator {
+    type Type = PreSharedKeyServerExtension;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type PreSharedKeyServerExtensionCombinatorAlias = Mapped<U16Be, PreSharedKeyServerExtensionMapper>;
+
+
+pub closed spec fn spec_pre_shared_key_server_extension() -> SpecPreSharedKeyServerExtensionCombinator {
+    SpecPreSharedKeyServerExtensionCombinator(
+    Mapped {
+        inner: U16Be,
+        mapper: PreSharedKeyServerExtensionMapper::spec_new(),
+    })
+}
+
+                
+pub fn pre_shared_key_server_extension() -> (o: PreSharedKeyServerExtensionCombinator)
+    ensures o@ == spec_pre_shared_key_server_extension(),
+{
+    PreSharedKeyServerExtensionCombinator(
+    Mapped {
+        inner: U16Be,
+        mapper: PreSharedKeyServerExtensionMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecKeyShareEntry {
+    pub group: SpecNamedGroup,
+    pub l: u16,
+    pub key_exchange: Seq<u8>,
+}
+
+pub type SpecKeyShareEntryInner = ((SpecNamedGroup, u16), Seq<u8>);
+impl SpecFrom<SpecKeyShareEntry> for SpecKeyShareEntryInner {
+    open spec fn spec_from(m: SpecKeyShareEntry) -> SpecKeyShareEntryInner {
+        ((m.group, m.l), m.key_exchange)
+    }
+}
+impl SpecFrom<SpecKeyShareEntryInner> for SpecKeyShareEntry {
+    open spec fn spec_from(m: SpecKeyShareEntryInner) -> SpecKeyShareEntry {
+        let ((group, l), key_exchange) = m;
+        SpecKeyShareEntry { group, l, key_exchange }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct KeyShareEntry<'a> {
+    pub group: NamedGroup,
+    pub l: u16,
+    pub key_exchange: &'a [u8],
+}
+
+impl View for KeyShareEntry<'_> {
+    type V = SpecKeyShareEntry;
+
+    open spec fn view(&self) -> Self::V {
+        SpecKeyShareEntry {
+            group: self.group@,
+            l: self.l@,
+            key_exchange: self.key_exchange@,
+        }
+    }
+}
+pub type KeyShareEntryInner<'a> = ((NamedGroup, u16), &'a [u8]);
+impl<'a> From<KeyShareEntry<'a>> for KeyShareEntryInner<'a> {
+    fn ex_from(m: KeyShareEntry) -> KeyShareEntryInner {
+        ((m.group, m.l), m.key_exchange)
+    }
+}
+impl<'a> From<KeyShareEntryInner<'a>> for KeyShareEntry<'a> {
+    fn ex_from(m: KeyShareEntryInner) -> KeyShareEntry {
+        let ((group, l), key_exchange) = m;
+        KeyShareEntry { group, l, key_exchange }
+    }
+}
+
+pub struct KeyShareEntryMapper<'a>(PhantomData<&'a ()>);
+impl<'a> KeyShareEntryMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        KeyShareEntryMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        KeyShareEntryMapper(PhantomData)
+    }
+}
+impl View for KeyShareEntryMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for KeyShareEntryMapper<'_> {
+    type Src = SpecKeyShareEntryInner;
+    type Dst = SpecKeyShareEntry;
+}
+impl SpecIsoProof for KeyShareEntryMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for KeyShareEntryMapper<'a> {
+    type Src = KeyShareEntryInner<'a>;
+    type Dst = KeyShareEntry<'a>;
+}
+
+pub struct SpecKeyShareEntryCombinator(SpecKeyShareEntryCombinatorAlias);
+
+impl SpecCombinator for SpecKeyShareEntryCombinator {
+    type Type = SpecKeyShareEntry;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecKeyShareEntryCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecKeyShareEntryCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecKeyShareEntryCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecNamedGroupCombinator, Refined<U16Be, Predicate16977634203518580913>>, Bytes>, KeyShareEntryMapper<'static>>;
+
+pub struct KeyShareEntryCombinator<'a>(KeyShareEntryCombinatorAlias<'a>);
+
+impl<'a> View for KeyShareEntryCombinator<'a> {
+    type V = SpecKeyShareEntryCombinator;
+    closed spec fn view(&self) -> Self::V { SpecKeyShareEntryCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for KeyShareEntryCombinator<'a> {
+    type Type = KeyShareEntry<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type KeyShareEntryCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, NamedGroupCombinator, Refined<U16Be, Predicate16977634203518580913>, KeyShareEntryCont1<'a>>, Bytes, KeyShareEntryCont0<'a>>, KeyShareEntryMapper<'a>>;
+
+
+pub closed spec fn spec_key_share_entry() -> SpecKeyShareEntryCombinator {
+    SpecKeyShareEntryCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_named_group(), snd: |deps| spec_key_share_entry_cont1(deps) }, snd: |deps| spec_key_share_entry_cont0(deps) },
+        mapper: KeyShareEntryMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_key_share_entry_cont1(deps: SpecNamedGroup) -> Refined<U16Be, Predicate16977634203518580913> {
+    let group = deps;
+    Refined { inner: U16Be, predicate: Predicate16977634203518580913 }
+}
+pub open spec fn spec_key_share_entry_cont0(deps: (SpecNamedGroup, u16)) -> Bytes {
+    let (group, l) = deps;
+    Bytes(l.spec_into())
+}
+                
+pub fn key_share_entry<'a>() -> (o: KeyShareEntryCombinator<'a>)
+    ensures o@ == spec_key_share_entry(),
+{
+    KeyShareEntryCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: named_group(), snd: KeyShareEntryCont1::new(), spec_snd: Ghost(|deps| spec_key_share_entry_cont1(deps)) }, snd: KeyShareEntryCont0::new(), spec_snd: Ghost(|deps| spec_key_share_entry_cont0(deps)) },
+        mapper: KeyShareEntryMapper::new(),
+    })
+}
+
+pub struct KeyShareEntryCont1<'a>(PhantomData<&'a ()>);
+impl<'a> KeyShareEntryCont1<'a> {
+    pub fn new() -> Self {
+        KeyShareEntryCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&NamedGroup> for KeyShareEntryCont1<'a> {
+    type Output = Refined<U16Be, Predicate16977634203518580913>;
+
+    open spec fn requires(&self, deps: &NamedGroup) -> bool { true }
+
+    open spec fn ensures(&self, deps: &NamedGroup, o: Self::Output) -> bool {
+        o@ == spec_key_share_entry_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &NamedGroup) -> Self::Output {
+        let group = *deps;
+        Refined { inner: U16Be, predicate: Predicate16977634203518580913 }
+    }
+}
+pub struct KeyShareEntryCont0<'a>(PhantomData<&'a ()>);
+impl<'a> KeyShareEntryCont0<'a> {
+    pub fn new() -> Self {
+        KeyShareEntryCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(NamedGroup, u16)> for KeyShareEntryCont0<'a> {
+    type Output = Bytes;
+
+    open spec fn requires(&self, deps: &(NamedGroup, u16)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(NamedGroup, u16), o: Self::Output) -> bool {
+        o@ == spec_key_share_entry_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(NamedGroup, u16)) -> Self::Output {
+        let (group, l) = *deps;
+        Bytes(l.ex_into())
+    }
+}
+                
+
+pub enum SpecSeverHelloExtensionExtensionData {
+    PreSharedKey(SpecPreSharedKeyServerExtension),
+    SupportedVersions(SpecSupportedVersionsServer),
+    KeyShare(SpecKeyShareEntry),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecSeverHelloExtensionExtensionDataInner = Either<SpecPreSharedKeyServerExtension, Either<SpecSupportedVersionsServer, Either<SpecKeyShareEntry, Seq<u8>>>>;
+
+
+
+impl SpecFrom<SpecSeverHelloExtensionExtensionData> for SpecSeverHelloExtensionExtensionDataInner {
+    open spec fn spec_from(m: SpecSeverHelloExtensionExtensionData) -> SpecSeverHelloExtensionExtensionDataInner {
+        match m {
+            SpecSeverHelloExtensionExtensionData::PreSharedKey(m) => Either::Left(m),
+            SpecSeverHelloExtensionExtensionData::SupportedVersions(m) => Either::Right(Either::Left(m)),
+            SpecSeverHelloExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecSeverHelloExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecSeverHelloExtensionExtensionDataInner> for SpecSeverHelloExtensionExtensionData {
+    open spec fn spec_from(m: SpecSeverHelloExtensionExtensionDataInner) -> SpecSeverHelloExtensionExtensionData {
+        match m {
+            Either::Left(m) => SpecSeverHelloExtensionExtensionData::PreSharedKey(m),
+            Either::Right(Either::Left(m)) => SpecSeverHelloExtensionExtensionData::SupportedVersions(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecSeverHelloExtensionExtensionData::KeyShare(m),
+            Either::Right(Either::Right(Either::Right(m))) => SpecSeverHelloExtensionExtensionData::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SeverHelloExtensionExtensionData<'a> {
+    PreSharedKey(PreSharedKeyServerExtension),
+    SupportedVersions(SupportedVersionsServer),
+    KeyShare(KeyShareEntry<'a>),
+    Unrecognized(&'a [u8]),
+}
+
+pub type SeverHelloExtensionExtensionDataInner<'a> = Either<PreSharedKeyServerExtension, Either<SupportedVersionsServer, Either<KeyShareEntry<'a>, &'a [u8]>>>;
+
+
+impl<'a> View for SeverHelloExtensionExtensionData<'a> {
+    type V = SpecSeverHelloExtensionExtensionData;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            SeverHelloExtensionExtensionData::PreSharedKey(m) => SpecSeverHelloExtensionExtensionData::PreSharedKey(m@),
+            SeverHelloExtensionExtensionData::SupportedVersions(m) => SpecSeverHelloExtensionExtensionData::SupportedVersions(m@),
+            SeverHelloExtensionExtensionData::KeyShare(m) => SpecSeverHelloExtensionExtensionData::KeyShare(m@),
+            SeverHelloExtensionExtensionData::Unrecognized(m) => SpecSeverHelloExtensionExtensionData::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<SeverHelloExtensionExtensionData<'a>> for SeverHelloExtensionExtensionDataInner<'a> {
+    fn ex_from(m: SeverHelloExtensionExtensionData<'a>) -> SeverHelloExtensionExtensionDataInner<'a> {
+        match m {
+            SeverHelloExtensionExtensionData::PreSharedKey(m) => Either::Left(m),
+            SeverHelloExtensionExtensionData::SupportedVersions(m) => Either::Right(Either::Left(m)),
+            SeverHelloExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
+            SeverHelloExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
+        }
+    }
+
+}
+
+impl<'a> From<SeverHelloExtensionExtensionDataInner<'a>> for SeverHelloExtensionExtensionData<'a> {
+    fn ex_from(m: SeverHelloExtensionExtensionDataInner<'a>) -> SeverHelloExtensionExtensionData<'a> {
+        match m {
+            Either::Left(m) => SeverHelloExtensionExtensionData::PreSharedKey(m),
+            Either::Right(Either::Left(m)) => SeverHelloExtensionExtensionData::SupportedVersions(m),
+            Either::Right(Either::Right(Either::Left(m))) => SeverHelloExtensionExtensionData::KeyShare(m),
+            Either::Right(Either::Right(Either::Right(m))) => SeverHelloExtensionExtensionData::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct SeverHelloExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> SeverHelloExtensionExtensionDataMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        SeverHelloExtensionExtensionDataMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        SeverHelloExtensionExtensionDataMapper(PhantomData)
+    }
+}
+impl View for SeverHelloExtensionExtensionDataMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for SeverHelloExtensionExtensionDataMapper<'_> {
+    type Src = SpecSeverHelloExtensionExtensionDataInner;
+    type Dst = SpecSeverHelloExtensionExtensionData;
+}
+impl SpecIsoProof for SeverHelloExtensionExtensionDataMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for SeverHelloExtensionExtensionDataMapper<'a> {
+    type Src = SeverHelloExtensionExtensionDataInner<'a>;
+    type Dst = SeverHelloExtensionExtensionData<'a>;
+}
+
+
+pub struct SpecSeverHelloExtensionExtensionDataCombinator(SpecSeverHelloExtensionExtensionDataCombinatorAlias);
+
+impl SpecCombinator for SpecSeverHelloExtensionExtensionDataCombinator {
+    type Type = SpecSeverHelloExtensionExtensionData;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSeverHelloExtensionExtensionDataCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSeverHelloExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSeverHelloExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecPreSharedKeyServerExtensionCombinator>, OrdChoice<Cond<SpecSupportedVersionsServerCombinator>, OrdChoice<Cond<SpecKeyShareEntryCombinator>, Cond<Bytes>>>>, SeverHelloExtensionExtensionDataMapper<'static>>>;
+
+pub struct SeverHelloExtensionExtensionDataCombinator<'a>(SeverHelloExtensionExtensionDataCombinatorAlias<'a>);
+
+impl<'a> View for SeverHelloExtensionExtensionDataCombinator<'a> {
+    type V = SpecSeverHelloExtensionExtensionDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSeverHelloExtensionExtensionDataCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SeverHelloExtensionExtensionDataCombinator<'a> {
+    type Type = SeverHelloExtensionExtensionData<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SeverHelloExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<PreSharedKeyServerExtensionCombinator>, OrdChoice<Cond<SupportedVersionsServerCombinator>, OrdChoice<Cond<KeyShareEntryCombinator<'a>>, Cond<Bytes>>>>, SeverHelloExtensionExtensionDataMapper<'a>>>;
+
+
+pub closed spec fn spec_sever_hello_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecSeverHelloExtensionExtensionDataCombinator {
+    SpecSeverHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 41, inner: spec_pre_shared_key_server_extension() }, OrdChoice(Cond { cond: extension_type == 43, inner: spec_supported_versions_server() }, OrdChoice(Cond { cond: extension_type == 51, inner: spec_key_share_entry() }, Cond { cond: !(extension_type == 41 || extension_type == 43 || extension_type == 51), inner: Bytes(ext_len.spec_into()) }))), mapper: SeverHelloExtensionExtensionDataMapper::spec_new() }))
+}
+
+pub fn sever_hello_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: SeverHelloExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_sever_hello_extension_extension_data(extension_type@, ext_len@),
+{
+    SeverHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 41, inner: pre_shared_key_server_extension() }, OrdChoice::new(Cond { cond: extension_type == 43, inner: supported_versions_server() }, OrdChoice::new(Cond { cond: extension_type == 51, inner: key_share_entry() }, Cond { cond: !(extension_type == 41 || extension_type == 43 || extension_type == 51), inner: Bytes(ext_len.ex_into()) }))), mapper: SeverHelloExtensionExtensionDataMapper::new() }))
+}
+
+
+pub struct SpecSeverHelloExtension {
+    pub extension_type: SpecExtensionType,
+    pub ext_len: u16,
+    pub extension_data: SpecSeverHelloExtensionExtensionData,
+}
+
+pub type SpecSeverHelloExtensionInner = ((SpecExtensionType, u16), SpecSeverHelloExtensionExtensionData);
+impl SpecFrom<SpecSeverHelloExtension> for SpecSeverHelloExtensionInner {
+    open spec fn spec_from(m: SpecSeverHelloExtension) -> SpecSeverHelloExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl SpecFrom<SpecSeverHelloExtensionInner> for SpecSeverHelloExtension {
+    open spec fn spec_from(m: SpecSeverHelloExtensionInner) -> SpecSeverHelloExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        SpecSeverHelloExtension { extension_type, ext_len, extension_data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct SeverHelloExtension<'a> {
+    pub extension_type: ExtensionType,
+    pub ext_len: u16,
+    pub extension_data: SeverHelloExtensionExtensionData<'a>,
+}
+
+impl View for SeverHelloExtension<'_> {
+    type V = SpecSeverHelloExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecSeverHelloExtension {
+            extension_type: self.extension_type@,
+            ext_len: self.ext_len@,
+            extension_data: self.extension_data@,
+        }
+    }
+}
+pub type SeverHelloExtensionInner<'a> = ((ExtensionType, u16), SeverHelloExtensionExtensionData<'a>);
+impl<'a> From<SeverHelloExtension<'a>> for SeverHelloExtensionInner<'a> {
+    fn ex_from(m: SeverHelloExtension) -> SeverHelloExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl<'a> From<SeverHelloExtensionInner<'a>> for SeverHelloExtension<'a> {
+    fn ex_from(m: SeverHelloExtensionInner) -> SeverHelloExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        SeverHelloExtension { extension_type, ext_len, extension_data }
+    }
+}
+
+pub struct SeverHelloExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> SeverHelloExtensionMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        SeverHelloExtensionMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        SeverHelloExtensionMapper(PhantomData)
+    }
+}
+impl View for SeverHelloExtensionMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for SeverHelloExtensionMapper<'_> {
+    type Src = SpecSeverHelloExtensionInner;
+    type Dst = SpecSeverHelloExtension;
+}
+impl SpecIsoProof for SeverHelloExtensionMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for SeverHelloExtensionMapper<'a> {
+    type Src = SeverHelloExtensionInner<'a>;
+    type Dst = SeverHelloExtension<'a>;
+}
+
+pub struct SpecSeverHelloExtensionCombinator(SpecSeverHelloExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecSeverHelloExtensionCombinator {
+    type Type = SpecSeverHelloExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSeverHelloExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSeverHelloExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSeverHelloExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecSeverHelloExtensionExtensionDataCombinator>, SeverHelloExtensionMapper<'static>>;
+
+pub struct SeverHelloExtensionCombinator<'a>(SeverHelloExtensionCombinatorAlias<'a>);
+
+impl<'a> View for SeverHelloExtensionCombinator<'a> {
+    type V = SpecSeverHelloExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSeverHelloExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SeverHelloExtensionCombinator<'a> {
+    type Type = SeverHelloExtension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SeverHelloExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, SeverHelloExtensionCont1<'a>>, SeverHelloExtensionExtensionDataCombinator<'a>, SeverHelloExtensionCont0<'a>>, SeverHelloExtensionMapper<'a>>;
+
+
+pub closed spec fn spec_sever_hello_extension() -> SpecSeverHelloExtensionCombinator {
+    SpecSeverHelloExtensionCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_sever_hello_extension_cont1(deps) }, snd: |deps| spec_sever_hello_extension_cont0(deps) },
+        mapper: SeverHelloExtensionMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_sever_hello_extension_cont1(deps: SpecExtensionType) -> U16Be {
+    let extension_type = deps;
+    U16Be
+}
+pub open spec fn spec_sever_hello_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecSeverHelloExtensionExtensionDataCombinator {
+    let (extension_type, ext_len) = deps;
+    spec_sever_hello_extension_extension_data(extension_type, ext_len)
+}
+                
+pub fn sever_hello_extension<'a>() -> (o: SeverHelloExtensionCombinator<'a>)
+    ensures o@ == spec_sever_hello_extension(),
+{
+    SeverHelloExtensionCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: extension_type(), snd: SeverHelloExtensionCont1::new(), spec_snd: Ghost(|deps| spec_sever_hello_extension_cont1(deps)) }, snd: SeverHelloExtensionCont0::new(), spec_snd: Ghost(|deps| spec_sever_hello_extension_cont0(deps)) },
+        mapper: SeverHelloExtensionMapper::new(),
+    })
+}
+
+pub struct SeverHelloExtensionCont1<'a>(PhantomData<&'a ()>);
+impl<'a> SeverHelloExtensionCont1<'a> {
+    pub fn new() -> Self {
+        SeverHelloExtensionCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&ExtensionType> for SeverHelloExtensionCont1<'a> {
+    type Output = U16Be;
+
+    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
+        o@ == spec_sever_hello_extension_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &ExtensionType) -> Self::Output {
+        let extension_type = *deps;
+        U16Be
+    }
+}
+pub struct SeverHelloExtensionCont0<'a>(PhantomData<&'a ()>);
+impl<'a> SeverHelloExtensionCont0<'a> {
+    pub fn new() -> Self {
+        SeverHelloExtensionCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(ExtensionType, u16)> for SeverHelloExtensionCont0<'a> {
+    type Output = SeverHelloExtensionExtensionDataCombinator<'a>;
+
+    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
+        o@ == spec_sever_hello_extension_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
+        let (extension_type, ext_len) = *deps;
+        sever_hello_extension_extension_data(extension_type, ext_len)
+    }
+}
+                
+
+pub struct SpecServerExtensions {
+    pub l: u16,
+    pub list: Seq<SpecSeverHelloExtension>,
+}
+
+pub type SpecServerExtensionsInner = (u16, Seq<SpecSeverHelloExtension>);
+impl SpecFrom<SpecServerExtensions> for SpecServerExtensionsInner {
+    open spec fn spec_from(m: SpecServerExtensions) -> SpecServerExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecServerExtensionsInner> for SpecServerExtensions {
+    open spec fn spec_from(m: SpecServerExtensionsInner) -> SpecServerExtensions {
+        let (l, list) = m;
+        SpecServerExtensions { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ServerExtensions<'a> {
+    pub l: u16,
+    pub list: RepeatResult<SeverHelloExtension<'a>>,
+}
+
+impl View for ServerExtensions<'_> {
+    type V = SpecServerExtensions;
+
+    open spec fn view(&self) -> Self::V {
+        SpecServerExtensions {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type ServerExtensionsInner<'a> = (u16, RepeatResult<SeverHelloExtension<'a>>);
+impl<'a> From<ServerExtensions<'a>> for ServerExtensionsInner<'a> {
+    fn ex_from(m: ServerExtensions) -> ServerExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<ServerExtensionsInner<'a>> for ServerExtensions<'a> {
+    fn ex_from(m: ServerExtensionsInner) -> ServerExtensions {
+        let (l, list) = m;
+        ServerExtensions { l, list }
+    }
+}
+
+pub struct ServerExtensionsMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ServerExtensionsMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ServerExtensionsMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ServerExtensionsMapper(PhantomData)
+    }
+}
+impl View for ServerExtensionsMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ServerExtensionsMapper<'_> {
+    type Src = SpecServerExtensionsInner;
+    type Dst = SpecServerExtensions;
+}
+impl SpecIsoProof for ServerExtensionsMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ServerExtensionsMapper<'a> {
+    type Src = ServerExtensionsInner<'a>;
+    type Dst = ServerExtensions<'a>;
+}
+
+pub struct SpecServerExtensionsCombinator(SpecServerExtensionsCombinatorAlias);
+
+impl SpecCombinator for SpecServerExtensionsCombinator {
+    type Type = SpecServerExtensions;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecServerExtensionsCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecServerExtensionsCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecServerExtensionsCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<SpecSeverHelloExtensionCombinator>>>, ServerExtensionsMapper<'static>>;
+
+pub struct ServerExtensionsCombinator<'a>(ServerExtensionsCombinatorAlias<'a>);
+
+impl<'a> View for ServerExtensionsCombinator<'a> {
+    type V = SpecServerExtensionsCombinator;
+    closed spec fn view(&self) -> Self::V { SpecServerExtensionsCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerExtensionsCombinator<'a> {
+    type Type = ServerExtensions<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ServerExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<SeverHelloExtensionCombinator<'a>>>, ServerExtensionsCont0<'a>>, ServerExtensionsMapper<'a>>;
+
+
+pub closed spec fn spec_server_extensions() -> SpecServerExtensionsCombinator {
+    SpecServerExtensionsCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: |deps| spec_server_extensions_cont0(deps) },
+        mapper: ServerExtensionsMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_server_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSeverHelloExtensionCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_sever_hello_extension()))
+}
+                
+pub fn server_extensions<'a>() -> (o: ServerExtensionsCombinator<'a>)
+    ensures o@ == spec_server_extensions(),
+{
+    ServerExtensionsCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: ServerExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_server_extensions_cont0(deps)) },
+        mapper: ServerExtensionsMapper::new(),
+    })
+}
+
+pub struct ServerExtensionsCont0<'a>(PhantomData<&'a ()>);
+impl<'a> ServerExtensionsCont0<'a> {
+    pub fn new() -> Self {
+        ServerExtensionsCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for ServerExtensionsCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<SeverHelloExtensionCombinator<'a>>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_server_extensions_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(sever_hello_extension()))
+    }
+}
+                
+
+pub struct SpecServerHello {
+    pub legacy_session_id_echo: SpecSessionId,
+    pub cipher_suite: SpecCipherSuite,
+    pub legacy_compression_method: u8,
+    pub extensions: SpecServerExtensions,
+}
+
+pub type SpecServerHelloInner = (SpecSessionId, (SpecCipherSuite, (u8, SpecServerExtensions)));
+impl SpecFrom<SpecServerHello> for SpecServerHelloInner {
+    open spec fn spec_from(m: SpecServerHello) -> SpecServerHelloInner {
+        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
+    }
+}
+impl SpecFrom<SpecServerHelloInner> for SpecServerHello {
+    open spec fn spec_from(m: SpecServerHelloInner) -> SpecServerHello {
+        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
+        SpecServerHello { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ServerHello<'a> {
+    pub legacy_session_id_echo: SessionId<'a>,
+    pub cipher_suite: CipherSuite,
+    pub legacy_compression_method: u8,
+    pub extensions: ServerExtensions<'a>,
+}
+
+impl View for ServerHello<'_> {
+    type V = SpecServerHello;
+
+    open spec fn view(&self) -> Self::V {
+        SpecServerHello {
+            legacy_session_id_echo: self.legacy_session_id_echo@,
+            cipher_suite: self.cipher_suite@,
+            legacy_compression_method: self.legacy_compression_method@,
+            extensions: self.extensions@,
+        }
+    }
+}
+pub type ServerHelloInner<'a> = (SessionId<'a>, (CipherSuite, (u8, ServerExtensions<'a>)));
+impl<'a> From<ServerHello<'a>> for ServerHelloInner<'a> {
+    fn ex_from(m: ServerHello) -> ServerHelloInner {
+        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
+    }
+}
+impl<'a> From<ServerHelloInner<'a>> for ServerHello<'a> {
+    fn ex_from(m: ServerHelloInner) -> ServerHello {
+        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
+        ServerHello { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
+    }
+}
+
+pub struct ServerHelloMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ServerHelloMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ServerHelloMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ServerHelloMapper(PhantomData)
+    }
+}
+impl View for ServerHelloMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ServerHelloMapper<'_> {
+    type Src = SpecServerHelloInner;
+    type Dst = SpecServerHello;
+}
+impl SpecIsoProof for ServerHelloMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ServerHelloMapper<'a> {
+    type Src = ServerHelloInner<'a>;
+    type Dst = ServerHello<'a>;
+}
+pub const SERVERHELLOLEGACY_COMPRESSION_METHOD_CONST: u8 = 0;
+
+pub struct SpecServerHelloCombinator(SpecServerHelloCombinatorAlias);
+
+impl SpecCombinator for SpecServerHelloCombinator {
+    type Type = SpecServerHello;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecServerHelloCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecServerHelloCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecServerHelloCombinatorAlias = Mapped<(SpecSessionIdCombinator, (SpecCipherSuiteCombinator, (Refined<U8, TagPred<u8>>, SpecServerExtensionsCombinator))), ServerHelloMapper<'static>>;
+
+pub struct ServerHelloCombinator<'a>(ServerHelloCombinatorAlias<'a>);
+
+impl<'a> View for ServerHelloCombinator<'a> {
+    type V = SpecServerHelloCombinator;
+    closed spec fn view(&self) -> Self::V { SpecServerHelloCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerHelloCombinator<'a> {
+    type Type = ServerHello<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ServerHelloCombinatorAlias<'a> = Mapped<(SessionIdCombinator<'a>, (CipherSuiteCombinator, (Refined<U8, TagPred<u8>>, ServerExtensionsCombinator<'a>))), ServerHelloMapper<'a>>;
+
+
+pub closed spec fn spec_server_hello() -> SpecServerHelloCombinator {
+    SpecServerHelloCombinator(
+    Mapped {
+        inner: (spec_session_id(), (spec_cipher_suite(), (Refined { inner: U8, predicate: TagPred(SERVERHELLOLEGACY_COMPRESSION_METHOD_CONST) }, spec_server_extensions()))),
+        mapper: ServerHelloMapper::spec_new(),
+    })
+}
+
+                
+pub fn server_hello<'a>() -> (o: ServerHelloCombinator<'a>)
+    ensures o@ == spec_server_hello(),
+{
+    ServerHelloCombinator(
+    Mapped {
+        inner: (session_id(), (cipher_suite(), (Refined { inner: U8, predicate: TagPred(SERVERHELLOLEGACY_COMPRESSION_METHOD_CONST) }, server_extensions()))),
+        mapper: ServerHelloMapper::new(),
+    })
+}
+
+                
+
+pub enum SpecShOrHrrPayload {
+    Variant0(SpecHelloRetryRequest),
+    Variant1(SpecServerHello),
+}
+
+pub type SpecShOrHrrPayloadInner = Either<SpecHelloRetryRequest, SpecServerHello>;
+
+
+
+impl SpecFrom<SpecShOrHrrPayload> for SpecShOrHrrPayloadInner {
+    open spec fn spec_from(m: SpecShOrHrrPayload) -> SpecShOrHrrPayloadInner {
+        match m {
+            SpecShOrHrrPayload::Variant0(m) => Either::Left(m),
+            SpecShOrHrrPayload::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecShOrHrrPayloadInner> for SpecShOrHrrPayload {
+    open spec fn spec_from(m: SpecShOrHrrPayloadInner) -> SpecShOrHrrPayload {
+        match m {
+            Either::Left(m) => SpecShOrHrrPayload::Variant0(m),
+            Either::Right(m) => SpecShOrHrrPayload::Variant1(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShOrHrrPayload<'a> {
+    Variant0(HelloRetryRequest<'a>),
+    Variant1(ServerHello<'a>),
+}
+
+pub type ShOrHrrPayloadInner<'a> = Either<HelloRetryRequest<'a>, ServerHello<'a>>;
+
+
+impl<'a> View for ShOrHrrPayload<'a> {
+    type V = SpecShOrHrrPayload;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            ShOrHrrPayload::Variant0(m) => SpecShOrHrrPayload::Variant0(m@),
+            ShOrHrrPayload::Variant1(m) => SpecShOrHrrPayload::Variant1(m@),
+        }
+    }
+}
+
+
+impl<'a> From<ShOrHrrPayload<'a>> for ShOrHrrPayloadInner<'a> {
+    fn ex_from(m: ShOrHrrPayload<'a>) -> ShOrHrrPayloadInner<'a> {
+        match m {
+            ShOrHrrPayload::Variant0(m) => Either::Left(m),
+            ShOrHrrPayload::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl<'a> From<ShOrHrrPayloadInner<'a>> for ShOrHrrPayload<'a> {
+    fn ex_from(m: ShOrHrrPayloadInner<'a>) -> ShOrHrrPayload<'a> {
+        match m {
+            Either::Left(m) => ShOrHrrPayload::Variant0(m),
+            Either::Right(m) => ShOrHrrPayload::Variant1(m),
+        }
+    }
+    
+}
+
+
+pub struct ShOrHrrPayloadMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ShOrHrrPayloadMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ShOrHrrPayloadMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ShOrHrrPayloadMapper(PhantomData)
+    }
+}
+impl View for ShOrHrrPayloadMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ShOrHrrPayloadMapper<'_> {
+    type Src = SpecShOrHrrPayloadInner;
+    type Dst = SpecShOrHrrPayload;
+}
+impl SpecIsoProof for ShOrHrrPayloadMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ShOrHrrPayloadMapper<'a> {
+    type Src = ShOrHrrPayloadInner<'a>;
+    type Dst = ShOrHrrPayload<'a>;
+}
+
+
+pub struct SpecShOrHrrPayloadCombinator(SpecShOrHrrPayloadCombinatorAlias);
+
+impl SpecCombinator for SpecShOrHrrPayloadCombinator {
+    type Type = SpecShOrHrrPayload;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecShOrHrrPayloadCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecShOrHrrPayloadCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecShOrHrrPayloadCombinatorAlias = Mapped<OrdChoice<Cond<SpecHelloRetryRequestCombinator>, Cond<SpecServerHelloCombinator>>, ShOrHrrPayloadMapper<'static>>;
+
+pub struct ShOrHrrPayloadCombinator<'a>(ShOrHrrPayloadCombinatorAlias<'a>);
+
+impl<'a> View for ShOrHrrPayloadCombinator<'a> {
+    type V = SpecShOrHrrPayloadCombinator;
+    closed spec fn view(&self) -> Self::V { SpecShOrHrrPayloadCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ShOrHrrPayloadCombinator<'a> {
+    type Type = ShOrHrrPayload<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ShOrHrrPayloadCombinatorAlias<'a> = Mapped<OrdChoice<Cond<HelloRetryRequestCombinator<'a>>, Cond<ServerHelloCombinator<'a>>>, ShOrHrrPayloadMapper<'a>>;
+
+
+pub closed spec fn spec_sh_or_hrr_payload(random: Seq<u8>) -> SpecShOrHrrPayloadCombinator {
+    SpecShOrHrrPayloadCombinator(Mapped { inner: OrdChoice(Cond { cond: random == seq![207u8, 33u8, 173u8, 116u8, 229u8, 154u8, 97u8, 17u8, 190u8, 29u8, 140u8, 2u8, 30u8, 101u8, 184u8, 145u8, 194u8, 162u8, 17u8, 22u8, 122u8, 187u8, 140u8, 94u8, 7u8, 158u8, 9u8, 226u8, 200u8, 168u8, 51u8, 156u8], inner: spec_hello_retry_request() }, Cond { cond: !(random == seq![207u8, 33u8, 173u8, 116u8, 229u8, 154u8, 97u8, 17u8, 190u8, 29u8, 140u8, 2u8, 30u8, 101u8, 184u8, 145u8, 194u8, 162u8, 17u8, 22u8, 122u8, 187u8, 140u8, 94u8, 7u8, 158u8, 9u8, 226u8, 200u8, 168u8, 51u8, 156u8]), inner: spec_server_hello() }), mapper: ShOrHrrPayloadMapper::spec_new() })
+}
+
+pub fn sh_or_hrr_payload<'a>(random: &'a [u8]) -> (o: ShOrHrrPayloadCombinator<'a>)
+    ensures o@ == spec_sh_or_hrr_payload(random@),
+{
+    ShOrHrrPayloadCombinator(Mapped { inner: OrdChoice::new(Cond { cond: compare_slice(random, [207, 33, 173, 116, 229, 154, 97, 17, 190, 29, 140, 2, 30, 101, 184, 145, 194, 162, 17, 22, 122, 187, 140, 94, 7, 158, 9, 226, 200, 168, 51, 156].as_slice()), inner: hello_retry_request() }, Cond { cond: !(compare_slice(random, [207, 33, 173, 116, 229, 154, 97, 17, 190, 29, 140, 2, 30, 101, 184, 145, 194, 162, 17, 22, 122, 187, 140, 94, 7, 158, 9, 226, 200, 168, 51, 156].as_slice())), inner: server_hello() }), mapper: ShOrHrrPayloadMapper::new() })
+}
+
+pub type SpecHeartbeatMode = u8;
+pub type HeartbeatMode = u8;
+
+
+pub struct SpecHeartbeatModeCombinator(SpecHeartbeatModeCombinatorAlias);
+
+impl SpecCombinator for SpecHeartbeatModeCombinator {
+    type Type = SpecHeartbeatMode;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHeartbeatModeCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHeartbeatModeCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHeartbeatModeCombinatorAlias = U8;
+
+pub struct HeartbeatModeCombinator(HeartbeatModeCombinatorAlias);
+
+impl View for HeartbeatModeCombinator {
+    type V = SpecHeartbeatModeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHeartbeatModeCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HeartbeatModeCombinator {
+    type Type = HeartbeatMode;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HeartbeatModeCombinatorAlias = U8;
+
+
+pub closed spec fn spec_heartbeat_mode() -> SpecHeartbeatModeCombinator {
+    SpecHeartbeatModeCombinator(U8)
+}
+
+                
+pub fn heartbeat_mode() -> (o: HeartbeatModeCombinator)
+    ensures o@ == spec_heartbeat_mode(),
+{
+    HeartbeatModeCombinator(U8)
+}
+
+                
+
+pub struct SpecHeartbeatExtension {
+    pub mode: SpecHeartbeatMode,
+}
+
+pub type SpecHeartbeatExtensionInner = SpecHeartbeatMode;
+impl SpecFrom<SpecHeartbeatExtension> for SpecHeartbeatExtensionInner {
+    open spec fn spec_from(m: SpecHeartbeatExtension) -> SpecHeartbeatExtensionInner {
+        m.mode
+    }
+}
+impl SpecFrom<SpecHeartbeatExtensionInner> for SpecHeartbeatExtension {
+    open spec fn spec_from(m: SpecHeartbeatExtensionInner) -> SpecHeartbeatExtension {
+        let mode = m;
+        SpecHeartbeatExtension { mode }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct HeartbeatExtension {
+    pub mode: HeartbeatMode,
+}
+
+impl View for HeartbeatExtension {
+    type V = SpecHeartbeatExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecHeartbeatExtension {
+            mode: self.mode@,
+        }
+    }
+}
+pub type HeartbeatExtensionInner = HeartbeatMode;
+impl From<HeartbeatExtension> for HeartbeatExtensionInner {
+    fn ex_from(m: HeartbeatExtension) -> HeartbeatExtensionInner {
+        m.mode
+    }
+}
+impl From<HeartbeatExtensionInner> for HeartbeatExtension {
+    fn ex_from(m: HeartbeatExtensionInner) -> HeartbeatExtension {
+        let mode = m;
+        HeartbeatExtension { mode }
+    }
+}
+
+pub struct HeartbeatExtensionMapper;
+impl HeartbeatExtensionMapper {
+    pub closed spec fn spec_new() -> Self {
+        HeartbeatExtensionMapper
+    }
+    pub fn new() -> Self {
+        HeartbeatExtensionMapper
+    }
+}
+impl View for HeartbeatExtensionMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for HeartbeatExtensionMapper {
+    type Src = SpecHeartbeatExtensionInner;
+    type Dst = SpecHeartbeatExtension;
+}
+impl SpecIsoProof for HeartbeatExtensionMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for HeartbeatExtensionMapper {
+    type Src = HeartbeatExtensionInner;
+    type Dst = HeartbeatExtension;
+}
+
+pub struct SpecHeartbeatExtensionCombinator(SpecHeartbeatExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecHeartbeatExtensionCombinator {
+    type Type = SpecHeartbeatExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHeartbeatExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHeartbeatExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHeartbeatExtensionCombinatorAlias = Mapped<SpecHeartbeatModeCombinator, HeartbeatExtensionMapper>;
+
+pub struct HeartbeatExtensionCombinator(HeartbeatExtensionCombinatorAlias);
+
+impl View for HeartbeatExtensionCombinator {
+    type V = SpecHeartbeatExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHeartbeatExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HeartbeatExtensionCombinator {
+    type Type = HeartbeatExtension;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HeartbeatExtensionCombinatorAlias = Mapped<HeartbeatModeCombinator, HeartbeatExtensionMapper>;
+
+
+pub closed spec fn spec_heartbeat_extension() -> SpecHeartbeatExtensionCombinator {
+    SpecHeartbeatExtensionCombinator(
+    Mapped {
+        inner: spec_heartbeat_mode(),
+        mapper: HeartbeatExtensionMapper::spec_new(),
+    })
+}
+
+                
+pub fn heartbeat_extension() -> (o: HeartbeatExtensionCombinator)
+    ensures o@ == spec_heartbeat_extension(),
+{
+    HeartbeatExtensionCombinator(
+    Mapped {
+        inner: heartbeat_mode(),
+        mapper: HeartbeatExtensionMapper::new(),
+    })
+}
+
+                
+pub type SpecPskKeyExchangeMode = u8;
+pub type PskKeyExchangeMode = u8;
+
+
+pub struct SpecPskKeyExchangeModeCombinator(SpecPskKeyExchangeModeCombinatorAlias);
+
+impl SpecCombinator for SpecPskKeyExchangeModeCombinator {
+    type Type = SpecPskKeyExchangeMode;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecPskKeyExchangeModeCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecPskKeyExchangeModeCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecPskKeyExchangeModeCombinatorAlias = U8;
+
+pub struct PskKeyExchangeModeCombinator(PskKeyExchangeModeCombinatorAlias);
+
+impl View for PskKeyExchangeModeCombinator {
+    type V = SpecPskKeyExchangeModeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecPskKeyExchangeModeCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for PskKeyExchangeModeCombinator {
+    type Type = PskKeyExchangeMode;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type PskKeyExchangeModeCombinatorAlias = U8;
+
+
+pub closed spec fn spec_psk_key_exchange_mode() -> SpecPskKeyExchangeModeCombinator {
+    SpecPskKeyExchangeModeCombinator(U8)
+}
+
+                
+pub fn psk_key_exchange_mode() -> (o: PskKeyExchangeModeCombinator)
+    ensures o@ == spec_psk_key_exchange_mode(),
+{
+    PskKeyExchangeModeCombinator(U8)
+}
+
+                
+pub type SpecEmpty = Seq<u8>;
+pub type Empty<'a> = &'a [u8];
+
+
+pub struct SpecEmptyCombinator(SpecEmptyCombinatorAlias);
+
+impl SpecCombinator for SpecEmptyCombinator {
+    type Type = SpecEmpty;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEmptyCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEmptyCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEmptyCombinatorAlias = BytesN<0>;
+
+pub struct EmptyCombinator(EmptyCombinatorAlias);
+
+impl View for EmptyCombinator {
+    type V = SpecEmptyCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEmptyCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EmptyCombinator {
+    type Type = Empty<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EmptyCombinatorAlias = BytesN<0>;
+
+
+pub closed spec fn spec_empty() -> SpecEmptyCombinator {
+    SpecEmptyCombinator(BytesN::<0>)
+}
+
+                
+pub fn empty() -> (o: EmptyCombinator)
+    ensures o@ == spec_empty(),
+{
+    EmptyCombinator(BytesN::<0>)
+}
+
+                
+pub type SpecMaxFragmentLength = u8;
+pub type MaxFragmentLength = u8;
+
+
+pub struct SpecMaxFragmentLengthCombinator(SpecMaxFragmentLengthCombinatorAlias);
+
+impl SpecCombinator for SpecMaxFragmentLengthCombinator {
+    type Type = SpecMaxFragmentLength;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMaxFragmentLengthCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecMaxFragmentLengthCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMaxFragmentLengthCombinatorAlias = U8;
+
+pub struct MaxFragmentLengthCombinator(MaxFragmentLengthCombinatorAlias);
+
+impl View for MaxFragmentLengthCombinator {
+    type V = SpecMaxFragmentLengthCombinator;
+    closed spec fn view(&self) -> Self::V { SpecMaxFragmentLengthCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for MaxFragmentLengthCombinator {
+    type Type = MaxFragmentLength;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type MaxFragmentLengthCombinatorAlias = U8;
+
+
+pub closed spec fn spec_max_fragment_length() -> SpecMaxFragmentLengthCombinator {
+    SpecMaxFragmentLengthCombinator(U8)
+}
+
+                
+pub fn max_fragment_length() -> (o: MaxFragmentLengthCombinator)
+    ensures o@ == spec_max_fragment_length(),
+{
+    MaxFragmentLengthCombinator(U8)
+}
+
+                
+
+pub struct SpecNamedGroupList {
+    pub l: u16,
+    pub list: Seq<SpecNamedGroup>,
+}
+
+pub type SpecNamedGroupListInner = (u16, Seq<SpecNamedGroup>);
+impl SpecFrom<SpecNamedGroupList> for SpecNamedGroupListInner {
+    open spec fn spec_from(m: SpecNamedGroupList) -> SpecNamedGroupListInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecNamedGroupListInner> for SpecNamedGroupList {
+    open spec fn spec_from(m: SpecNamedGroupListInner) -> SpecNamedGroupList {
+        let (l, list) = m;
+        SpecNamedGroupList { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct NamedGroupList {
+    pub l: u16,
+    pub list: RepeatResult<NamedGroup>,
+}
+
+impl View for NamedGroupList {
+    type V = SpecNamedGroupList;
+
+    open spec fn view(&self) -> Self::V {
+        SpecNamedGroupList {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type NamedGroupListInner = (u16, RepeatResult<NamedGroup>);
+impl From<NamedGroupList> for NamedGroupListInner {
+    fn ex_from(m: NamedGroupList) -> NamedGroupListInner {
+        (m.l, m.list)
+    }
+}
+impl From<NamedGroupListInner> for NamedGroupList {
+    fn ex_from(m: NamedGroupListInner) -> NamedGroupList {
+        let (l, list) = m;
+        NamedGroupList { l, list }
+    }
+}
+
+pub struct NamedGroupListMapper;
+impl NamedGroupListMapper {
+    pub closed spec fn spec_new() -> Self {
+        NamedGroupListMapper
+    }
+    pub fn new() -> Self {
+        NamedGroupListMapper
+    }
+}
+impl View for NamedGroupListMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for NamedGroupListMapper {
+    type Src = SpecNamedGroupListInner;
+    type Dst = SpecNamedGroupList;
+}
+impl SpecIsoProof for NamedGroupListMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for NamedGroupListMapper {
+    type Src = NamedGroupListInner;
+    type Dst = NamedGroupList;
+}
+
+pub struct SpecNamedGroupListCombinator(SpecNamedGroupListCombinatorAlias);
+
+impl SpecCombinator for SpecNamedGroupListCombinator {
+    type Type = SpecNamedGroupList;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNamedGroupListCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNamedGroupListCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNamedGroupListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<SpecNamedGroupCombinator>>>, NamedGroupListMapper>;
+pub struct Predicate8195707947578446211;
+impl View for Predicate8195707947578446211 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate8195707947578446211 {
+    type Input = u16;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 2 && i <= 65535)
+    }
+}
+impl SpecPred for Predicate8195707947578446211 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 2 && i <= 65535)
+    }
+}
+
+pub struct NamedGroupListCombinator<'a>(NamedGroupListCombinatorAlias<'a>);
+
+impl<'a> View for NamedGroupListCombinator<'a> {
+    type V = SpecNamedGroupListCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNamedGroupListCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NamedGroupListCombinator<'a> {
+    type Type = NamedGroupList;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NamedGroupListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<NamedGroupCombinator>>, NamedGroupListCont0<'a>>, NamedGroupListMapper>;
+
+
+pub closed spec fn spec_named_group_list() -> SpecNamedGroupListCombinator {
+    SpecNamedGroupListCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: |deps| spec_named_group_list_cont0(deps) },
+        mapper: NamedGroupListMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_named_group_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecNamedGroupCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_named_group()))
+}
+                
+pub fn named_group_list<'a>() -> (o: NamedGroupListCombinator<'a>)
+    ensures o@ == spec_named_group_list(),
+{
+    NamedGroupListCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: NamedGroupListCont0::new(), spec_snd: Ghost(|deps| spec_named_group_list_cont0(deps)) },
+        mapper: NamedGroupListMapper::new(),
+    })
+}
+
+pub struct NamedGroupListCont0<'a>(PhantomData<&'a ()>);
+impl<'a> NamedGroupListCont0<'a> {
+    pub fn new() -> Self {
+        NamedGroupListCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for NamedGroupListCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<NamedGroupCombinator>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_named_group_list_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(named_group()))
     }
 }
                 
@@ -4326,6 +6907,8 @@ impl View for ProtocolNameListMapper<'_> {
 impl SpecIso for ProtocolNameListMapper<'_> {
     type Src = SpecProtocolNameListInner;
     type Dst = SpecProtocolNameList;
+}
+impl SpecIsoProof for ProtocolNameListMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -4430,246 +7013,6 @@ impl<'a> Continuation<&u16> for ProtocolNameListCont0<'a> {
     fn apply(&self, deps: &u16) -> Self::Output {
         let l = *deps;
         AndThen(Bytes(l.ex_into()), Repeat::new(protocol_name()))
-    }
-}
-                
-pub type SpecSerializedSct = SpecOpaque1Ffff;
-pub type SerializedSct<'a> = Opaque1Ffff<'a>;
-
-
-pub struct SpecSerializedSctCombinator(SpecSerializedSctCombinatorAlias);
-
-impl SpecCombinator for SpecSerializedSctCombinator {
-    type Type = SpecSerializedSct;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSerializedSctCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSerializedSctCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSerializedSctCombinatorAlias = SpecOpaque1FfffCombinator;
-
-pub struct SerializedSctCombinator<'a>(SerializedSctCombinatorAlias<'a>);
-
-impl<'a> View for SerializedSctCombinator<'a> {
-    type V = SpecSerializedSctCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSerializedSctCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SerializedSctCombinator<'a> {
-    type Type = SerializedSct<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SerializedSctCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
-
-
-pub closed spec fn spec_serialized_sct() -> SpecSerializedSctCombinator {
-    SpecSerializedSctCombinator(spec_opaque_1_ffff())
-}
-
-                
-pub fn serialized_sct<'a>() -> (o: SerializedSctCombinator<'a>)
-    ensures o@ == spec_serialized_sct(),
-{
-    SerializedSctCombinator(opaque_1_ffff())
-}
-
-                
-
-pub struct SpecSignedCertificateTimestampList {
-    pub l: u16,
-    pub list: Seq<SpecSerializedSct>,
-}
-
-pub type SpecSignedCertificateTimestampListInner = (u16, Seq<SpecSerializedSct>);
-impl SpecFrom<SpecSignedCertificateTimestampList> for SpecSignedCertificateTimestampListInner {
-    open spec fn spec_from(m: SpecSignedCertificateTimestampList) -> SpecSignedCertificateTimestampListInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecSignedCertificateTimestampListInner> for SpecSignedCertificateTimestampList {
-    open spec fn spec_from(m: SpecSignedCertificateTimestampListInner) -> SpecSignedCertificateTimestampList {
-        let (l, list) = m;
-        SpecSignedCertificateTimestampList { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct SignedCertificateTimestampList<'a> {
-    pub l: u16,
-    pub list: RepeatResult<SerializedSct<'a>>,
-}
-
-impl View for SignedCertificateTimestampList<'_> {
-    type V = SpecSignedCertificateTimestampList;
-
-    open spec fn view(&self) -> Self::V {
-        SpecSignedCertificateTimestampList {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type SignedCertificateTimestampListInner<'a> = (u16, RepeatResult<SerializedSct<'a>>);
-impl<'a> From<SignedCertificateTimestampList<'a>> for SignedCertificateTimestampListInner<'a> {
-    fn ex_from(m: SignedCertificateTimestampList) -> SignedCertificateTimestampListInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<SignedCertificateTimestampListInner<'a>> for SignedCertificateTimestampList<'a> {
-    fn ex_from(m: SignedCertificateTimestampListInner) -> SignedCertificateTimestampList {
-        let (l, list) = m;
-        SignedCertificateTimestampList { l, list }
-    }
-}
-
-pub struct SignedCertificateTimestampListMapper<'a>(PhantomData<&'a ()>);
-impl<'a> SignedCertificateTimestampListMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        SignedCertificateTimestampListMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        SignedCertificateTimestampListMapper(PhantomData)
-    }
-}
-impl View for SignedCertificateTimestampListMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for SignedCertificateTimestampListMapper<'_> {
-    type Src = SpecSignedCertificateTimestampListInner;
-    type Dst = SpecSignedCertificateTimestampList;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for SignedCertificateTimestampListMapper<'a> {
-    type Src = SignedCertificateTimestampListInner<'a>;
-    type Dst = SignedCertificateTimestampList<'a>;
-}
-
-pub struct SpecSignedCertificateTimestampListCombinator(SpecSignedCertificateTimestampListCombinatorAlias);
-
-impl SpecCombinator for SpecSignedCertificateTimestampListCombinator {
-    type Type = SpecSignedCertificateTimestampList;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSignedCertificateTimestampListCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSignedCertificateTimestampListCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSignedCertificateTimestampListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<SpecSerializedSctCombinator>>>, SignedCertificateTimestampListMapper<'static>>;
-
-pub struct SignedCertificateTimestampListCombinator<'a>(SignedCertificateTimestampListCombinatorAlias<'a>);
-
-impl<'a> View for SignedCertificateTimestampListCombinator<'a> {
-    type V = SpecSignedCertificateTimestampListCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSignedCertificateTimestampListCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SignedCertificateTimestampListCombinator<'a> {
-    type Type = SignedCertificateTimestampList<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SignedCertificateTimestampListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<SerializedSctCombinator<'a>>>, SignedCertificateTimestampListCont0<'a>>, SignedCertificateTimestampListMapper<'a>>;
-
-
-pub closed spec fn spec_signed_certificate_timestamp_list() -> SpecSignedCertificateTimestampListCombinator {
-    SpecSignedCertificateTimestampListCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: |deps| spec_signed_certificate_timestamp_list_cont0(deps) },
-        mapper: SignedCertificateTimestampListMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_signed_certificate_timestamp_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSerializedSctCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_serialized_sct()))
-}
-                
-pub fn signed_certificate_timestamp_list<'a>() -> (o: SignedCertificateTimestampListCombinator<'a>)
-    ensures o@ == spec_signed_certificate_timestamp_list(),
-{
-    SignedCertificateTimestampListCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: SignedCertificateTimestampListCont0::new(), spec_snd: Ghost(|deps| spec_signed_certificate_timestamp_list_cont0(deps)) },
-        mapper: SignedCertificateTimestampListMapper::new(),
-    })
-}
-
-pub struct SignedCertificateTimestampListCont0<'a>(PhantomData<&'a ()>);
-impl<'a> SignedCertificateTimestampListCont0<'a> {
-    pub fn new() -> Self {
-        SignedCertificateTimestampListCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for SignedCertificateTimestampListCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<SerializedSctCombinator<'a>>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_signed_certificate_timestamp_list_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(serialized_sct()))
     }
 }
                 
@@ -4806,6 +7149,8 @@ impl View for ClientCertTypeClientExtensionMapper {
 impl SpecIso for ClientCertTypeClientExtensionMapper {
     type Src = SpecClientCertTypeClientExtensionInner;
     type Dst = SpecClientCertTypeClientExtension;
+}
+impl SpecIsoProof for ClientCertTypeClientExtensionMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -4844,6 +7189,30 @@ impl SecureSpecCombinator for SpecClientCertTypeClientExtensionCombinator {
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecClientCertTypeClientExtensionCombinatorAlias = Mapped<SpecDepend<Refined<U8, Predicate13984338198318635021>, AndThen<Bytes, Repeat<SpecCertificateTypeCombinator>>>, ClientCertTypeClientExtensionMapper>;
+pub struct Predicate13984338198318635021;
+impl View for Predicate13984338198318635021 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate13984338198318635021 {
+    type Input = u8;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 1 && i <= 255)
+    }
+}
+impl SpecPred for Predicate13984338198318635021 {
+    type Input = u8;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 1 && i <= 255)
+    }
+}
 
 pub struct ClientCertTypeClientExtensionCombinator<'a>(ClientCertTypeClientExtensionCombinatorAlias<'a>);
 
@@ -4979,6 +7348,8 @@ impl View for ServerCertTypeClientExtensionMapper {
 impl SpecIso for ServerCertTypeClientExtensionMapper {
     type Src = SpecServerCertTypeClientExtensionInner;
     type Dst = SpecServerCertTypeClientExtension;
+}
+impl SpecIsoProof for ServerCertTypeClientExtensionMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -5087,6 +7458,1535 @@ impl<'a> Continuation<&u8> for ServerCertTypeClientExtensionCont0<'a> {
 }
                 
 
+pub enum SpecEncryptedExtensionExtensionData {
+    ServerName(SpecEmpty),
+    MaxFragmentLength(SpecMaxFragmentLength),
+    SupportedGroups(SpecNamedGroupList),
+    Heartbeat(SpecHeartbeatMode),
+    ApplicationLayerProtocolNegotiation(SpecProtocolNameList),
+    ClientCertificateType(SpecClientCertTypeClientExtension),
+    ServerCertificateType(SpecServerCertTypeClientExtension),
+    EarlyData(SpecEmpty),
+    Unrecognized(Seq<u8>),
+}
+
+pub type SpecEncryptedExtensionExtensionDataInner = Either<SpecEmpty, Either<SpecMaxFragmentLength, Either<SpecNamedGroupList, Either<SpecHeartbeatMode, Either<SpecProtocolNameList, Either<SpecClientCertTypeClientExtension, Either<SpecServerCertTypeClientExtension, Either<SpecEmpty, Seq<u8>>>>>>>>>;
+
+
+
+impl SpecFrom<SpecEncryptedExtensionExtensionData> for SpecEncryptedExtensionExtensionDataInner {
+    open spec fn spec_from(m: SpecEncryptedExtensionExtensionData) -> SpecEncryptedExtensionExtensionDataInner {
+        match m {
+            SpecEncryptedExtensionExtensionData::ServerName(m) => Either::Left(m),
+            SpecEncryptedExtensionExtensionData::MaxFragmentLength(m) => Either::Right(Either::Left(m)),
+            SpecEncryptedExtensionExtensionData::SupportedGroups(m) => Either::Right(Either::Right(Either::Left(m))),
+            SpecEncryptedExtensionExtensionData::Heartbeat(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
+            SpecEncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
+            SpecEncryptedExtensionExtensionData::ClientCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
+            SpecEncryptedExtensionExtensionData::ServerCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))),
+            SpecEncryptedExtensionExtensionData::EarlyData(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))),
+            SpecEncryptedExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecEncryptedExtensionExtensionDataInner> for SpecEncryptedExtensionExtensionData {
+    open spec fn spec_from(m: SpecEncryptedExtensionExtensionDataInner) -> SpecEncryptedExtensionExtensionData {
+        match m {
+            Either::Left(m) => SpecEncryptedExtensionExtensionData::ServerName(m),
+            Either::Right(Either::Left(m)) => SpecEncryptedExtensionExtensionData::MaxFragmentLength(m),
+            Either::Right(Either::Right(Either::Left(m))) => SpecEncryptedExtensionExtensionData::SupportedGroups(m),
+            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => SpecEncryptedExtensionExtensionData::Heartbeat(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => SpecEncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => SpecEncryptedExtensionExtensionData::ClientCertificateType(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))) => SpecEncryptedExtensionExtensionData::ServerCertificateType(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))) => SpecEncryptedExtensionExtensionData::EarlyData(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))) => SpecEncryptedExtensionExtensionData::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncryptedExtensionExtensionData<'a> {
+    ServerName(Empty<'a>),
+    MaxFragmentLength(MaxFragmentLength),
+    SupportedGroups(NamedGroupList),
+    Heartbeat(HeartbeatMode),
+    ApplicationLayerProtocolNegotiation(ProtocolNameList<'a>),
+    ClientCertificateType(ClientCertTypeClientExtension),
+    ServerCertificateType(ServerCertTypeClientExtension),
+    EarlyData(Empty<'a>),
+    Unrecognized(&'a [u8]),
+}
+
+pub type EncryptedExtensionExtensionDataInner<'a> = Either<Empty<'a>, Either<MaxFragmentLength, Either<NamedGroupList, Either<HeartbeatMode, Either<ProtocolNameList<'a>, Either<ClientCertTypeClientExtension, Either<ServerCertTypeClientExtension, Either<Empty<'a>, &'a [u8]>>>>>>>>;
+
+
+impl<'a> View for EncryptedExtensionExtensionData<'a> {
+    type V = SpecEncryptedExtensionExtensionData;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            EncryptedExtensionExtensionData::ServerName(m) => SpecEncryptedExtensionExtensionData::ServerName(m@),
+            EncryptedExtensionExtensionData::MaxFragmentLength(m) => SpecEncryptedExtensionExtensionData::MaxFragmentLength(m@),
+            EncryptedExtensionExtensionData::SupportedGroups(m) => SpecEncryptedExtensionExtensionData::SupportedGroups(m@),
+            EncryptedExtensionExtensionData::Heartbeat(m) => SpecEncryptedExtensionExtensionData::Heartbeat(m@),
+            EncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m) => SpecEncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m@),
+            EncryptedExtensionExtensionData::ClientCertificateType(m) => SpecEncryptedExtensionExtensionData::ClientCertificateType(m@),
+            EncryptedExtensionExtensionData::ServerCertificateType(m) => SpecEncryptedExtensionExtensionData::ServerCertificateType(m@),
+            EncryptedExtensionExtensionData::EarlyData(m) => SpecEncryptedExtensionExtensionData::EarlyData(m@),
+            EncryptedExtensionExtensionData::Unrecognized(m) => SpecEncryptedExtensionExtensionData::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<EncryptedExtensionExtensionData<'a>> for EncryptedExtensionExtensionDataInner<'a> {
+    fn ex_from(m: EncryptedExtensionExtensionData<'a>) -> EncryptedExtensionExtensionDataInner<'a> {
+        match m {
+            EncryptedExtensionExtensionData::ServerName(m) => Either::Left(m),
+            EncryptedExtensionExtensionData::MaxFragmentLength(m) => Either::Right(Either::Left(m)),
+            EncryptedExtensionExtensionData::SupportedGroups(m) => Either::Right(Either::Right(Either::Left(m))),
+            EncryptedExtensionExtensionData::Heartbeat(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
+            EncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
+            EncryptedExtensionExtensionData::ClientCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
+            EncryptedExtensionExtensionData::ServerCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))),
+            EncryptedExtensionExtensionData::EarlyData(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))),
+            EncryptedExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))),
+        }
+    }
+
+}
+
+impl<'a> From<EncryptedExtensionExtensionDataInner<'a>> for EncryptedExtensionExtensionData<'a> {
+    fn ex_from(m: EncryptedExtensionExtensionDataInner<'a>) -> EncryptedExtensionExtensionData<'a> {
+        match m {
+            Either::Left(m) => EncryptedExtensionExtensionData::ServerName(m),
+            Either::Right(Either::Left(m)) => EncryptedExtensionExtensionData::MaxFragmentLength(m),
+            Either::Right(Either::Right(Either::Left(m))) => EncryptedExtensionExtensionData::SupportedGroups(m),
+            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => EncryptedExtensionExtensionData::Heartbeat(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => EncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => EncryptedExtensionExtensionData::ClientCertificateType(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))) => EncryptedExtensionExtensionData::ServerCertificateType(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))) => EncryptedExtensionExtensionData::EarlyData(m),
+            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))) => EncryptedExtensionExtensionData::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct EncryptedExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> EncryptedExtensionExtensionDataMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        EncryptedExtensionExtensionDataMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        EncryptedExtensionExtensionDataMapper(PhantomData)
+    }
+}
+impl View for EncryptedExtensionExtensionDataMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for EncryptedExtensionExtensionDataMapper<'_> {
+    type Src = SpecEncryptedExtensionExtensionDataInner;
+    type Dst = SpecEncryptedExtensionExtensionData;
+}
+impl SpecIsoProof for EncryptedExtensionExtensionDataMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for EncryptedExtensionExtensionDataMapper<'a> {
+    type Src = EncryptedExtensionExtensionDataInner<'a>;
+    type Dst = EncryptedExtensionExtensionData<'a>;
+}
+
+
+pub struct SpecEncryptedExtensionExtensionDataCombinator(SpecEncryptedExtensionExtensionDataCombinatorAlias);
+
+impl SpecCombinator for SpecEncryptedExtensionExtensionDataCombinator {
+    type Type = SpecEncryptedExtensionExtensionData;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEncryptedExtensionExtensionDataCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEncryptedExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEncryptedExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecEmptyCombinator>, OrdChoice<Cond<SpecMaxFragmentLengthCombinator>, OrdChoice<Cond<SpecNamedGroupListCombinator>, OrdChoice<Cond<SpecHeartbeatModeCombinator>, OrdChoice<Cond<SpecProtocolNameListCombinator>, OrdChoice<Cond<SpecClientCertTypeClientExtensionCombinator>, OrdChoice<Cond<SpecServerCertTypeClientExtensionCombinator>, OrdChoice<Cond<SpecEmptyCombinator>, Cond<Bytes>>>>>>>>>, EncryptedExtensionExtensionDataMapper<'static>>>;
+
+pub struct EncryptedExtensionExtensionDataCombinator<'a>(EncryptedExtensionExtensionDataCombinatorAlias<'a>);
+
+impl<'a> View for EncryptedExtensionExtensionDataCombinator<'a> {
+    type V = SpecEncryptedExtensionExtensionDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEncryptedExtensionExtensionDataCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EncryptedExtensionExtensionDataCombinator<'a> {
+    type Type = EncryptedExtensionExtensionData<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EncryptedExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<EmptyCombinator>, OrdChoice<Cond<MaxFragmentLengthCombinator>, OrdChoice<Cond<NamedGroupListCombinator<'a>>, OrdChoice<Cond<HeartbeatModeCombinator>, OrdChoice<Cond<ProtocolNameListCombinator<'a>>, OrdChoice<Cond<ClientCertTypeClientExtensionCombinator<'a>>, OrdChoice<Cond<ServerCertTypeClientExtensionCombinator<'a>>, OrdChoice<Cond<EmptyCombinator>, Cond<Bytes>>>>>>>>>, EncryptedExtensionExtensionDataMapper<'a>>>;
+
+
+pub closed spec fn spec_encrypted_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecEncryptedExtensionExtensionDataCombinator {
+    SpecEncryptedExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 0, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 1, inner: spec_max_fragment_length() }, OrdChoice(Cond { cond: extension_type == 10, inner: spec_named_group_list() }, OrdChoice(Cond { cond: extension_type == 15, inner: spec_heartbeat_mode() }, OrdChoice(Cond { cond: extension_type == 16, inner: spec_protocol_name_list() }, OrdChoice(Cond { cond: extension_type == 19, inner: spec_client_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 20, inner: spec_server_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 42, inner: spec_empty() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 10 || extension_type == 15 || extension_type == 16 || extension_type == 19 || extension_type == 20 || extension_type == 42), inner: Bytes(ext_len.spec_into()) })))))))), mapper: EncryptedExtensionExtensionDataMapper::spec_new() }))
+}
+
+pub fn encrypted_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: EncryptedExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_encrypted_extension_extension_data(extension_type@, ext_len@),
+{
+    EncryptedExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 0, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 1, inner: max_fragment_length() }, OrdChoice::new(Cond { cond: extension_type == 10, inner: named_group_list() }, OrdChoice::new(Cond { cond: extension_type == 15, inner: heartbeat_mode() }, OrdChoice::new(Cond { cond: extension_type == 16, inner: protocol_name_list() }, OrdChoice::new(Cond { cond: extension_type == 19, inner: client_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 20, inner: server_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 42, inner: empty() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 10 || extension_type == 15 || extension_type == 16 || extension_type == 19 || extension_type == 20 || extension_type == 42), inner: Bytes(ext_len.ex_into()) })))))))), mapper: EncryptedExtensionExtensionDataMapper::new() }))
+}
+
+
+pub struct SpecEncryptedExtension {
+    pub extension_type: SpecExtensionType,
+    pub ext_len: u16,
+    pub extension_data: SpecEncryptedExtensionExtensionData,
+}
+
+pub type SpecEncryptedExtensionInner = ((SpecExtensionType, u16), SpecEncryptedExtensionExtensionData);
+impl SpecFrom<SpecEncryptedExtension> for SpecEncryptedExtensionInner {
+    open spec fn spec_from(m: SpecEncryptedExtension) -> SpecEncryptedExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl SpecFrom<SpecEncryptedExtensionInner> for SpecEncryptedExtension {
+    open spec fn spec_from(m: SpecEncryptedExtensionInner) -> SpecEncryptedExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        SpecEncryptedExtension { extension_type, ext_len, extension_data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct EncryptedExtension<'a> {
+    pub extension_type: ExtensionType,
+    pub ext_len: u16,
+    pub extension_data: EncryptedExtensionExtensionData<'a>,
+}
+
+impl View for EncryptedExtension<'_> {
+    type V = SpecEncryptedExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecEncryptedExtension {
+            extension_type: self.extension_type@,
+            ext_len: self.ext_len@,
+            extension_data: self.extension_data@,
+        }
+    }
+}
+pub type EncryptedExtensionInner<'a> = ((ExtensionType, u16), EncryptedExtensionExtensionData<'a>);
+impl<'a> From<EncryptedExtension<'a>> for EncryptedExtensionInner<'a> {
+    fn ex_from(m: EncryptedExtension) -> EncryptedExtensionInner {
+        ((m.extension_type, m.ext_len), m.extension_data)
+    }
+}
+impl<'a> From<EncryptedExtensionInner<'a>> for EncryptedExtension<'a> {
+    fn ex_from(m: EncryptedExtensionInner) -> EncryptedExtension {
+        let ((extension_type, ext_len), extension_data) = m;
+        EncryptedExtension { extension_type, ext_len, extension_data }
+    }
+}
+
+pub struct EncryptedExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> EncryptedExtensionMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        EncryptedExtensionMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        EncryptedExtensionMapper(PhantomData)
+    }
+}
+impl View for EncryptedExtensionMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for EncryptedExtensionMapper<'_> {
+    type Src = SpecEncryptedExtensionInner;
+    type Dst = SpecEncryptedExtension;
+}
+impl SpecIsoProof for EncryptedExtensionMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for EncryptedExtensionMapper<'a> {
+    type Src = EncryptedExtensionInner<'a>;
+    type Dst = EncryptedExtension<'a>;
+}
+
+pub struct SpecEncryptedExtensionCombinator(SpecEncryptedExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecEncryptedExtensionCombinator {
+    type Type = SpecEncryptedExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEncryptedExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEncryptedExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEncryptedExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecEncryptedExtensionExtensionDataCombinator>, EncryptedExtensionMapper<'static>>;
+
+pub struct EncryptedExtensionCombinator<'a>(EncryptedExtensionCombinatorAlias<'a>);
+
+impl<'a> View for EncryptedExtensionCombinator<'a> {
+    type V = SpecEncryptedExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEncryptedExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EncryptedExtensionCombinator<'a> {
+    type Type = EncryptedExtension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EncryptedExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, EncryptedExtensionCont1<'a>>, EncryptedExtensionExtensionDataCombinator<'a>, EncryptedExtensionCont0<'a>>, EncryptedExtensionMapper<'a>>;
+
+
+pub closed spec fn spec_encrypted_extension() -> SpecEncryptedExtensionCombinator {
+    SpecEncryptedExtensionCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_encrypted_extension_cont1(deps) }, snd: |deps| spec_encrypted_extension_cont0(deps) },
+        mapper: EncryptedExtensionMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_encrypted_extension_cont1(deps: SpecExtensionType) -> U16Be {
+    let extension_type = deps;
+    U16Be
+}
+pub open spec fn spec_encrypted_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecEncryptedExtensionExtensionDataCombinator {
+    let (extension_type, ext_len) = deps;
+    spec_encrypted_extension_extension_data(extension_type, ext_len)
+}
+                
+pub fn encrypted_extension<'a>() -> (o: EncryptedExtensionCombinator<'a>)
+    ensures o@ == spec_encrypted_extension(),
+{
+    EncryptedExtensionCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: extension_type(), snd: EncryptedExtensionCont1::new(), spec_snd: Ghost(|deps| spec_encrypted_extension_cont1(deps)) }, snd: EncryptedExtensionCont0::new(), spec_snd: Ghost(|deps| spec_encrypted_extension_cont0(deps)) },
+        mapper: EncryptedExtensionMapper::new(),
+    })
+}
+
+pub struct EncryptedExtensionCont1<'a>(PhantomData<&'a ()>);
+impl<'a> EncryptedExtensionCont1<'a> {
+    pub fn new() -> Self {
+        EncryptedExtensionCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&ExtensionType> for EncryptedExtensionCont1<'a> {
+    type Output = U16Be;
+
+    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
+        o@ == spec_encrypted_extension_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &ExtensionType) -> Self::Output {
+        let extension_type = *deps;
+        U16Be
+    }
+}
+pub struct EncryptedExtensionCont0<'a>(PhantomData<&'a ()>);
+impl<'a> EncryptedExtensionCont0<'a> {
+    pub fn new() -> Self {
+        EncryptedExtensionCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(ExtensionType, u16)> for EncryptedExtensionCont0<'a> {
+    type Output = EncryptedExtensionExtensionDataCombinator<'a>;
+
+    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
+        o@ == spec_encrypted_extension_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
+        let (extension_type, ext_len) = *deps;
+        encrypted_extension_extension_data(extension_type, ext_len)
+    }
+}
+                
+
+pub struct SpecExtension {
+    pub extension_type: SpecExtensionType,
+    pub extension_data: SpecOpaque0Ffff,
+}
+
+pub type SpecExtensionInner = (SpecExtensionType, SpecOpaque0Ffff);
+impl SpecFrom<SpecExtension> for SpecExtensionInner {
+    open spec fn spec_from(m: SpecExtension) -> SpecExtensionInner {
+        (m.extension_type, m.extension_data)
+    }
+}
+impl SpecFrom<SpecExtensionInner> for SpecExtension {
+    open spec fn spec_from(m: SpecExtensionInner) -> SpecExtension {
+        let (extension_type, extension_data) = m;
+        SpecExtension { extension_type, extension_data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct Extension<'a> {
+    pub extension_type: ExtensionType,
+    pub extension_data: Opaque0Ffff<'a>,
+}
+
+impl View for Extension<'_> {
+    type V = SpecExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecExtension {
+            extension_type: self.extension_type@,
+            extension_data: self.extension_data@,
+        }
+    }
+}
+pub type ExtensionInner<'a> = (ExtensionType, Opaque0Ffff<'a>);
+impl<'a> From<Extension<'a>> for ExtensionInner<'a> {
+    fn ex_from(m: Extension) -> ExtensionInner {
+        (m.extension_type, m.extension_data)
+    }
+}
+impl<'a> From<ExtensionInner<'a>> for Extension<'a> {
+    fn ex_from(m: ExtensionInner) -> Extension {
+        let (extension_type, extension_data) = m;
+        Extension { extension_type, extension_data }
+    }
+}
+
+pub struct ExtensionMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ExtensionMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ExtensionMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ExtensionMapper(PhantomData)
+    }
+}
+impl View for ExtensionMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ExtensionMapper<'_> {
+    type Src = SpecExtensionInner;
+    type Dst = SpecExtension;
+}
+impl SpecIsoProof for ExtensionMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ExtensionMapper<'a> {
+    type Src = ExtensionInner<'a>;
+    type Dst = Extension<'a>;
+}
+
+pub struct SpecExtensionCombinator(SpecExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecExtensionCombinator {
+    type Type = SpecExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecExtensionCombinatorAlias = Mapped<(SpecExtensionTypeCombinator, SpecOpaque0FfffCombinator), ExtensionMapper<'static>>;
+
+pub struct ExtensionCombinator<'a>(ExtensionCombinatorAlias<'a>);
+
+impl<'a> View for ExtensionCombinator<'a> {
+    type V = SpecExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ExtensionCombinator<'a> {
+    type Type = Extension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ExtensionCombinatorAlias<'a> = Mapped<(ExtensionTypeCombinator, Opaque0FfffCombinator<'a>), ExtensionMapper<'a>>;
+
+
+pub closed spec fn spec_extension() -> SpecExtensionCombinator {
+    SpecExtensionCombinator(
+    Mapped {
+        inner: (spec_extension_type(), spec_opaque_0_ffff()),
+        mapper: ExtensionMapper::spec_new(),
+    })
+}
+
+                
+pub fn extension<'a>() -> (o: ExtensionCombinator<'a>)
+    ensures o@ == spec_extension(),
+{
+    ExtensionCombinator(
+    Mapped {
+        inner: (extension_type(), opaque_0_ffff()),
+        mapper: ExtensionMapper::new(),
+    })
+}
+
+                
+pub type SpecNameType = u8;
+pub type NameType = u8;
+
+
+pub struct SpecNameTypeCombinator(SpecNameTypeCombinatorAlias);
+
+impl SpecCombinator for SpecNameTypeCombinator {
+    type Type = SpecNameType;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecNameTypeCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecNameTypeCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecNameTypeCombinatorAlias = U8;
+
+pub struct NameTypeCombinator(NameTypeCombinatorAlias);
+
+impl View for NameTypeCombinator {
+    type V = SpecNameTypeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecNameTypeCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for NameTypeCombinator {
+    type Type = NameType;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type NameTypeCombinatorAlias = U8;
+
+
+pub closed spec fn spec_name_type() -> SpecNameTypeCombinator {
+    SpecNameTypeCombinator(U8)
+}
+
+                
+pub fn name_type() -> (o: NameTypeCombinator)
+    ensures o@ == spec_name_type(),
+{
+    NameTypeCombinator(U8)
+}
+
+                
+pub type SpecHostName = SpecOpaque1Ffff;
+pub type HostName<'a> = Opaque1Ffff<'a>;
+
+
+pub struct SpecHostNameCombinator(SpecHostNameCombinatorAlias);
+
+impl SpecCombinator for SpecHostNameCombinator {
+    type Type = SpecHostName;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHostNameCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHostNameCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHostNameCombinatorAlias = SpecOpaque1FfffCombinator;
+
+pub struct HostNameCombinator<'a>(HostNameCombinatorAlias<'a>);
+
+impl<'a> View for HostNameCombinator<'a> {
+    type V = SpecHostNameCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHostNameCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HostNameCombinator<'a> {
+    type Type = HostName<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HostNameCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
+
+
+pub closed spec fn spec_host_name() -> SpecHostNameCombinator {
+    SpecHostNameCombinator(spec_opaque_1_ffff())
+}
+
+                
+pub fn host_name<'a>() -> (o: HostNameCombinator<'a>)
+    ensures o@ == spec_host_name(),
+{
+    HostNameCombinator(opaque_1_ffff())
+}
+
+                
+pub type SpecUnknownName = SpecOpaque1Ffff;
+pub type UnknownName<'a> = Opaque1Ffff<'a>;
+
+
+pub struct SpecUnknownNameCombinator(SpecUnknownNameCombinatorAlias);
+
+impl SpecCombinator for SpecUnknownNameCombinator {
+    type Type = SpecUnknownName;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecUnknownNameCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecUnknownNameCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecUnknownNameCombinatorAlias = SpecOpaque1FfffCombinator;
+
+pub struct UnknownNameCombinator<'a>(UnknownNameCombinatorAlias<'a>);
+
+impl<'a> View for UnknownNameCombinator<'a> {
+    type V = SpecUnknownNameCombinator;
+    closed spec fn view(&self) -> Self::V { SpecUnknownNameCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for UnknownNameCombinator<'a> {
+    type Type = UnknownName<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type UnknownNameCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
+
+
+pub closed spec fn spec_unknown_name() -> SpecUnknownNameCombinator {
+    SpecUnknownNameCombinator(spec_opaque_1_ffff())
+}
+
+                
+pub fn unknown_name<'a>() -> (o: UnknownNameCombinator<'a>)
+    ensures o@ == spec_unknown_name(),
+{
+    UnknownNameCombinator(opaque_1_ffff())
+}
+
+                
+
+pub enum SpecServerNameName {
+    HostName(SpecHostName),
+    Unrecognized(SpecUnknownName),
+}
+
+pub type SpecServerNameNameInner = Either<SpecHostName, SpecUnknownName>;
+
+
+
+impl SpecFrom<SpecServerNameName> for SpecServerNameNameInner {
+    open spec fn spec_from(m: SpecServerNameName) -> SpecServerNameNameInner {
+        match m {
+            SpecServerNameName::HostName(m) => Either::Left(m),
+            SpecServerNameName::Unrecognized(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl SpecFrom<SpecServerNameNameInner> for SpecServerNameName {
+    open spec fn spec_from(m: SpecServerNameNameInner) -> SpecServerNameName {
+        match m {
+            Either::Left(m) => SpecServerNameName::HostName(m),
+            Either::Right(m) => SpecServerNameName::Unrecognized(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerNameName<'a> {
+    HostName(HostName<'a>),
+    Unrecognized(UnknownName<'a>),
+}
+
+pub type ServerNameNameInner<'a> = Either<HostName<'a>, UnknownName<'a>>;
+
+
+impl<'a> View for ServerNameName<'a> {
+    type V = SpecServerNameName;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            ServerNameName::HostName(m) => SpecServerNameName::HostName(m@),
+            ServerNameName::Unrecognized(m) => SpecServerNameName::Unrecognized(m@),
+        }
+    }
+}
+
+
+impl<'a> From<ServerNameName<'a>> for ServerNameNameInner<'a> {
+    fn ex_from(m: ServerNameName<'a>) -> ServerNameNameInner<'a> {
+        match m {
+            ServerNameName::HostName(m) => Either::Left(m),
+            ServerNameName::Unrecognized(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl<'a> From<ServerNameNameInner<'a>> for ServerNameName<'a> {
+    fn ex_from(m: ServerNameNameInner<'a>) -> ServerNameName<'a> {
+        match m {
+            Either::Left(m) => ServerNameName::HostName(m),
+            Either::Right(m) => ServerNameName::Unrecognized(m),
+        }
+    }
+    
+}
+
+
+pub struct ServerNameNameMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ServerNameNameMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ServerNameNameMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ServerNameNameMapper(PhantomData)
+    }
+}
+impl View for ServerNameNameMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ServerNameNameMapper<'_> {
+    type Src = SpecServerNameNameInner;
+    type Dst = SpecServerNameName;
+}
+impl SpecIsoProof for ServerNameNameMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ServerNameNameMapper<'a> {
+    type Src = ServerNameNameInner<'a>;
+    type Dst = ServerNameName<'a>;
+}
+
+
+pub struct SpecServerNameNameCombinator(SpecServerNameNameCombinatorAlias);
+
+impl SpecCombinator for SpecServerNameNameCombinator {
+    type Type = SpecServerNameName;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecServerNameNameCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecServerNameNameCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecServerNameNameCombinatorAlias = Mapped<OrdChoice<Cond<SpecHostNameCombinator>, Cond<SpecUnknownNameCombinator>>, ServerNameNameMapper<'static>>;
+
+pub struct ServerNameNameCombinator<'a>(ServerNameNameCombinatorAlias<'a>);
+
+impl<'a> View for ServerNameNameCombinator<'a> {
+    type V = SpecServerNameNameCombinator;
+    closed spec fn view(&self) -> Self::V { SpecServerNameNameCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameNameCombinator<'a> {
+    type Type = ServerNameName<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ServerNameNameCombinatorAlias<'a> = Mapped<OrdChoice<Cond<HostNameCombinator<'a>>, Cond<UnknownNameCombinator<'a>>>, ServerNameNameMapper<'a>>;
+
+
+pub closed spec fn spec_server_name_name(name_type: SpecNameType) -> SpecServerNameNameCombinator {
+    SpecServerNameNameCombinator(Mapped { inner: OrdChoice(Cond { cond: name_type == 0, inner: spec_host_name() }, Cond { cond: !(name_type == 0), inner: spec_unknown_name() }), mapper: ServerNameNameMapper::spec_new() })
+}
+
+pub fn server_name_name<'a>(name_type: NameType) -> (o: ServerNameNameCombinator<'a>)
+    ensures o@ == spec_server_name_name(name_type@),
+{
+    ServerNameNameCombinator(Mapped { inner: OrdChoice::new(Cond { cond: name_type == 0, inner: host_name() }, Cond { cond: !(name_type == 0), inner: unknown_name() }), mapper: ServerNameNameMapper::new() })
+}
+
+
+pub struct SpecServerName {
+    pub name_type: SpecNameType,
+    pub name: SpecServerNameName,
+}
+
+pub type SpecServerNameInner = (SpecNameType, SpecServerNameName);
+impl SpecFrom<SpecServerName> for SpecServerNameInner {
+    open spec fn spec_from(m: SpecServerName) -> SpecServerNameInner {
+        (m.name_type, m.name)
+    }
+}
+impl SpecFrom<SpecServerNameInner> for SpecServerName {
+    open spec fn spec_from(m: SpecServerNameInner) -> SpecServerName {
+        let (name_type, name) = m;
+        SpecServerName { name_type, name }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ServerName<'a> {
+    pub name_type: NameType,
+    pub name: ServerNameName<'a>,
+}
+
+impl View for ServerName<'_> {
+    type V = SpecServerName;
+
+    open spec fn view(&self) -> Self::V {
+        SpecServerName {
+            name_type: self.name_type@,
+            name: self.name@,
+        }
+    }
+}
+pub type ServerNameInner<'a> = (NameType, ServerNameName<'a>);
+impl<'a> From<ServerName<'a>> for ServerNameInner<'a> {
+    fn ex_from(m: ServerName) -> ServerNameInner {
+        (m.name_type, m.name)
+    }
+}
+impl<'a> From<ServerNameInner<'a>> for ServerName<'a> {
+    fn ex_from(m: ServerNameInner) -> ServerName {
+        let (name_type, name) = m;
+        ServerName { name_type, name }
+    }
+}
+
+pub struct ServerNameMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ServerNameMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ServerNameMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ServerNameMapper(PhantomData)
+    }
+}
+impl View for ServerNameMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ServerNameMapper<'_> {
+    type Src = SpecServerNameInner;
+    type Dst = SpecServerName;
+}
+impl SpecIsoProof for ServerNameMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ServerNameMapper<'a> {
+    type Src = ServerNameInner<'a>;
+    type Dst = ServerName<'a>;
+}
+
+pub struct SpecServerNameCombinator(SpecServerNameCombinatorAlias);
+
+impl SpecCombinator for SpecServerNameCombinator {
+    type Type = SpecServerName;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecServerNameCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecServerNameCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecServerNameCombinatorAlias = Mapped<SpecDepend<SpecNameTypeCombinator, SpecServerNameNameCombinator>, ServerNameMapper<'static>>;
+
+pub struct ServerNameCombinator<'a>(ServerNameCombinatorAlias<'a>);
+
+impl<'a> View for ServerNameCombinator<'a> {
+    type V = SpecServerNameCombinator;
+    closed spec fn view(&self) -> Self::V { SpecServerNameCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameCombinator<'a> {
+    type Type = ServerName<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ServerNameCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, NameTypeCombinator, ServerNameNameCombinator<'a>, ServerNameCont0<'a>>, ServerNameMapper<'a>>;
+
+
+pub closed spec fn spec_server_name() -> SpecServerNameCombinator {
+    SpecServerNameCombinator(
+    Mapped {
+        inner: SpecDepend { fst: spec_name_type(), snd: |deps| spec_server_name_cont0(deps) },
+        mapper: ServerNameMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_server_name_cont0(deps: SpecNameType) -> SpecServerNameNameCombinator {
+    let name_type = deps;
+    spec_server_name_name(name_type)
+}
+                
+pub fn server_name<'a>() -> (o: ServerNameCombinator<'a>)
+    ensures o@ == spec_server_name(),
+{
+    ServerNameCombinator(
+    Mapped {
+        inner: Depend { fst: name_type(), snd: ServerNameCont0::new(), spec_snd: Ghost(|deps| spec_server_name_cont0(deps)) },
+        mapper: ServerNameMapper::new(),
+    })
+}
+
+pub struct ServerNameCont0<'a>(PhantomData<&'a ()>);
+impl<'a> ServerNameCont0<'a> {
+    pub fn new() -> Self {
+        ServerNameCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&NameType> for ServerNameCont0<'a> {
+    type Output = ServerNameNameCombinator<'a>;
+
+    open spec fn requires(&self, deps: &NameType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &NameType, o: Self::Output) -> bool {
+        o@ == spec_server_name_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &NameType) -> Self::Output {
+        let name_type = *deps;
+        server_name_name(name_type)
+    }
+}
+                
+
+pub struct SpecServerNameList {
+    pub l: u16,
+    pub list: Seq<SpecServerName>,
+}
+
+pub type SpecServerNameListInner = (u16, Seq<SpecServerName>);
+impl SpecFrom<SpecServerNameList> for SpecServerNameListInner {
+    open spec fn spec_from(m: SpecServerNameList) -> SpecServerNameListInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecServerNameListInner> for SpecServerNameList {
+    open spec fn spec_from(m: SpecServerNameListInner) -> SpecServerNameList {
+        let (l, list) = m;
+        SpecServerNameList { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ServerNameList<'a> {
+    pub l: u16,
+    pub list: RepeatResult<ServerName<'a>>,
+}
+
+impl View for ServerNameList<'_> {
+    type V = SpecServerNameList;
+
+    open spec fn view(&self) -> Self::V {
+        SpecServerNameList {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type ServerNameListInner<'a> = (u16, RepeatResult<ServerName<'a>>);
+impl<'a> From<ServerNameList<'a>> for ServerNameListInner<'a> {
+    fn ex_from(m: ServerNameList) -> ServerNameListInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<ServerNameListInner<'a>> for ServerNameList<'a> {
+    fn ex_from(m: ServerNameListInner) -> ServerNameList {
+        let (l, list) = m;
+        ServerNameList { l, list }
+    }
+}
+
+pub struct ServerNameListMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ServerNameListMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ServerNameListMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ServerNameListMapper(PhantomData)
+    }
+}
+impl View for ServerNameListMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ServerNameListMapper<'_> {
+    type Src = SpecServerNameListInner;
+    type Dst = SpecServerNameList;
+}
+impl SpecIsoProof for ServerNameListMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ServerNameListMapper<'a> {
+    type Src = ServerNameListInner<'a>;
+    type Dst = ServerNameList<'a>;
+}
+
+pub struct SpecServerNameListCombinator(SpecServerNameListCombinatorAlias);
+
+impl SpecCombinator for SpecServerNameListCombinator {
+    type Type = SpecServerNameList;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecServerNameListCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecServerNameListCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecServerNameListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<SpecServerNameCombinator>>>, ServerNameListMapper<'static>>;
+
+pub struct ServerNameListCombinator<'a>(ServerNameListCombinatorAlias<'a>);
+
+impl<'a> View for ServerNameListCombinator<'a> {
+    type V = SpecServerNameListCombinator;
+    closed spec fn view(&self) -> Self::V { SpecServerNameListCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerNameListCombinator<'a> {
+    type Type = ServerNameList<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ServerNameListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate16977634203518580913>, AndThen<Bytes, Repeat<ServerNameCombinator<'a>>>, ServerNameListCont0<'a>>, ServerNameListMapper<'a>>;
+
+
+pub closed spec fn spec_server_name_list() -> SpecServerNameListCombinator {
+    SpecServerNameListCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: |deps| spec_server_name_list_cont0(deps) },
+        mapper: ServerNameListMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_server_name_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecServerNameCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_server_name()))
+}
+                
+pub fn server_name_list<'a>() -> (o: ServerNameListCombinator<'a>)
+    ensures o@ == spec_server_name_list(),
+{
+    ServerNameListCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate16977634203518580913 }, snd: ServerNameListCont0::new(), spec_snd: Ghost(|deps| spec_server_name_list_cont0(deps)) },
+        mapper: ServerNameListMapper::new(),
+    })
+}
+
+pub struct ServerNameListCont0<'a>(PhantomData<&'a ()>);
+impl<'a> ServerNameListCont0<'a> {
+    pub fn new() -> Self {
+        ServerNameListCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for ServerNameListCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<ServerNameCombinator<'a>>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_server_name_list_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(server_name()))
+    }
+}
+                
+pub type SpecEcPointFormat = u8;
+pub type EcPointFormat = u8;
+
+
+pub struct SpecEcPointFormatCombinator(SpecEcPointFormatCombinatorAlias);
+
+impl SpecCombinator for SpecEcPointFormatCombinator {
+    type Type = SpecEcPointFormat;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEcPointFormatCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEcPointFormatCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEcPointFormatCombinatorAlias = U8;
+
+pub struct EcPointFormatCombinator(EcPointFormatCombinatorAlias);
+
+impl View for EcPointFormatCombinator {
+    type V = SpecEcPointFormatCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEcPointFormatCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EcPointFormatCombinator {
+    type Type = EcPointFormat;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EcPointFormatCombinatorAlias = U8;
+
+
+pub closed spec fn spec_ec_point_format() -> SpecEcPointFormatCombinator {
+    SpecEcPointFormatCombinator(U8)
+}
+
+                
+pub fn ec_point_format() -> (o: EcPointFormatCombinator)
+    ensures o@ == spec_ec_point_format(),
+{
+    EcPointFormatCombinator(U8)
+}
+
+                
+
+pub struct SpecEcPointFormatList {
+    pub l: u8,
+    pub list: Seq<SpecEcPointFormat>,
+}
+
+pub type SpecEcPointFormatListInner = (u8, Seq<SpecEcPointFormat>);
+impl SpecFrom<SpecEcPointFormatList> for SpecEcPointFormatListInner {
+    open spec fn spec_from(m: SpecEcPointFormatList) -> SpecEcPointFormatListInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecEcPointFormatListInner> for SpecEcPointFormatList {
+    open spec fn spec_from(m: SpecEcPointFormatListInner) -> SpecEcPointFormatList {
+        let (l, list) = m;
+        SpecEcPointFormatList { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct EcPointFormatList {
+    pub l: u8,
+    pub list: RepeatResult<EcPointFormat>,
+}
+
+impl View for EcPointFormatList {
+    type V = SpecEcPointFormatList;
+
+    open spec fn view(&self) -> Self::V {
+        SpecEcPointFormatList {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type EcPointFormatListInner = (u8, RepeatResult<EcPointFormat>);
+impl From<EcPointFormatList> for EcPointFormatListInner {
+    fn ex_from(m: EcPointFormatList) -> EcPointFormatListInner {
+        (m.l, m.list)
+    }
+}
+impl From<EcPointFormatListInner> for EcPointFormatList {
+    fn ex_from(m: EcPointFormatListInner) -> EcPointFormatList {
+        let (l, list) = m;
+        EcPointFormatList { l, list }
+    }
+}
+
+pub struct EcPointFormatListMapper;
+impl EcPointFormatListMapper {
+    pub closed spec fn spec_new() -> Self {
+        EcPointFormatListMapper
+    }
+    pub fn new() -> Self {
+        EcPointFormatListMapper
+    }
+}
+impl View for EcPointFormatListMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for EcPointFormatListMapper {
+    type Src = SpecEcPointFormatListInner;
+    type Dst = SpecEcPointFormatList;
+}
+impl SpecIsoProof for EcPointFormatListMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for EcPointFormatListMapper {
+    type Src = EcPointFormatListInner;
+    type Dst = EcPointFormatList;
+}
+
+pub struct SpecEcPointFormatListCombinator(SpecEcPointFormatListCombinatorAlias);
+
+impl SpecCombinator for SpecEcPointFormatListCombinator {
+    type Type = SpecEcPointFormatList;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEcPointFormatListCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEcPointFormatListCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEcPointFormatListCombinatorAlias = Mapped<SpecDepend<Refined<U8, Predicate13984338198318635021>, AndThen<Bytes, Repeat<SpecEcPointFormatCombinator>>>, EcPointFormatListMapper>;
+
+pub struct EcPointFormatListCombinator<'a>(EcPointFormatListCombinatorAlias<'a>);
+
+impl<'a> View for EcPointFormatListCombinator<'a> {
+    type V = SpecEcPointFormatListCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEcPointFormatListCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EcPointFormatListCombinator<'a> {
+    type Type = EcPointFormatList;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EcPointFormatListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U8, Predicate13984338198318635021>, AndThen<Bytes, Repeat<EcPointFormatCombinator>>, EcPointFormatListCont0<'a>>, EcPointFormatListMapper>;
+
+
+pub closed spec fn spec_ec_point_format_list() -> SpecEcPointFormatListCombinator {
+    SpecEcPointFormatListCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U8, predicate: Predicate13984338198318635021 }, snd: |deps| spec_ec_point_format_list_cont0(deps) },
+        mapper: EcPointFormatListMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_ec_point_format_list_cont0(deps: u8) -> AndThen<Bytes, Repeat<SpecEcPointFormatCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_ec_point_format()))
+}
+                
+pub fn ec_point_format_list<'a>() -> (o: EcPointFormatListCombinator<'a>)
+    ensures o@ == spec_ec_point_format_list(),
+{
+    EcPointFormatListCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U8, predicate: Predicate13984338198318635021 }, snd: EcPointFormatListCont0::new(), spec_snd: Ghost(|deps| spec_ec_point_format_list_cont0(deps)) },
+        mapper: EcPointFormatListMapper::new(),
+    })
+}
+
+pub struct EcPointFormatListCont0<'a>(PhantomData<&'a ()>);
+impl<'a> EcPointFormatListCont0<'a> {
+    pub fn new() -> Self {
+        EcPointFormatListCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u8> for EcPointFormatListCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<EcPointFormatCombinator>>;
+
+    open spec fn requires(&self, deps: &u8) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u8, o: Self::Output) -> bool {
+        o@ == spec_ec_point_format_list_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u8) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(ec_point_format()))
+    }
+}
+                
+
 pub struct SpecZeroByte {
     pub zero: u8,
 }
@@ -5149,6 +9049,8 @@ impl View for ZeroByteMapper {
 impl SpecIso for ZeroByteMapper {
     type Src = SpecZeroByteInner;
     type Dst = SpecZeroByte;
+}
+impl SpecIsoProof for ZeroByteMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -5299,6 +9201,8 @@ impl View for PaddingExtensionMapper {
 impl SpecIso for PaddingExtensionMapper {
     type Src = SpecPaddingExtensionInner;
     type Dst = SpecPaddingExtension;
+}
+impl SpecIsoProof for PaddingExtensionMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -5406,73 +9310,6 @@ impl<'a> Continuation<&u16> for PaddingExtensionCont0<'a> {
     }
 }
                 
-pub type SpecEmpty = Seq<u8>;
-pub type Empty<'a> = &'a [u8];
-
-
-pub struct SpecEmptyCombinator(SpecEmptyCombinatorAlias);
-
-impl SpecCombinator for SpecEmptyCombinator {
-    type Type = SpecEmpty;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecEmptyCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecEmptyCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecEmptyCombinatorAlias = BytesN<0>;
-
-pub struct EmptyCombinator(EmptyCombinatorAlias);
-
-impl View for EmptyCombinator {
-    type V = SpecEmptyCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEmptyCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EmptyCombinator {
-    type Type = Empty<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type EmptyCombinatorAlias = BytesN<0>;
-
-
-pub closed spec fn spec_empty() -> SpecEmptyCombinator {
-    SpecEmptyCombinator(BytesN::<0>)
-}
-
-                
-pub fn empty() -> (o: EmptyCombinator)
-    ensures o@ == spec_empty(),
-{
-    EmptyCombinator(BytesN::<0>)
-}
-
-                
 
 pub struct SpecPskIdentity {
     pub identity: SpecOpaque1Ffff,
@@ -5539,6 +9376,8 @@ impl View for PskIdentityMapper<'_> {
 impl SpecIso for PskIdentityMapper<'_> {
     type Src = SpecPskIdentityInner;
     type Dst = SpecPskIdentity;
+}
+impl SpecIsoProof for PskIdentityMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -5688,6 +9527,8 @@ impl View for PskIdentitiesMapper<'_> {
 impl SpecIso for PskIdentitiesMapper<'_> {
     type Src = SpecPskIdentitiesInner;
     type Dst = SpecPskIdentities;
+}
+impl SpecIsoProof for PskIdentitiesMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -5885,6 +9726,8 @@ impl View for PskBinderEntryMapper<'_> {
 impl SpecIso for PskBinderEntryMapper<'_> {
     type Src = SpecPskBinderEntryInner;
     type Dst = SpecPskBinderEntry;
+}
+impl SpecIsoProof for PskBinderEntryMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -6082,6 +9925,8 @@ impl View for PskBinderEntriesMapper<'_> {
 impl SpecIso for PskBinderEntriesMapper<'_> {
     type Src = SpecPskBinderEntriesInner;
     type Dst = SpecPskBinderEntries;
+}
+impl SpecIsoProof for PskBinderEntriesMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -6279,6 +10124,8 @@ impl View for OfferedPsksMapper<'_> {
 impl SpecIso for OfferedPsksMapper<'_> {
     type Src = SpecOfferedPsksInner;
     type Dst = SpecOfferedPsks;
+}
+impl SpecIsoProof for OfferedPsksMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -6425,6 +10272,8 @@ impl View for PreSharedKeyClientExtensionMapper<'_> {
 impl SpecIso for PreSharedKeyClientExtensionMapper<'_> {
     type Src = SpecPreSharedKeyClientExtensionInner;
     type Dst = SpecPreSharedKeyClientExtension;
+}
+impl SpecIsoProof for PreSharedKeyClientExtensionMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -6574,6 +10423,8 @@ impl View for KeyShareClientHelloMapper<'_> {
 impl SpecIso for KeyShareClientHelloMapper<'_> {
     type Src = SpecKeyShareClientHelloInner;
     type Dst = SpecKeyShareClientHello;
+}
+impl SpecIsoProof for KeyShareClientHelloMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -6681,73 +10532,6 @@ impl<'a> Continuation<&u16> for KeyShareClientHelloCont0<'a> {
     }
 }
                 
-pub type SpecPskKeyExchangeMode = u8;
-pub type PskKeyExchangeMode = u8;
-
-
-pub struct SpecPskKeyExchangeModeCombinator(SpecPskKeyExchangeModeCombinatorAlias);
-
-impl SpecCombinator for SpecPskKeyExchangeModeCombinator {
-    type Type = SpecPskKeyExchangeMode;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecPskKeyExchangeModeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecPskKeyExchangeModeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecPskKeyExchangeModeCombinatorAlias = U8;
-
-pub struct PskKeyExchangeModeCombinator(PskKeyExchangeModeCombinatorAlias);
-
-impl View for PskKeyExchangeModeCombinator {
-    type V = SpecPskKeyExchangeModeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecPskKeyExchangeModeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for PskKeyExchangeModeCombinator {
-    type Type = PskKeyExchangeMode;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type PskKeyExchangeModeCombinatorAlias = U8;
-
-
-pub closed spec fn spec_psk_key_exchange_mode() -> SpecPskKeyExchangeModeCombinator {
-    SpecPskKeyExchangeModeCombinator(U8)
-}
-
-                
-pub fn psk_key_exchange_mode() -> (o: PskKeyExchangeModeCombinator)
-    ensures o@ == spec_psk_key_exchange_mode(),
-{
-    PskKeyExchangeModeCombinator(U8)
-}
-
-                
 
 pub struct SpecPskKeyExchangeModes {
     pub l: u8,
@@ -6814,6 +10598,8 @@ impl View for PskKeyExchangeModesMapper {
 impl SpecIso for PskKeyExchangeModesMapper {
     type Src = SpecPskKeyExchangeModesInner;
     type Dst = SpecPskKeyExchangeModes;
+}
+impl SpecIsoProof for PskKeyExchangeModesMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -6987,6 +10773,8 @@ impl View for SupportedVersionsClientMapper {
 impl SpecIso for SupportedVersionsClientMapper {
     type Src = SpecSupportedVersionsClientInner;
     type Dst = SpecSupportedVersionsClient;
+}
+impl SpecIsoProof for SupportedVersionsClientMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -7115,659 +10903,6 @@ impl<'a> Continuation<&u8> for SupportedVersionsClientCont0<'a> {
     fn apply(&self, deps: &u8) -> Self::Output {
         let l = *deps;
         AndThen(Bytes(l.ex_into()), Repeat::new(protocol_version()))
-    }
-}
-                
-pub type SpecCookie = SpecOpaque1Ffff;
-pub type Cookie<'a> = Opaque1Ffff<'a>;
-
-
-pub struct SpecCookieCombinator(SpecCookieCombinatorAlias);
-
-impl SpecCombinator for SpecCookieCombinator {
-    type Type = SpecCookie;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCookieCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCookieCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCookieCombinatorAlias = SpecOpaque1FfffCombinator;
-
-pub struct CookieCombinator<'a>(CookieCombinatorAlias<'a>);
-
-impl<'a> View for CookieCombinator<'a> {
-    type V = SpecCookieCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCookieCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CookieCombinator<'a> {
-    type Type = Cookie<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CookieCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
-
-
-pub closed spec fn spec_cookie() -> SpecCookieCombinator {
-    SpecCookieCombinator(spec_opaque_1_ffff())
-}
-
-                
-pub fn cookie<'a>() -> (o: CookieCombinator<'a>)
-    ensures o@ == spec_cookie(),
-{
-    CookieCombinator(opaque_1_ffff())
-}
-
-                
-pub type SpecDistinguishedName = SpecOpaque1Ffff;
-pub type DistinguishedName<'a> = Opaque1Ffff<'a>;
-
-
-pub struct SpecDistinguishedNameCombinator(SpecDistinguishedNameCombinatorAlias);
-
-impl SpecCombinator for SpecDistinguishedNameCombinator {
-    type Type = SpecDistinguishedName;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecDistinguishedNameCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecDistinguishedNameCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecDistinguishedNameCombinatorAlias = SpecOpaque1FfffCombinator;
-
-pub struct DistinguishedNameCombinator<'a>(DistinguishedNameCombinatorAlias<'a>);
-
-impl<'a> View for DistinguishedNameCombinator<'a> {
-    type V = SpecDistinguishedNameCombinator;
-    closed spec fn view(&self) -> Self::V { SpecDistinguishedNameCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for DistinguishedNameCombinator<'a> {
-    type Type = DistinguishedName<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type DistinguishedNameCombinatorAlias<'a> = Opaque1FfffCombinator<'a>;
-
-
-pub closed spec fn spec_distinguished_name() -> SpecDistinguishedNameCombinator {
-    SpecDistinguishedNameCombinator(spec_opaque_1_ffff())
-}
-
-                
-pub fn distinguished_name<'a>() -> (o: DistinguishedNameCombinator<'a>)
-    ensures o@ == spec_distinguished_name(),
-{
-    DistinguishedNameCombinator(opaque_1_ffff())
-}
-
-                
-
-pub struct SpecCertificateAuthoritiesExtension {
-    pub l: u16,
-    pub list: Seq<SpecDistinguishedName>,
-}
-
-pub type SpecCertificateAuthoritiesExtensionInner = (u16, Seq<SpecDistinguishedName>);
-impl SpecFrom<SpecCertificateAuthoritiesExtension> for SpecCertificateAuthoritiesExtensionInner {
-    open spec fn spec_from(m: SpecCertificateAuthoritiesExtension) -> SpecCertificateAuthoritiesExtensionInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecCertificateAuthoritiesExtensionInner> for SpecCertificateAuthoritiesExtension {
-    open spec fn spec_from(m: SpecCertificateAuthoritiesExtensionInner) -> SpecCertificateAuthoritiesExtension {
-        let (l, list) = m;
-        SpecCertificateAuthoritiesExtension { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct CertificateAuthoritiesExtension<'a> {
-    pub l: u16,
-    pub list: RepeatResult<DistinguishedName<'a>>,
-}
-
-impl View for CertificateAuthoritiesExtension<'_> {
-    type V = SpecCertificateAuthoritiesExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecCertificateAuthoritiesExtension {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type CertificateAuthoritiesExtensionInner<'a> = (u16, RepeatResult<DistinguishedName<'a>>);
-impl<'a> From<CertificateAuthoritiesExtension<'a>> for CertificateAuthoritiesExtensionInner<'a> {
-    fn ex_from(m: CertificateAuthoritiesExtension) -> CertificateAuthoritiesExtensionInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<CertificateAuthoritiesExtensionInner<'a>> for CertificateAuthoritiesExtension<'a> {
-    fn ex_from(m: CertificateAuthoritiesExtensionInner) -> CertificateAuthoritiesExtension {
-        let (l, list) = m;
-        CertificateAuthoritiesExtension { l, list }
-    }
-}
-
-pub struct CertificateAuthoritiesExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> CertificateAuthoritiesExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        CertificateAuthoritiesExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        CertificateAuthoritiesExtensionMapper(PhantomData)
-    }
-}
-impl View for CertificateAuthoritiesExtensionMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for CertificateAuthoritiesExtensionMapper<'_> {
-    type Src = SpecCertificateAuthoritiesExtensionInner;
-    type Dst = SpecCertificateAuthoritiesExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for CertificateAuthoritiesExtensionMapper<'a> {
-    type Src = CertificateAuthoritiesExtensionInner<'a>;
-    type Dst = CertificateAuthoritiesExtension<'a>;
-}
-
-pub struct SpecCertificateAuthoritiesExtensionCombinator(SpecCertificateAuthoritiesExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecCertificateAuthoritiesExtensionCombinator {
-    type Type = SpecCertificateAuthoritiesExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCertificateAuthoritiesExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCertificateAuthoritiesExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCertificateAuthoritiesExtensionCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate7402808336413996182>, AndThen<Bytes, Repeat<SpecDistinguishedNameCombinator>>>, CertificateAuthoritiesExtensionMapper<'static>>;
-pub struct Predicate7402808336413996182;
-impl View for Predicate7402808336413996182 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred for Predicate7402808336413996182 {
-    type Input = u16;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 3 && i <= 65535)
-    }
-}
-impl SpecPred for Predicate7402808336413996182 {
-    type Input = u16;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 3 && i <= 65535)
-    }
-}
-
-pub struct CertificateAuthoritiesExtensionCombinator<'a>(CertificateAuthoritiesExtensionCombinatorAlias<'a>);
-
-impl<'a> View for CertificateAuthoritiesExtensionCombinator<'a> {
-    type V = SpecCertificateAuthoritiesExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCertificateAuthoritiesExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateAuthoritiesExtensionCombinator<'a> {
-    type Type = CertificateAuthoritiesExtension<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CertificateAuthoritiesExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate7402808336413996182>, AndThen<Bytes, Repeat<DistinguishedNameCombinator<'a>>>, CertificateAuthoritiesExtensionCont0<'a>>, CertificateAuthoritiesExtensionMapper<'a>>;
-
-
-pub closed spec fn spec_certificate_authorities_extension() -> SpecCertificateAuthoritiesExtensionCombinator {
-    SpecCertificateAuthoritiesExtensionCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate7402808336413996182 }, snd: |deps| spec_certificate_authorities_extension_cont0(deps) },
-        mapper: CertificateAuthoritiesExtensionMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_certificate_authorities_extension_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecDistinguishedNameCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_distinguished_name()))
-}
-                
-pub fn certificate_authorities_extension<'a>() -> (o: CertificateAuthoritiesExtensionCombinator<'a>)
-    ensures o@ == spec_certificate_authorities_extension(),
-{
-    CertificateAuthoritiesExtensionCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate7402808336413996182 }, snd: CertificateAuthoritiesExtensionCont0::new(), spec_snd: Ghost(|deps| spec_certificate_authorities_extension_cont0(deps)) },
-        mapper: CertificateAuthoritiesExtensionMapper::new(),
-    })
-}
-
-pub struct CertificateAuthoritiesExtensionCont0<'a>(PhantomData<&'a ()>);
-impl<'a> CertificateAuthoritiesExtensionCont0<'a> {
-    pub fn new() -> Self {
-        CertificateAuthoritiesExtensionCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for CertificateAuthoritiesExtensionCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<DistinguishedNameCombinator<'a>>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_certificate_authorities_extension_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(distinguished_name()))
-    }
-}
-                
-
-pub struct SpecOidFilter {
-    pub certificate_extension_oid: SpecOpaque1Ff,
-    pub certificate_extension_values: SpecOpaque0Ffff,
-}
-
-pub type SpecOidFilterInner = (SpecOpaque1Ff, SpecOpaque0Ffff);
-impl SpecFrom<SpecOidFilter> for SpecOidFilterInner {
-    open spec fn spec_from(m: SpecOidFilter) -> SpecOidFilterInner {
-        (m.certificate_extension_oid, m.certificate_extension_values)
-    }
-}
-impl SpecFrom<SpecOidFilterInner> for SpecOidFilter {
-    open spec fn spec_from(m: SpecOidFilterInner) -> SpecOidFilter {
-        let (certificate_extension_oid, certificate_extension_values) = m;
-        SpecOidFilter { certificate_extension_oid, certificate_extension_values }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct OidFilter<'a> {
-    pub certificate_extension_oid: Opaque1Ff<'a>,
-    pub certificate_extension_values: Opaque0Ffff<'a>,
-}
-
-impl View for OidFilter<'_> {
-    type V = SpecOidFilter;
-
-    open spec fn view(&self) -> Self::V {
-        SpecOidFilter {
-            certificate_extension_oid: self.certificate_extension_oid@,
-            certificate_extension_values: self.certificate_extension_values@,
-        }
-    }
-}
-pub type OidFilterInner<'a> = (Opaque1Ff<'a>, Opaque0Ffff<'a>);
-impl<'a> From<OidFilter<'a>> for OidFilterInner<'a> {
-    fn ex_from(m: OidFilter) -> OidFilterInner {
-        (m.certificate_extension_oid, m.certificate_extension_values)
-    }
-}
-impl<'a> From<OidFilterInner<'a>> for OidFilter<'a> {
-    fn ex_from(m: OidFilterInner) -> OidFilter {
-        let (certificate_extension_oid, certificate_extension_values) = m;
-        OidFilter { certificate_extension_oid, certificate_extension_values }
-    }
-}
-
-pub struct OidFilterMapper<'a>(PhantomData<&'a ()>);
-impl<'a> OidFilterMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        OidFilterMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        OidFilterMapper(PhantomData)
-    }
-}
-impl View for OidFilterMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for OidFilterMapper<'_> {
-    type Src = SpecOidFilterInner;
-    type Dst = SpecOidFilter;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for OidFilterMapper<'a> {
-    type Src = OidFilterInner<'a>;
-    type Dst = OidFilter<'a>;
-}
-
-pub struct SpecOidFilterCombinator(SpecOidFilterCombinatorAlias);
-
-impl SpecCombinator for SpecOidFilterCombinator {
-    type Type = SpecOidFilter;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecOidFilterCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecOidFilterCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecOidFilterCombinatorAlias = Mapped<(SpecOpaque1FfCombinator, SpecOpaque0FfffCombinator), OidFilterMapper<'static>>;
-
-pub struct OidFilterCombinator<'a>(OidFilterCombinatorAlias<'a>);
-
-impl<'a> View for OidFilterCombinator<'a> {
-    type V = SpecOidFilterCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOidFilterCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for OidFilterCombinator<'a> {
-    type Type = OidFilter<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type OidFilterCombinatorAlias<'a> = Mapped<(Opaque1FfCombinator<'a>, Opaque0FfffCombinator<'a>), OidFilterMapper<'a>>;
-
-
-pub closed spec fn spec_oid_filter() -> SpecOidFilterCombinator {
-    SpecOidFilterCombinator(
-    Mapped {
-        inner: (spec_opaque_1_ff(), spec_opaque_0_ffff()),
-        mapper: OidFilterMapper::spec_new(),
-    })
-}
-
-                
-pub fn oid_filter<'a>() -> (o: OidFilterCombinator<'a>)
-    ensures o@ == spec_oid_filter(),
-{
-    OidFilterCombinator(
-    Mapped {
-        inner: (opaque_1_ff(), opaque_0_ffff()),
-        mapper: OidFilterMapper::new(),
-    })
-}
-
-                
-
-pub struct SpecOidFilterExtension {
-    pub l: u16,
-    pub list: Seq<SpecOidFilter>,
-}
-
-pub type SpecOidFilterExtensionInner = (u16, Seq<SpecOidFilter>);
-impl SpecFrom<SpecOidFilterExtension> for SpecOidFilterExtensionInner {
-    open spec fn spec_from(m: SpecOidFilterExtension) -> SpecOidFilterExtensionInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecOidFilterExtensionInner> for SpecOidFilterExtension {
-    open spec fn spec_from(m: SpecOidFilterExtensionInner) -> SpecOidFilterExtension {
-        let (l, list) = m;
-        SpecOidFilterExtension { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct OidFilterExtension<'a> {
-    pub l: u16,
-    pub list: RepeatResult<OidFilter<'a>>,
-}
-
-impl View for OidFilterExtension<'_> {
-    type V = SpecOidFilterExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecOidFilterExtension {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type OidFilterExtensionInner<'a> = (u16, RepeatResult<OidFilter<'a>>);
-impl<'a> From<OidFilterExtension<'a>> for OidFilterExtensionInner<'a> {
-    fn ex_from(m: OidFilterExtension) -> OidFilterExtensionInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<OidFilterExtensionInner<'a>> for OidFilterExtension<'a> {
-    fn ex_from(m: OidFilterExtensionInner) -> OidFilterExtension {
-        let (l, list) = m;
-        OidFilterExtension { l, list }
-    }
-}
-
-pub struct OidFilterExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> OidFilterExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        OidFilterExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        OidFilterExtensionMapper(PhantomData)
-    }
-}
-impl View for OidFilterExtensionMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for OidFilterExtensionMapper<'_> {
-    type Src = SpecOidFilterExtensionInner;
-    type Dst = SpecOidFilterExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for OidFilterExtensionMapper<'a> {
-    type Src = OidFilterExtensionInner<'a>;
-    type Dst = OidFilterExtension<'a>;
-}
-
-pub struct SpecOidFilterExtensionCombinator(SpecOidFilterExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecOidFilterExtensionCombinator {
-    type Type = SpecOidFilterExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecOidFilterExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecOidFilterExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecOidFilterExtensionCombinatorAlias = Mapped<SpecDepend<U16Be, AndThen<Bytes, Repeat<SpecOidFilterCombinator>>>, OidFilterExtensionMapper<'static>>;
-
-pub struct OidFilterExtensionCombinator<'a>(OidFilterExtensionCombinatorAlias<'a>);
-
-impl<'a> View for OidFilterExtensionCombinator<'a> {
-    type V = SpecOidFilterExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOidFilterExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for OidFilterExtensionCombinator<'a> {
-    type Type = OidFilterExtension<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type OidFilterExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U16Be, AndThen<Bytes, Repeat<OidFilterCombinator<'a>>>, OidFilterExtensionCont0<'a>>, OidFilterExtensionMapper<'a>>;
-
-
-pub closed spec fn spec_oid_filter_extension() -> SpecOidFilterExtensionCombinator {
-    SpecOidFilterExtensionCombinator(
-    Mapped {
-        inner: SpecDepend { fst: U16Be, snd: |deps| spec_oid_filter_extension_cont0(deps) },
-        mapper: OidFilterExtensionMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_oid_filter_extension_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecOidFilterCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_oid_filter()))
-}
-                
-pub fn oid_filter_extension<'a>() -> (o: OidFilterExtensionCombinator<'a>)
-    ensures o@ == spec_oid_filter_extension(),
-{
-    OidFilterExtensionCombinator(
-    Mapped {
-        inner: Depend { fst: U16Be, snd: OidFilterExtensionCont0::new(), spec_snd: Ghost(|deps| spec_oid_filter_extension_cont0(deps)) },
-        mapper: OidFilterExtensionMapper::new(),
-    })
-}
-
-pub struct OidFilterExtensionCont0<'a>(PhantomData<&'a ()>);
-impl<'a> OidFilterExtensionCont0<'a> {
-    pub fn new() -> Self {
-        OidFilterExtensionCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for OidFilterExtensionCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<OidFilterCombinator<'a>>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_oid_filter_extension_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(oid_filter()))
     }
 }
                 
@@ -8030,6 +11165,8 @@ impl View for ClientHelloExtensionExtensionDataMapper<'_> {
 impl SpecIso for ClientHelloExtensionExtensionDataMapper<'_> {
     type Src = SpecClientHelloExtensionExtensionDataInner;
     type Dst = SpecClientHelloExtensionExtensionData;
+}
+impl SpecIsoProof for ClientHelloExtensionExtensionDataMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -8094,453 +11231,16 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for ClientHelloExtensionExtensionDataComb
 pub type ClientHelloExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<ServerNameListCombinator<'a>>, OrdChoice<Cond<MaxFragmentLengthCombinator>, OrdChoice<Cond<CertificateStatusRequestCombinator<'a>>, OrdChoice<Cond<NamedGroupListCombinator<'a>>, OrdChoice<Cond<EcPointFormatListCombinator<'a>>, OrdChoice<Cond<SignatureSchemeListCombinator<'a>>, OrdChoice<Cond<HeartbeatModeCombinator>, OrdChoice<Cond<ProtocolNameListCombinator<'a>>, OrdChoice<Cond<SignedCertificateTimestampListCombinator<'a>>, OrdChoice<Cond<ClientCertTypeClientExtensionCombinator<'a>>, OrdChoice<Cond<ServerCertTypeClientExtensionCombinator<'a>>, OrdChoice<Cond<PaddingExtensionCombinator<'a>>, OrdChoice<Cond<EmptyCombinator>, OrdChoice<Cond<EmptyCombinator>, OrdChoice<Cond<Bytes>, OrdChoice<Cond<PreSharedKeyClientExtensionCombinator<'a>>, OrdChoice<Cond<KeyShareClientHelloCombinator<'a>>, OrdChoice<Cond<PskKeyExchangeModesCombinator<'a>>, OrdChoice<Cond<EmptyCombinator>, OrdChoice<Cond<SupportedVersionsClientCombinator<'a>>, OrdChoice<Cond<CookieCombinator<'a>>, OrdChoice<Cond<CertificateAuthoritiesExtensionCombinator<'a>>, OrdChoice<Cond<OidFilterExtensionCombinator<'a>>, OrdChoice<Cond<EmptyCombinator>, OrdChoice<Cond<SignatureSchemeListCombinator<'a>>, Cond<Bytes>>>>>>>>>>>>>>>>>>>>>>>>>>, ClientHelloExtensionExtensionDataMapper<'a>>>;
 
 
-pub closed spec fn spec_client_hello_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecClientHelloExtensionExtensionDataCombinator {
-    SpecClientHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 0, inner: spec_server_name_list() }, OrdChoice(Cond { cond: extension_type == 1, inner: spec_max_fragment_length() }, OrdChoice(Cond { cond: extension_type == 5, inner: spec_certificate_status_request() }, OrdChoice(Cond { cond: extension_type == 10, inner: spec_named_group_list() }, OrdChoice(Cond { cond: extension_type == 11, inner: spec_ec_point_format_list() }, OrdChoice(Cond { cond: extension_type == 13, inner: spec_signature_scheme_list() }, OrdChoice(Cond { cond: extension_type == 15, inner: spec_heartbeat_mode() }, OrdChoice(Cond { cond: extension_type == 16, inner: spec_protocol_name_list() }, OrdChoice(Cond { cond: extension_type == 18, inner: spec_signed_certificate_timestamp_list() }, OrdChoice(Cond { cond: extension_type == 19, inner: spec_client_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 20, inner: spec_server_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 21, inner: spec_padding_extension() }, OrdChoice(Cond { cond: extension_type == 22, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 23, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 35, inner: Bytes(ext_len.spec_into()) }, OrdChoice(Cond { cond: extension_type == 41, inner: spec_pre_shared_key_client_extension() }, OrdChoice(Cond { cond: extension_type == 51, inner: spec_key_share_client_hello() }, OrdChoice(Cond { cond: extension_type == 45, inner: spec_psk_key_exchange_modes() }, OrdChoice(Cond { cond: extension_type == 42, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 43, inner: spec_supported_versions_client() }, OrdChoice(Cond { cond: extension_type == 44, inner: spec_cookie() }, OrdChoice(Cond { cond: extension_type == 47, inner: spec_certificate_authorities_extension() }, OrdChoice(Cond { cond: extension_type == 48, inner: spec_oid_filter_extension() }, OrdChoice(Cond { cond: extension_type == 49, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 50, inner: spec_signature_scheme_list() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) }))))))))))))))))))))))))), mapper: ClientHelloExtensionExtensionDataMapper::spec_new() }))
+pub closed spec fn spec_client_hello_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecClientHelloExtensionExtensionDataCombinator {
+    SpecClientHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 0, inner: spec_server_name_list() }, OrdChoice(Cond { cond: extension_type == 1, inner: spec_max_fragment_length() }, OrdChoice(Cond { cond: extension_type == 5, inner: spec_certificate_status_request() }, OrdChoice(Cond { cond: extension_type == 10, inner: spec_named_group_list() }, OrdChoice(Cond { cond: extension_type == 11, inner: spec_ec_point_format_list() }, OrdChoice(Cond { cond: extension_type == 13, inner: spec_signature_scheme_list() }, OrdChoice(Cond { cond: extension_type == 15, inner: spec_heartbeat_mode() }, OrdChoice(Cond { cond: extension_type == 16, inner: spec_protocol_name_list() }, OrdChoice(Cond { cond: extension_type == 18, inner: spec_signed_certificate_timestamp_list() }, OrdChoice(Cond { cond: extension_type == 19, inner: spec_client_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 20, inner: spec_server_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 21, inner: spec_padding_extension() }, OrdChoice(Cond { cond: extension_type == 22, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 23, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 35, inner: Bytes(ext_len.spec_into()) }, OrdChoice(Cond { cond: extension_type == 41, inner: spec_pre_shared_key_client_extension() }, OrdChoice(Cond { cond: extension_type == 51, inner: spec_key_share_client_hello() }, OrdChoice(Cond { cond: extension_type == 45, inner: spec_psk_key_exchange_modes() }, OrdChoice(Cond { cond: extension_type == 42, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 43, inner: spec_supported_versions_client() }, OrdChoice(Cond { cond: extension_type == 44, inner: spec_cookie() }, OrdChoice(Cond { cond: extension_type == 47, inner: spec_certificate_authorities_extension() }, OrdChoice(Cond { cond: extension_type == 48, inner: spec_oid_filter_extension() }, OrdChoice(Cond { cond: extension_type == 49, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 50, inner: spec_signature_scheme_list() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 51 || extension_type == 45 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50), inner: Bytes(ext_len.spec_into()) }))))))))))))))))))))))))), mapper: ClientHelloExtensionExtensionDataMapper::spec_new() }))
 }
 
-pub fn client_hello_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: ClientHelloExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_client_hello_extension_extension_data(ext_len@, extension_type@),
+pub fn client_hello_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: ClientHelloExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_client_hello_extension_extension_data(extension_type@, ext_len@),
 {
-    ClientHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 0, inner: server_name_list() }, OrdChoice::new(Cond { cond: extension_type == 1, inner: max_fragment_length() }, OrdChoice::new(Cond { cond: extension_type == 5, inner: certificate_status_request() }, OrdChoice::new(Cond { cond: extension_type == 10, inner: named_group_list() }, OrdChoice::new(Cond { cond: extension_type == 11, inner: ec_point_format_list() }, OrdChoice::new(Cond { cond: extension_type == 13, inner: signature_scheme_list() }, OrdChoice::new(Cond { cond: extension_type == 15, inner: heartbeat_mode() }, OrdChoice::new(Cond { cond: extension_type == 16, inner: protocol_name_list() }, OrdChoice::new(Cond { cond: extension_type == 18, inner: signed_certificate_timestamp_list() }, OrdChoice::new(Cond { cond: extension_type == 19, inner: client_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 20, inner: server_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 21, inner: padding_extension() }, OrdChoice::new(Cond { cond: extension_type == 22, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 23, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 35, inner: Bytes(ext_len.ex_into()) }, OrdChoice::new(Cond { cond: extension_type == 41, inner: pre_shared_key_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 51, inner: key_share_client_hello() }, OrdChoice::new(Cond { cond: extension_type == 45, inner: psk_key_exchange_modes() }, OrdChoice::new(Cond { cond: extension_type == 42, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 43, inner: supported_versions_client() }, OrdChoice::new(Cond { cond: extension_type == 44, inner: cookie() }, OrdChoice::new(Cond { cond: extension_type == 47, inner: certificate_authorities_extension() }, OrdChoice::new(Cond { cond: extension_type == 48, inner: oid_filter_extension() }, OrdChoice::new(Cond { cond: extension_type == 49, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 50, inner: signature_scheme_list() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) }))))))))))))))))))))))))), mapper: ClientHelloExtensionExtensionDataMapper::new() }))
+    ClientHelloExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 0, inner: server_name_list() }, OrdChoice::new(Cond { cond: extension_type == 1, inner: max_fragment_length() }, OrdChoice::new(Cond { cond: extension_type == 5, inner: certificate_status_request() }, OrdChoice::new(Cond { cond: extension_type == 10, inner: named_group_list() }, OrdChoice::new(Cond { cond: extension_type == 11, inner: ec_point_format_list() }, OrdChoice::new(Cond { cond: extension_type == 13, inner: signature_scheme_list() }, OrdChoice::new(Cond { cond: extension_type == 15, inner: heartbeat_mode() }, OrdChoice::new(Cond { cond: extension_type == 16, inner: protocol_name_list() }, OrdChoice::new(Cond { cond: extension_type == 18, inner: signed_certificate_timestamp_list() }, OrdChoice::new(Cond { cond: extension_type == 19, inner: client_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 20, inner: server_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 21, inner: padding_extension() }, OrdChoice::new(Cond { cond: extension_type == 22, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 23, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 35, inner: Bytes(ext_len.ex_into()) }, OrdChoice::new(Cond { cond: extension_type == 41, inner: pre_shared_key_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 51, inner: key_share_client_hello() }, OrdChoice::new(Cond { cond: extension_type == 45, inner: psk_key_exchange_modes() }, OrdChoice::new(Cond { cond: extension_type == 42, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 43, inner: supported_versions_client() }, OrdChoice::new(Cond { cond: extension_type == 44, inner: cookie() }, OrdChoice::new(Cond { cond: extension_type == 47, inner: certificate_authorities_extension() }, OrdChoice::new(Cond { cond: extension_type == 48, inner: oid_filter_extension() }, OrdChoice::new(Cond { cond: extension_type == 49, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 50, inner: signature_scheme_list() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 51 || extension_type == 45 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50), inner: Bytes(ext_len.ex_into()) }))))))))))))))))))))))))), mapper: ClientHelloExtensionExtensionDataMapper::new() }))
 }
 
-
-pub struct SpecSessionId {
-    pub l: u8,
-    pub id: Seq<u8>,
-}
-
-pub type SpecSessionIdInner = (u8, Seq<u8>);
-impl SpecFrom<SpecSessionId> for SpecSessionIdInner {
-    open spec fn spec_from(m: SpecSessionId) -> SpecSessionIdInner {
-        (m.l, m.id)
-    }
-}
-impl SpecFrom<SpecSessionIdInner> for SpecSessionId {
-    open spec fn spec_from(m: SpecSessionIdInner) -> SpecSessionId {
-        let (l, id) = m;
-        SpecSessionId { l, id }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct SessionId<'a> {
-    pub l: u8,
-    pub id: &'a [u8],
-}
-
-impl View for SessionId<'_> {
-    type V = SpecSessionId;
-
-    open spec fn view(&self) -> Self::V {
-        SpecSessionId {
-            l: self.l@,
-            id: self.id@,
-        }
-    }
-}
-pub type SessionIdInner<'a> = (u8, &'a [u8]);
-impl<'a> From<SessionId<'a>> for SessionIdInner<'a> {
-    fn ex_from(m: SessionId) -> SessionIdInner {
-        (m.l, m.id)
-    }
-}
-impl<'a> From<SessionIdInner<'a>> for SessionId<'a> {
-    fn ex_from(m: SessionIdInner) -> SessionId {
-        let (l, id) = m;
-        SessionId { l, id }
-    }
-}
-
-pub struct SessionIdMapper<'a>(PhantomData<&'a ()>);
-impl<'a> SessionIdMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        SessionIdMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        SessionIdMapper(PhantomData)
-    }
-}
-impl View for SessionIdMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for SessionIdMapper<'_> {
-    type Src = SpecSessionIdInner;
-    type Dst = SpecSessionId;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for SessionIdMapper<'a> {
-    type Src = SessionIdInner<'a>;
-    type Dst = SessionId<'a>;
-}
-
-pub struct SpecSessionIdCombinator(SpecSessionIdCombinatorAlias);
-
-impl SpecCombinator for SpecSessionIdCombinator {
-    type Type = SpecSessionId;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSessionIdCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSessionIdCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSessionIdCombinatorAlias = Mapped<SpecDepend<Refined<U8, Predicate14254733753739482027>, Bytes>, SessionIdMapper<'static>>;
-pub struct Predicate14254733753739482027;
-impl View for Predicate14254733753739482027 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred for Predicate14254733753739482027 {
-    type Input = u8;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 0 && i <= 32)
-    }
-}
-impl SpecPred for Predicate14254733753739482027 {
-    type Input = u8;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 0 && i <= 32)
-    }
-}
-
-pub struct SessionIdCombinator<'a>(SessionIdCombinatorAlias<'a>);
-
-impl<'a> View for SessionIdCombinator<'a> {
-    type V = SpecSessionIdCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSessionIdCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SessionIdCombinator<'a> {
-    type Type = SessionId<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SessionIdCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U8, Predicate14254733753739482027>, Bytes, SessionIdCont0<'a>>, SessionIdMapper<'a>>;
-
-
-pub closed spec fn spec_session_id() -> SpecSessionIdCombinator {
-    SpecSessionIdCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U8, predicate: Predicate14254733753739482027 }, snd: |deps| spec_session_id_cont0(deps) },
-        mapper: SessionIdMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_session_id_cont0(deps: u8) -> Bytes {
-    let l = deps;
-    Bytes(l.spec_into())
-}
-                
-pub fn session_id<'a>() -> (o: SessionIdCombinator<'a>)
-    ensures o@ == spec_session_id(),
-{
-    SessionIdCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U8, predicate: Predicate14254733753739482027 }, snd: SessionIdCont0::new(), spec_snd: Ghost(|deps| spec_session_id_cont0(deps)) },
-        mapper: SessionIdMapper::new(),
-    })
-}
-
-pub struct SessionIdCont0<'a>(PhantomData<&'a ()>);
-impl<'a> SessionIdCont0<'a> {
-    pub fn new() -> Self {
-        SessionIdCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u8> for SessionIdCont0<'a> {
-    type Output = Bytes;
-
-    open spec fn requires(&self, deps: &u8) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u8, o: Self::Output) -> bool {
-        o@ == spec_session_id_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u8) -> Self::Output {
-        let l = *deps;
-        Bytes(l.ex_into())
-    }
-}
-                
-pub type SpecCipherSuite = u16;
-pub type CipherSuite = u16;
-
-
-pub struct SpecCipherSuiteCombinator(SpecCipherSuiteCombinatorAlias);
-
-impl SpecCombinator for SpecCipherSuiteCombinator {
-    type Type = SpecCipherSuite;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCipherSuiteCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCipherSuiteCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCipherSuiteCombinatorAlias = U16Be;
-
-pub struct CipherSuiteCombinator(CipherSuiteCombinatorAlias);
-
-impl View for CipherSuiteCombinator {
-    type V = SpecCipherSuiteCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCipherSuiteCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CipherSuiteCombinator {
-    type Type = CipherSuite;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CipherSuiteCombinatorAlias = U16Be;
-
-
-pub closed spec fn spec_cipher_suite() -> SpecCipherSuiteCombinator {
-    SpecCipherSuiteCombinator(U16Be)
-}
-
-                
-pub fn cipher_suite() -> (o: CipherSuiteCombinator)
-    ensures o@ == spec_cipher_suite(),
-{
-    CipherSuiteCombinator(U16Be)
-}
-
-                
-
-pub struct SpecCipherSuiteList {
-    pub l: u16,
-    pub list: Seq<SpecCipherSuite>,
-}
-
-pub type SpecCipherSuiteListInner = (u16, Seq<SpecCipherSuite>);
-impl SpecFrom<SpecCipherSuiteList> for SpecCipherSuiteListInner {
-    open spec fn spec_from(m: SpecCipherSuiteList) -> SpecCipherSuiteListInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecCipherSuiteListInner> for SpecCipherSuiteList {
-    open spec fn spec_from(m: SpecCipherSuiteListInner) -> SpecCipherSuiteList {
-        let (l, list) = m;
-        SpecCipherSuiteList { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct CipherSuiteList {
-    pub l: u16,
-    pub list: RepeatResult<CipherSuite>,
-}
-
-impl View for CipherSuiteList {
-    type V = SpecCipherSuiteList;
-
-    open spec fn view(&self) -> Self::V {
-        SpecCipherSuiteList {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type CipherSuiteListInner = (u16, RepeatResult<CipherSuite>);
-impl From<CipherSuiteList> for CipherSuiteListInner {
-    fn ex_from(m: CipherSuiteList) -> CipherSuiteListInner {
-        (m.l, m.list)
-    }
-}
-impl From<CipherSuiteListInner> for CipherSuiteList {
-    fn ex_from(m: CipherSuiteListInner) -> CipherSuiteList {
-        let (l, list) = m;
-        CipherSuiteList { l, list }
-    }
-}
-
-pub struct CipherSuiteListMapper;
-impl CipherSuiteListMapper {
-    pub closed spec fn spec_new() -> Self {
-        CipherSuiteListMapper
-    }
-    pub fn new() -> Self {
-        CipherSuiteListMapper
-    }
-}
-impl View for CipherSuiteListMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for CipherSuiteListMapper {
-    type Src = SpecCipherSuiteListInner;
-    type Dst = SpecCipherSuiteList;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for CipherSuiteListMapper {
-    type Src = CipherSuiteListInner;
-    type Dst = CipherSuiteList;
-}
-
-pub struct SpecCipherSuiteListCombinator(SpecCipherSuiteListCombinatorAlias);
-
-impl SpecCombinator for SpecCipherSuiteListCombinator {
-    type Type = SpecCipherSuiteList;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCipherSuiteListCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCipherSuiteListCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCipherSuiteListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<SpecCipherSuiteCombinator>>>, CipherSuiteListMapper>;
-
-pub struct CipherSuiteListCombinator<'a>(CipherSuiteListCombinatorAlias<'a>);
-
-impl<'a> View for CipherSuiteListCombinator<'a> {
-    type V = SpecCipherSuiteListCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCipherSuiteListCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CipherSuiteListCombinator<'a> {
-    type Type = CipherSuiteList;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CipherSuiteListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<CipherSuiteCombinator>>, CipherSuiteListCont0<'a>>, CipherSuiteListMapper>;
-
-
-pub closed spec fn spec_cipher_suite_list() -> SpecCipherSuiteListCombinator {
-    SpecCipherSuiteListCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: |deps| spec_cipher_suite_list_cont0(deps) },
-        mapper: CipherSuiteListMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_cipher_suite_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecCipherSuiteCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_cipher_suite()))
-}
-                
-pub fn cipher_suite_list<'a>() -> (o: CipherSuiteListCombinator<'a>)
-    ensures o@ == spec_cipher_suite_list(),
-{
-    CipherSuiteListCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: CipherSuiteListCont0::new(), spec_snd: Ghost(|deps| spec_cipher_suite_list_cont0(deps)) },
-        mapper: CipherSuiteListMapper::new(),
-    })
-}
-
-pub struct CipherSuiteListCont0<'a>(PhantomData<&'a ()>);
-impl<'a> CipherSuiteListCont0<'a> {
-    pub fn new() -> Self {
-        CipherSuiteListCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for CipherSuiteListCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<CipherSuiteCombinator>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_cipher_suite_list_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(cipher_suite()))
-    }
-}
-                
 
 pub struct SpecClientHelloExtension {
     pub extension_type: SpecExtensionType,
@@ -8610,6 +11310,8 @@ impl View for ClientHelloExtensionMapper<'_> {
 impl SpecIso for ClientHelloExtensionMapper<'_> {
     type Src = SpecClientHelloExtensionInner;
     type Dst = SpecClientHelloExtension;
+}
+impl SpecIsoProof for ClientHelloExtensionMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -8687,7 +11389,7 @@ pub open spec fn spec_client_hello_extension_cont1(deps: SpecExtensionType) -> U
 }
 pub open spec fn spec_client_hello_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecClientHelloExtensionExtensionDataCombinator {
     let (extension_type, ext_len) = deps;
-    spec_client_hello_extension_extension_data(ext_len, extension_type)
+    spec_client_hello_extension_extension_data(extension_type, ext_len)
 }
                 
 pub fn client_hello_extension<'a>() -> (o: ClientHelloExtensionCombinator<'a>)
@@ -8737,7 +11439,7 @@ impl<'a> Continuation<&(ExtensionType, u16)> for ClientHelloExtensionCont0<'a> {
 
     fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
         let (extension_type, ext_len) = *deps;
-        client_hello_extension_extension_data(ext_len, extension_type)
+        client_hello_extension_extension_data(extension_type, ext_len)
     }
 }
                 
@@ -8807,6 +11509,8 @@ impl View for ClientExtensionsMapper<'_> {
 impl SpecIso for ClientExtensionsMapper<'_> {
     type Src = SpecClientExtensionsInner;
     type Dst = SpecClientExtensions;
+}
+impl SpecIsoProof for ClientExtensionsMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -8939,1332 +11643,6 @@ impl<'a> Continuation<&u16> for ClientExtensionsCont0<'a> {
 }
                 
 
-pub struct SpecClientHello {
-    pub legacy_version: u16,
-    pub random: Seq<u8>,
-    pub legacy_session_id: SpecSessionId,
-    pub cipher_suites: SpecCipherSuiteList,
-    pub legacy_compression_methods: SpecOpaque1Ff,
-    pub extensions: SpecClientExtensions,
-}
-
-pub type SpecClientHelloInner = (u16, (Seq<u8>, (SpecSessionId, (SpecCipherSuiteList, (SpecOpaque1Ff, SpecClientExtensions)))));
-impl SpecFrom<SpecClientHello> for SpecClientHelloInner {
-    open spec fn spec_from(m: SpecClientHello) -> SpecClientHelloInner {
-        (m.legacy_version, (m.random, (m.legacy_session_id, (m.cipher_suites, (m.legacy_compression_methods, m.extensions)))))
-    }
-}
-impl SpecFrom<SpecClientHelloInner> for SpecClientHello {
-    open spec fn spec_from(m: SpecClientHelloInner) -> SpecClientHello {
-        let (legacy_version, (random, (legacy_session_id, (cipher_suites, (legacy_compression_methods, extensions))))) = m;
-        SpecClientHello { legacy_version, random, legacy_session_id, cipher_suites, legacy_compression_methods, extensions }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct ClientHello<'a> {
-    pub legacy_version: u16,
-    pub random: &'a [u8],
-    pub legacy_session_id: SessionId<'a>,
-    pub cipher_suites: CipherSuiteList,
-    pub legacy_compression_methods: Opaque1Ff<'a>,
-    pub extensions: ClientExtensions<'a>,
-}
-
-impl View for ClientHello<'_> {
-    type V = SpecClientHello;
-
-    open spec fn view(&self) -> Self::V {
-        SpecClientHello {
-            legacy_version: self.legacy_version@,
-            random: self.random@,
-            legacy_session_id: self.legacy_session_id@,
-            cipher_suites: self.cipher_suites@,
-            legacy_compression_methods: self.legacy_compression_methods@,
-            extensions: self.extensions@,
-        }
-    }
-}
-pub type ClientHelloInner<'a> = (u16, (&'a [u8], (SessionId<'a>, (CipherSuiteList, (Opaque1Ff<'a>, ClientExtensions<'a>)))));
-impl<'a> From<ClientHello<'a>> for ClientHelloInner<'a> {
-    fn ex_from(m: ClientHello) -> ClientHelloInner {
-        (m.legacy_version, (m.random, (m.legacy_session_id, (m.cipher_suites, (m.legacy_compression_methods, m.extensions)))))
-    }
-}
-impl<'a> From<ClientHelloInner<'a>> for ClientHello<'a> {
-    fn ex_from(m: ClientHelloInner) -> ClientHello {
-        let (legacy_version, (random, (legacy_session_id, (cipher_suites, (legacy_compression_methods, extensions))))) = m;
-        ClientHello { legacy_version, random, legacy_session_id, cipher_suites, legacy_compression_methods, extensions }
-    }
-}
-
-pub struct ClientHelloMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ClientHelloMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ClientHelloMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ClientHelloMapper(PhantomData)
-    }
-}
-impl View for ClientHelloMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ClientHelloMapper<'_> {
-    type Src = SpecClientHelloInner;
-    type Dst = SpecClientHello;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for ClientHelloMapper<'a> {
-    type Src = ClientHelloInner<'a>;
-    type Dst = ClientHello<'a>;
-}
-pub const CLIENTHELLOLEGACY_VERSION_CONST: u16 = 771;
-
-pub struct SpecClientHelloCombinator(SpecClientHelloCombinatorAlias);
-
-impl SpecCombinator for SpecClientHelloCombinator {
-    type Type = SpecClientHello;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecClientHelloCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecClientHelloCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecClientHelloCombinatorAlias = Mapped<(Refined<U16Be, TagPred<u16>>, (BytesN<32>, (SpecSessionIdCombinator, (SpecCipherSuiteListCombinator, (SpecOpaque1FfCombinator, SpecClientExtensionsCombinator))))), ClientHelloMapper<'static>>;
-
-pub struct ClientHelloCombinator<'a>(ClientHelloCombinatorAlias<'a>);
-
-impl<'a> View for ClientHelloCombinator<'a> {
-    type V = SpecClientHelloCombinator;
-    closed spec fn view(&self) -> Self::V { SpecClientHelloCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ClientHelloCombinator<'a> {
-    type Type = ClientHello<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ClientHelloCombinatorAlias<'a> = Mapped<(Refined<U16Be, TagPred<u16>>, (BytesN<32>, (SessionIdCombinator<'a>, (CipherSuiteListCombinator<'a>, (Opaque1FfCombinator<'a>, ClientExtensionsCombinator<'a>))))), ClientHelloMapper<'a>>;
-
-
-pub closed spec fn spec_client_hello() -> SpecClientHelloCombinator {
-    SpecClientHelloCombinator(
-    Mapped {
-        inner: (Refined { inner: U16Be, predicate: TagPred(CLIENTHELLOLEGACY_VERSION_CONST) }, (BytesN::<32>, (spec_session_id(), (spec_cipher_suite_list(), (spec_opaque_1_ff(), spec_client_extensions()))))),
-        mapper: ClientHelloMapper::spec_new(),
-    })
-}
-
-                
-pub fn client_hello<'a>() -> (o: ClientHelloCombinator<'a>)
-    ensures o@ == spec_client_hello(),
-{
-    ClientHelloCombinator(
-    Mapped {
-        inner: (Refined { inner: U16Be, predicate: TagPred(CLIENTHELLOLEGACY_VERSION_CONST) }, (BytesN::<32>, (session_id(), (cipher_suite_list(), (opaque_1_ff(), client_extensions()))))),
-        mapper: ClientHelloMapper::new(),
-    })
-}
-
-                
-
-#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum AlertLevel {
-    Warning = 1,
-Fatal = 2
-}
-pub type SpecAlertLevel = AlertLevel;
-
-pub type AlertLevelInner = u8;
-
-impl View for AlertLevel {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFrom<AlertLevelInner> for AlertLevel {
-    type Error = ();
-
-    open spec fn spec_try_from(v: AlertLevelInner) -> Result<AlertLevel, ()> {
-        match v {
-            1u8 => Ok(AlertLevel::Warning),
-            2u8 => Ok(AlertLevel::Fatal),
-            _ => Err(()),
-        }
-    }
-}
-
-impl SpecTryFrom<AlertLevel> for AlertLevelInner {
-    type Error = ();
-
-    open spec fn spec_try_from(v: AlertLevel) -> Result<AlertLevelInner, ()> {
-        match v {
-            AlertLevel::Warning => Ok(1u8),
-            AlertLevel::Fatal => Ok(2u8),
-        }
-    }
-}
-
-impl TryFrom<AlertLevelInner> for AlertLevel {
-    type Error = ();
-
-    fn ex_try_from(v: AlertLevelInner) -> Result<AlertLevel, ()> {
-        match v {
-            1u8 => Ok(AlertLevel::Warning),
-            2u8 => Ok(AlertLevel::Fatal),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<AlertLevel> for AlertLevelInner {
-    type Error = ();
-
-    fn ex_try_from(v: AlertLevel) -> Result<AlertLevelInner, ()> {
-        match v {
-            AlertLevel::Warning => Ok(1u8),
-            AlertLevel::Fatal => Ok(2u8),
-        }
-    }
-}
-
-pub struct AlertLevelMapper;
-
-impl View for AlertLevelMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFromInto for AlertLevelMapper {
-    type Src = AlertLevelInner;
-    type Dst = AlertLevel;
-
-    proof fn spec_iso(s: Self::Src) { 
-        assert(
-            Self::spec_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_rev_apply(v) is Ok
-            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) { 
-        assert(
-            Self::spec_rev_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_apply(v) is Ok
-            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-}
-
-impl TryFromInto for AlertLevelMapper {
-    type Src = AlertLevelInner;
-    type Dst = AlertLevel;
-}
-
-
-pub struct SpecAlertLevelCombinator(SpecAlertLevelCombinatorAlias);
-
-impl SpecCombinator for SpecAlertLevelCombinator {
-    type Type = SpecAlertLevel;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecAlertLevelCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecAlertLevelCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecAlertLevelCombinatorAlias = TryMap<U8, AlertLevelMapper>;
-
-pub struct AlertLevelCombinator(AlertLevelCombinatorAlias);
-
-impl View for AlertLevelCombinator {
-    type V = SpecAlertLevelCombinator;
-    closed spec fn view(&self) -> Self::V { SpecAlertLevelCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for AlertLevelCombinator {
-    type Type = AlertLevel;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type AlertLevelCombinatorAlias = TryMap<U8, AlertLevelMapper>;
-
-
-pub closed spec fn spec_alert_level() -> SpecAlertLevelCombinator {
-    SpecAlertLevelCombinator(TryMap { inner: U8, mapper: AlertLevelMapper })
-}
-
-                
-pub fn alert_level() -> (o: AlertLevelCombinator)
-    ensures o@ == spec_alert_level(),
-{
-    AlertLevelCombinator(TryMap { inner: U8, mapper: AlertLevelMapper })
-}
-
-                
-pub type SpecDigestSize = u24;
-pub type DigestSize = u24;
-
-
-pub struct SpecDigestSizeCombinator(SpecDigestSizeCombinatorAlias);
-
-impl SpecCombinator for SpecDigestSizeCombinator {
-    type Type = SpecDigestSize;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecDigestSizeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecDigestSizeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecDigestSizeCombinatorAlias = U24Be;
-
-pub struct DigestSizeCombinator(DigestSizeCombinatorAlias);
-
-impl View for DigestSizeCombinator {
-    type V = SpecDigestSizeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecDigestSizeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for DigestSizeCombinator {
-    type Type = DigestSize;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type DigestSizeCombinatorAlias = U24Be;
-
-
-pub closed spec fn spec_digest_size() -> SpecDigestSizeCombinator {
-    SpecDigestSizeCombinator(U24Be)
-}
-
-                
-pub fn digest_size() -> (o: DigestSizeCombinator)
-    ensures o@ == spec_digest_size(),
-{
-    DigestSizeCombinator(U24Be)
-}
-
-                
-
-pub struct SpecOpaque0Ffffff {
-    pub l: u24,
-    pub data: Seq<u8>,
-}
-
-pub type SpecOpaque0FfffffInner = (u24, Seq<u8>);
-impl SpecFrom<SpecOpaque0Ffffff> for SpecOpaque0FfffffInner {
-    open spec fn spec_from(m: SpecOpaque0Ffffff) -> SpecOpaque0FfffffInner {
-        (m.l, m.data)
-    }
-}
-impl SpecFrom<SpecOpaque0FfffffInner> for SpecOpaque0Ffffff {
-    open spec fn spec_from(m: SpecOpaque0FfffffInner) -> SpecOpaque0Ffffff {
-        let (l, data) = m;
-        SpecOpaque0Ffffff { l, data }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct Opaque0Ffffff<'a> {
-    pub l: u24,
-    pub data: &'a [u8],
-}
-
-impl View for Opaque0Ffffff<'_> {
-    type V = SpecOpaque0Ffffff;
-
-    open spec fn view(&self) -> Self::V {
-        SpecOpaque0Ffffff {
-            l: self.l@,
-            data: self.data@,
-        }
-    }
-}
-pub type Opaque0FfffffInner<'a> = (u24, &'a [u8]);
-impl<'a> From<Opaque0Ffffff<'a>> for Opaque0FfffffInner<'a> {
-    fn ex_from(m: Opaque0Ffffff) -> Opaque0FfffffInner {
-        (m.l, m.data)
-    }
-}
-impl<'a> From<Opaque0FfffffInner<'a>> for Opaque0Ffffff<'a> {
-    fn ex_from(m: Opaque0FfffffInner) -> Opaque0Ffffff {
-        let (l, data) = m;
-        Opaque0Ffffff { l, data }
-    }
-}
-
-pub struct Opaque0FfffffMapper<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque0FfffffMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        Opaque0FfffffMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        Opaque0FfffffMapper(PhantomData)
-    }
-}
-impl View for Opaque0FfffffMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Opaque0FfffffMapper<'_> {
-    type Src = SpecOpaque0FfffffInner;
-    type Dst = SpecOpaque0Ffffff;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for Opaque0FfffffMapper<'a> {
-    type Src = Opaque0FfffffInner<'a>;
-    type Dst = Opaque0Ffffff<'a>;
-}
-
-pub struct SpecOpaque0FfffffCombinator(SpecOpaque0FfffffCombinatorAlias);
-
-impl SpecCombinator for SpecOpaque0FfffffCombinator {
-    type Type = SpecOpaque0Ffffff;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecOpaque0FfffffCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecOpaque0FfffffCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecOpaque0FfffffCombinatorAlias = Mapped<SpecDepend<U24Be, Bytes>, Opaque0FfffffMapper<'static>>;
-
-pub struct Opaque0FfffffCombinator<'a>(Opaque0FfffffCombinatorAlias<'a>);
-
-impl<'a> View for Opaque0FfffffCombinator<'a> {
-    type V = SpecOpaque0FfffffCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOpaque0FfffffCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque0FfffffCombinator<'a> {
-    type Type = Opaque0Ffffff<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Opaque0FfffffCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U24Be, Bytes, Opaque0FfffffCont0<'a>>, Opaque0FfffffMapper<'a>>;
-
-
-pub closed spec fn spec_opaque_0_ffffff() -> SpecOpaque0FfffffCombinator {
-    SpecOpaque0FfffffCombinator(
-    Mapped {
-        inner: SpecDepend { fst: U24Be, snd: |deps| spec_opaque0_ffffff_cont0(deps) },
-        mapper: Opaque0FfffffMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_opaque0_ffffff_cont0(deps: u24) -> Bytes {
-    let l = deps;
-    Bytes(l.spec_into())
-}
-                
-pub fn opaque_0_ffffff<'a>() -> (o: Opaque0FfffffCombinator<'a>)
-    ensures o@ == spec_opaque_0_ffffff(),
-{
-    Opaque0FfffffCombinator(
-    Mapped {
-        inner: Depend { fst: U24Be, snd: Opaque0FfffffCont0::new(), spec_snd: Ghost(|deps| spec_opaque0_ffffff_cont0(deps)) },
-        mapper: Opaque0FfffffMapper::new(),
-    })
-}
-
-pub struct Opaque0FfffffCont0<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque0FfffffCont0<'a> {
-    pub fn new() -> Self {
-        Opaque0FfffffCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u24> for Opaque0FfffffCont0<'a> {
-    type Output = Bytes;
-
-    open spec fn requires(&self, deps: &u24) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u24, o: Self::Output) -> bool {
-        o@ == spec_opaque0_ffffff_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u24) -> Self::Output {
-        let l = *deps;
-        Bytes(l.ex_into())
-    }
-}
-                
-
-pub enum SpecEncryptedExtensionExtensionData {
-    ServerName(SpecEmpty),
-    MaxFragmentLength(SpecMaxFragmentLength),
-    SupportedGroups(SpecNamedGroupList),
-    Heartbeat(SpecHeartbeatMode),
-    ApplicationLayerProtocolNegotiation(SpecProtocolNameList),
-    ClientCertificateType(SpecClientCertTypeClientExtension),
-    ServerCertificateType(SpecServerCertTypeClientExtension),
-    EarlyData(SpecEmpty),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecEncryptedExtensionExtensionDataInner = Either<SpecEmpty, Either<SpecMaxFragmentLength, Either<SpecNamedGroupList, Either<SpecHeartbeatMode, Either<SpecProtocolNameList, Either<SpecClientCertTypeClientExtension, Either<SpecServerCertTypeClientExtension, Either<SpecEmpty, Seq<u8>>>>>>>>>;
-
-
-
-impl SpecFrom<SpecEncryptedExtensionExtensionData> for SpecEncryptedExtensionExtensionDataInner {
-    open spec fn spec_from(m: SpecEncryptedExtensionExtensionData) -> SpecEncryptedExtensionExtensionDataInner {
-        match m {
-            SpecEncryptedExtensionExtensionData::ServerName(m) => Either::Left(m),
-            SpecEncryptedExtensionExtensionData::MaxFragmentLength(m) => Either::Right(Either::Left(m)),
-            SpecEncryptedExtensionExtensionData::SupportedGroups(m) => Either::Right(Either::Right(Either::Left(m))),
-            SpecEncryptedExtensionExtensionData::Heartbeat(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
-            SpecEncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
-            SpecEncryptedExtensionExtensionData::ClientCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
-            SpecEncryptedExtensionExtensionData::ServerCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))),
-            SpecEncryptedExtensionExtensionData::EarlyData(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))),
-            SpecEncryptedExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecEncryptedExtensionExtensionDataInner> for SpecEncryptedExtensionExtensionData {
-    open spec fn spec_from(m: SpecEncryptedExtensionExtensionDataInner) -> SpecEncryptedExtensionExtensionData {
-        match m {
-            Either::Left(m) => SpecEncryptedExtensionExtensionData::ServerName(m),
-            Either::Right(Either::Left(m)) => SpecEncryptedExtensionExtensionData::MaxFragmentLength(m),
-            Either::Right(Either::Right(Either::Left(m))) => SpecEncryptedExtensionExtensionData::SupportedGroups(m),
-            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => SpecEncryptedExtensionExtensionData::Heartbeat(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => SpecEncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => SpecEncryptedExtensionExtensionData::ClientCertificateType(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))) => SpecEncryptedExtensionExtensionData::ServerCertificateType(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))) => SpecEncryptedExtensionExtensionData::EarlyData(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))) => SpecEncryptedExtensionExtensionData::Unrecognized(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EncryptedExtensionExtensionData<'a> {
-    ServerName(Empty<'a>),
-    MaxFragmentLength(MaxFragmentLength),
-    SupportedGroups(NamedGroupList),
-    Heartbeat(HeartbeatMode),
-    ApplicationLayerProtocolNegotiation(ProtocolNameList<'a>),
-    ClientCertificateType(ClientCertTypeClientExtension),
-    ServerCertificateType(ServerCertTypeClientExtension),
-    EarlyData(Empty<'a>),
-    Unrecognized(&'a [u8]),
-}
-
-pub type EncryptedExtensionExtensionDataInner<'a> = Either<Empty<'a>, Either<MaxFragmentLength, Either<NamedGroupList, Either<HeartbeatMode, Either<ProtocolNameList<'a>, Either<ClientCertTypeClientExtension, Either<ServerCertTypeClientExtension, Either<Empty<'a>, &'a [u8]>>>>>>>>;
-
-
-impl<'a> View for EncryptedExtensionExtensionData<'a> {
-    type V = SpecEncryptedExtensionExtensionData;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            EncryptedExtensionExtensionData::ServerName(m) => SpecEncryptedExtensionExtensionData::ServerName(m@),
-            EncryptedExtensionExtensionData::MaxFragmentLength(m) => SpecEncryptedExtensionExtensionData::MaxFragmentLength(m@),
-            EncryptedExtensionExtensionData::SupportedGroups(m) => SpecEncryptedExtensionExtensionData::SupportedGroups(m@),
-            EncryptedExtensionExtensionData::Heartbeat(m) => SpecEncryptedExtensionExtensionData::Heartbeat(m@),
-            EncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m) => SpecEncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m@),
-            EncryptedExtensionExtensionData::ClientCertificateType(m) => SpecEncryptedExtensionExtensionData::ClientCertificateType(m@),
-            EncryptedExtensionExtensionData::ServerCertificateType(m) => SpecEncryptedExtensionExtensionData::ServerCertificateType(m@),
-            EncryptedExtensionExtensionData::EarlyData(m) => SpecEncryptedExtensionExtensionData::EarlyData(m@),
-            EncryptedExtensionExtensionData::Unrecognized(m) => SpecEncryptedExtensionExtensionData::Unrecognized(m@),
-        }
-    }
-}
-
-
-impl<'a> From<EncryptedExtensionExtensionData<'a>> for EncryptedExtensionExtensionDataInner<'a> {
-    fn ex_from(m: EncryptedExtensionExtensionData<'a>) -> EncryptedExtensionExtensionDataInner<'a> {
-        match m {
-            EncryptedExtensionExtensionData::ServerName(m) => Either::Left(m),
-            EncryptedExtensionExtensionData::MaxFragmentLength(m) => Either::Right(Either::Left(m)),
-            EncryptedExtensionExtensionData::SupportedGroups(m) => Either::Right(Either::Right(Either::Left(m))),
-            EncryptedExtensionExtensionData::Heartbeat(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
-            EncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
-            EncryptedExtensionExtensionData::ClientCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
-            EncryptedExtensionExtensionData::ServerCertificateType(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))),
-            EncryptedExtensionExtensionData::EarlyData(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))),
-            EncryptedExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))),
-        }
-    }
-
-}
-
-impl<'a> From<EncryptedExtensionExtensionDataInner<'a>> for EncryptedExtensionExtensionData<'a> {
-    fn ex_from(m: EncryptedExtensionExtensionDataInner<'a>) -> EncryptedExtensionExtensionData<'a> {
-        match m {
-            Either::Left(m) => EncryptedExtensionExtensionData::ServerName(m),
-            Either::Right(Either::Left(m)) => EncryptedExtensionExtensionData::MaxFragmentLength(m),
-            Either::Right(Either::Right(Either::Left(m))) => EncryptedExtensionExtensionData::SupportedGroups(m),
-            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => EncryptedExtensionExtensionData::Heartbeat(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => EncryptedExtensionExtensionData::ApplicationLayerProtocolNegotiation(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => EncryptedExtensionExtensionData::ClientCertificateType(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))))) => EncryptedExtensionExtensionData::ServerCertificateType(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))))) => EncryptedExtensionExtensionData::EarlyData(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))))) => EncryptedExtensionExtensionData::Unrecognized(m),
-        }
-    }
-    
-}
-
-
-pub struct EncryptedExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> EncryptedExtensionExtensionDataMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        EncryptedExtensionExtensionDataMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        EncryptedExtensionExtensionDataMapper(PhantomData)
-    }
-}
-impl View for EncryptedExtensionExtensionDataMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for EncryptedExtensionExtensionDataMapper<'_> {
-    type Src = SpecEncryptedExtensionExtensionDataInner;
-    type Dst = SpecEncryptedExtensionExtensionData;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for EncryptedExtensionExtensionDataMapper<'a> {
-    type Src = EncryptedExtensionExtensionDataInner<'a>;
-    type Dst = EncryptedExtensionExtensionData<'a>;
-}
-
-
-pub struct SpecEncryptedExtensionExtensionDataCombinator(SpecEncryptedExtensionExtensionDataCombinatorAlias);
-
-impl SpecCombinator for SpecEncryptedExtensionExtensionDataCombinator {
-    type Type = SpecEncryptedExtensionExtensionData;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecEncryptedExtensionExtensionDataCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecEncryptedExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecEncryptedExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecEmptyCombinator>, OrdChoice<Cond<SpecMaxFragmentLengthCombinator>, OrdChoice<Cond<SpecNamedGroupListCombinator>, OrdChoice<Cond<SpecHeartbeatModeCombinator>, OrdChoice<Cond<SpecProtocolNameListCombinator>, OrdChoice<Cond<SpecClientCertTypeClientExtensionCombinator>, OrdChoice<Cond<SpecServerCertTypeClientExtensionCombinator>, OrdChoice<Cond<SpecEmptyCombinator>, Cond<Bytes>>>>>>>>>, EncryptedExtensionExtensionDataMapper<'static>>>;
-
-pub struct EncryptedExtensionExtensionDataCombinator<'a>(EncryptedExtensionExtensionDataCombinatorAlias<'a>);
-
-impl<'a> View for EncryptedExtensionExtensionDataCombinator<'a> {
-    type V = SpecEncryptedExtensionExtensionDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEncryptedExtensionExtensionDataCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EncryptedExtensionExtensionDataCombinator<'a> {
-    type Type = EncryptedExtensionExtensionData<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type EncryptedExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<EmptyCombinator>, OrdChoice<Cond<MaxFragmentLengthCombinator>, OrdChoice<Cond<NamedGroupListCombinator<'a>>, OrdChoice<Cond<HeartbeatModeCombinator>, OrdChoice<Cond<ProtocolNameListCombinator<'a>>, OrdChoice<Cond<ClientCertTypeClientExtensionCombinator<'a>>, OrdChoice<Cond<ServerCertTypeClientExtensionCombinator<'a>>, OrdChoice<Cond<EmptyCombinator>, Cond<Bytes>>>>>>>>>, EncryptedExtensionExtensionDataMapper<'a>>>;
-
-
-pub closed spec fn spec_encrypted_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecEncryptedExtensionExtensionDataCombinator {
-    SpecEncryptedExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 0, inner: spec_empty() }, OrdChoice(Cond { cond: extension_type == 1, inner: spec_max_fragment_length() }, OrdChoice(Cond { cond: extension_type == 10, inner: spec_named_group_list() }, OrdChoice(Cond { cond: extension_type == 15, inner: spec_heartbeat_mode() }, OrdChoice(Cond { cond: extension_type == 16, inner: spec_protocol_name_list() }, OrdChoice(Cond { cond: extension_type == 19, inner: spec_client_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 20, inner: spec_server_cert_type_client_extension() }, OrdChoice(Cond { cond: extension_type == 42, inner: spec_empty() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) })))))))), mapper: EncryptedExtensionExtensionDataMapper::spec_new() }))
-}
-
-pub fn encrypted_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: EncryptedExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_encrypted_extension_extension_data(ext_len@, extension_type@),
-{
-    EncryptedExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 0, inner: empty() }, OrdChoice::new(Cond { cond: extension_type == 1, inner: max_fragment_length() }, OrdChoice::new(Cond { cond: extension_type == 10, inner: named_group_list() }, OrdChoice::new(Cond { cond: extension_type == 15, inner: heartbeat_mode() }, OrdChoice::new(Cond { cond: extension_type == 16, inner: protocol_name_list() }, OrdChoice::new(Cond { cond: extension_type == 19, inner: client_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 20, inner: server_cert_type_client_extension() }, OrdChoice::new(Cond { cond: extension_type == 42, inner: empty() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) })))))))), mapper: EncryptedExtensionExtensionDataMapper::new() }))
-}
-
-
-pub struct SpecEncryptedExtension {
-    pub extension_type: SpecExtensionType,
-    pub ext_len: u16,
-    pub extension_data: SpecEncryptedExtensionExtensionData,
-}
-
-pub type SpecEncryptedExtensionInner = ((SpecExtensionType, u16), SpecEncryptedExtensionExtensionData);
-impl SpecFrom<SpecEncryptedExtension> for SpecEncryptedExtensionInner {
-    open spec fn spec_from(m: SpecEncryptedExtension) -> SpecEncryptedExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl SpecFrom<SpecEncryptedExtensionInner> for SpecEncryptedExtension {
-    open spec fn spec_from(m: SpecEncryptedExtensionInner) -> SpecEncryptedExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        SpecEncryptedExtension { extension_type, ext_len, extension_data }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct EncryptedExtension<'a> {
-    pub extension_type: ExtensionType,
-    pub ext_len: u16,
-    pub extension_data: EncryptedExtensionExtensionData<'a>,
-}
-
-impl View for EncryptedExtension<'_> {
-    type V = SpecEncryptedExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecEncryptedExtension {
-            extension_type: self.extension_type@,
-            ext_len: self.ext_len@,
-            extension_data: self.extension_data@,
-        }
-    }
-}
-pub type EncryptedExtensionInner<'a> = ((ExtensionType, u16), EncryptedExtensionExtensionData<'a>);
-impl<'a> From<EncryptedExtension<'a>> for EncryptedExtensionInner<'a> {
-    fn ex_from(m: EncryptedExtension) -> EncryptedExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl<'a> From<EncryptedExtensionInner<'a>> for EncryptedExtension<'a> {
-    fn ex_from(m: EncryptedExtensionInner) -> EncryptedExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        EncryptedExtension { extension_type, ext_len, extension_data }
-    }
-}
-
-pub struct EncryptedExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> EncryptedExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        EncryptedExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        EncryptedExtensionMapper(PhantomData)
-    }
-}
-impl View for EncryptedExtensionMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for EncryptedExtensionMapper<'_> {
-    type Src = SpecEncryptedExtensionInner;
-    type Dst = SpecEncryptedExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for EncryptedExtensionMapper<'a> {
-    type Src = EncryptedExtensionInner<'a>;
-    type Dst = EncryptedExtension<'a>;
-}
-
-pub struct SpecEncryptedExtensionCombinator(SpecEncryptedExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecEncryptedExtensionCombinator {
-    type Type = SpecEncryptedExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecEncryptedExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecEncryptedExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecEncryptedExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecEncryptedExtensionExtensionDataCombinator>, EncryptedExtensionMapper<'static>>;
-
-pub struct EncryptedExtensionCombinator<'a>(EncryptedExtensionCombinatorAlias<'a>);
-
-impl<'a> View for EncryptedExtensionCombinator<'a> {
-    type V = SpecEncryptedExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEncryptedExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EncryptedExtensionCombinator<'a> {
-    type Type = EncryptedExtension<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type EncryptedExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, EncryptedExtensionCont1<'a>>, EncryptedExtensionExtensionDataCombinator<'a>, EncryptedExtensionCont0<'a>>, EncryptedExtensionMapper<'a>>;
-
-
-pub closed spec fn spec_encrypted_extension() -> SpecEncryptedExtensionCombinator {
-    SpecEncryptedExtensionCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_encrypted_extension_cont1(deps) }, snd: |deps| spec_encrypted_extension_cont0(deps) },
-        mapper: EncryptedExtensionMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_encrypted_extension_cont1(deps: SpecExtensionType) -> U16Be {
-    let extension_type = deps;
-    U16Be
-}
-pub open spec fn spec_encrypted_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecEncryptedExtensionExtensionDataCombinator {
-    let (extension_type, ext_len) = deps;
-    spec_encrypted_extension_extension_data(ext_len, extension_type)
-}
-                
-pub fn encrypted_extension<'a>() -> (o: EncryptedExtensionCombinator<'a>)
-    ensures o@ == spec_encrypted_extension(),
-{
-    EncryptedExtensionCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: extension_type(), snd: EncryptedExtensionCont1::new(), spec_snd: Ghost(|deps| spec_encrypted_extension_cont1(deps)) }, snd: EncryptedExtensionCont0::new(), spec_snd: Ghost(|deps| spec_encrypted_extension_cont0(deps)) },
-        mapper: EncryptedExtensionMapper::new(),
-    })
-}
-
-pub struct EncryptedExtensionCont1<'a>(PhantomData<&'a ()>);
-impl<'a> EncryptedExtensionCont1<'a> {
-    pub fn new() -> Self {
-        EncryptedExtensionCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&ExtensionType> for EncryptedExtensionCont1<'a> {
-    type Output = U16Be;
-
-    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
-        o@ == spec_encrypted_extension_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &ExtensionType) -> Self::Output {
-        let extension_type = *deps;
-        U16Be
-    }
-}
-pub struct EncryptedExtensionCont0<'a>(PhantomData<&'a ()>);
-impl<'a> EncryptedExtensionCont0<'a> {
-    pub fn new() -> Self {
-        EncryptedExtensionCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(ExtensionType, u16)> for EncryptedExtensionCont0<'a> {
-    type Output = EncryptedExtensionExtensionDataCombinator<'a>;
-
-    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
-        o@ == spec_encrypted_extension_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
-        let (extension_type, ext_len) = *deps;
-        encrypted_extension_extension_data(ext_len, extension_type)
-    }
-}
-                
-
-pub struct SpecHeartbeatExtension {
-    pub mode: SpecHeartbeatMode,
-}
-
-pub type SpecHeartbeatExtensionInner = SpecHeartbeatMode;
-impl SpecFrom<SpecHeartbeatExtension> for SpecHeartbeatExtensionInner {
-    open spec fn spec_from(m: SpecHeartbeatExtension) -> SpecHeartbeatExtensionInner {
-        m.mode
-    }
-}
-impl SpecFrom<SpecHeartbeatExtensionInner> for SpecHeartbeatExtension {
-    open spec fn spec_from(m: SpecHeartbeatExtensionInner) -> SpecHeartbeatExtension {
-        let mode = m;
-        SpecHeartbeatExtension { mode }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct HeartbeatExtension {
-    pub mode: HeartbeatMode,
-}
-
-impl View for HeartbeatExtension {
-    type V = SpecHeartbeatExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecHeartbeatExtension {
-            mode: self.mode@,
-        }
-    }
-}
-pub type HeartbeatExtensionInner = HeartbeatMode;
-impl From<HeartbeatExtension> for HeartbeatExtensionInner {
-    fn ex_from(m: HeartbeatExtension) -> HeartbeatExtensionInner {
-        m.mode
-    }
-}
-impl From<HeartbeatExtensionInner> for HeartbeatExtension {
-    fn ex_from(m: HeartbeatExtensionInner) -> HeartbeatExtension {
-        let mode = m;
-        HeartbeatExtension { mode }
-    }
-}
-
-pub struct HeartbeatExtensionMapper;
-impl HeartbeatExtensionMapper {
-    pub closed spec fn spec_new() -> Self {
-        HeartbeatExtensionMapper
-    }
-    pub fn new() -> Self {
-        HeartbeatExtensionMapper
-    }
-}
-impl View for HeartbeatExtensionMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for HeartbeatExtensionMapper {
-    type Src = SpecHeartbeatExtensionInner;
-    type Dst = SpecHeartbeatExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for HeartbeatExtensionMapper {
-    type Src = HeartbeatExtensionInner;
-    type Dst = HeartbeatExtension;
-}
-
-pub struct SpecHeartbeatExtensionCombinator(SpecHeartbeatExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecHeartbeatExtensionCombinator {
-    type Type = SpecHeartbeatExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecHeartbeatExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecHeartbeatExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecHeartbeatExtensionCombinatorAlias = Mapped<SpecHeartbeatModeCombinator, HeartbeatExtensionMapper>;
-
-pub struct HeartbeatExtensionCombinator(HeartbeatExtensionCombinatorAlias);
-
-impl View for HeartbeatExtensionCombinator {
-    type V = SpecHeartbeatExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHeartbeatExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HeartbeatExtensionCombinator {
-    type Type = HeartbeatExtension;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type HeartbeatExtensionCombinatorAlias = Mapped<HeartbeatModeCombinator, HeartbeatExtensionMapper>;
-
-
-pub closed spec fn spec_heartbeat_extension() -> SpecHeartbeatExtensionCombinator {
-    SpecHeartbeatExtensionCombinator(
-    Mapped {
-        inner: spec_heartbeat_mode(),
-        mapper: HeartbeatExtensionMapper::spec_new(),
-    })
-}
-
-                
-pub fn heartbeat_extension() -> (o: HeartbeatExtensionCombinator)
-    ensures o@ == spec_heartbeat_extension(),
-{
-    HeartbeatExtensionCombinator(
-    Mapped {
-        inner: heartbeat_mode(),
-        mapper: HeartbeatExtensionMapper::new(),
-    })
-}
-
-                
-
-pub enum SpecCertificateRequestExtensionExtensionData {
-    SignatureAlgorithms(SpecSignatureSchemeList),
-    CertificateAuthorities(SpecCertificateAuthoritiesExtension),
-    SignatureAlgorithmsCert(SpecSignatureSchemeList),
-    StatusRequest(SpecCertificateStatusRequest),
-    SignedCertificateTimeStamp(SpecSignedCertificateTimestampList),
-    OidFilters(SpecOidFilterExtension),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecCertificateRequestExtensionExtensionDataInner = Either<SpecSignatureSchemeList, Either<SpecCertificateAuthoritiesExtension, Either<SpecSignatureSchemeList, Either<SpecCertificateStatusRequest, Either<SpecSignedCertificateTimestampList, Either<SpecOidFilterExtension, Seq<u8>>>>>>>;
-
-
-
-impl SpecFrom<SpecCertificateRequestExtensionExtensionData> for SpecCertificateRequestExtensionExtensionDataInner {
-    open spec fn spec_from(m: SpecCertificateRequestExtensionExtensionData) -> SpecCertificateRequestExtensionExtensionDataInner {
-        match m {
-            SpecCertificateRequestExtensionExtensionData::SignatureAlgorithms(m) => Either::Left(m),
-            SpecCertificateRequestExtensionExtensionData::CertificateAuthorities(m) => Either::Right(Either::Left(m)),
-            SpecCertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m) => Either::Right(Either::Right(Either::Left(m))),
-            SpecCertificateRequestExtensionExtensionData::StatusRequest(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
-            SpecCertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
-            SpecCertificateRequestExtensionExtensionData::OidFilters(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
-            SpecCertificateRequestExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecCertificateRequestExtensionExtensionDataInner> for SpecCertificateRequestExtensionExtensionData {
-    open spec fn spec_from(m: SpecCertificateRequestExtensionExtensionDataInner) -> SpecCertificateRequestExtensionExtensionData {
-        match m {
-            Either::Left(m) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithms(m),
-            Either::Right(Either::Left(m)) => SpecCertificateRequestExtensionExtensionData::CertificateAuthorities(m),
-            Either::Right(Either::Right(Either::Left(m))) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m),
-            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => SpecCertificateRequestExtensionExtensionData::StatusRequest(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => SpecCertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => SpecCertificateRequestExtensionExtensionData::OidFilters(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))) => SpecCertificateRequestExtensionExtensionData::Unrecognized(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CertificateRequestExtensionExtensionData<'a> {
-    SignatureAlgorithms(SignatureSchemeList),
-    CertificateAuthorities(CertificateAuthoritiesExtension<'a>),
-    SignatureAlgorithmsCert(SignatureSchemeList),
-    StatusRequest(CertificateStatusRequest<'a>),
-    SignedCertificateTimeStamp(SignedCertificateTimestampList<'a>),
-    OidFilters(OidFilterExtension<'a>),
-    Unrecognized(&'a [u8]),
-}
-
-pub type CertificateRequestExtensionExtensionDataInner<'a> = Either<SignatureSchemeList, Either<CertificateAuthoritiesExtension<'a>, Either<SignatureSchemeList, Either<CertificateStatusRequest<'a>, Either<SignedCertificateTimestampList<'a>, Either<OidFilterExtension<'a>, &'a [u8]>>>>>>;
-
-
-impl<'a> View for CertificateRequestExtensionExtensionData<'a> {
-    type V = SpecCertificateRequestExtensionExtensionData;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            CertificateRequestExtensionExtensionData::SignatureAlgorithms(m) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithms(m@),
-            CertificateRequestExtensionExtensionData::CertificateAuthorities(m) => SpecCertificateRequestExtensionExtensionData::CertificateAuthorities(m@),
-            CertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m) => SpecCertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m@),
-            CertificateRequestExtensionExtensionData::StatusRequest(m) => SpecCertificateRequestExtensionExtensionData::StatusRequest(m@),
-            CertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m) => SpecCertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m@),
-            CertificateRequestExtensionExtensionData::OidFilters(m) => SpecCertificateRequestExtensionExtensionData::OidFilters(m@),
-            CertificateRequestExtensionExtensionData::Unrecognized(m) => SpecCertificateRequestExtensionExtensionData::Unrecognized(m@),
-        }
-    }
-}
-
-
-impl<'a> From<CertificateRequestExtensionExtensionData<'a>> for CertificateRequestExtensionExtensionDataInner<'a> {
-    fn ex_from(m: CertificateRequestExtensionExtensionData<'a>) -> CertificateRequestExtensionExtensionDataInner<'a> {
-        match m {
-            CertificateRequestExtensionExtensionData::SignatureAlgorithms(m) => Either::Left(m),
-            CertificateRequestExtensionExtensionData::CertificateAuthorities(m) => Either::Right(Either::Left(m)),
-            CertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m) => Either::Right(Either::Right(Either::Left(m))),
-            CertificateRequestExtensionExtensionData::StatusRequest(m) => Either::Right(Either::Right(Either::Right(Either::Left(m)))),
-            CertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))),
-            CertificateRequestExtensionExtensionData::OidFilters(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))),
-            CertificateRequestExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))),
-        }
-    }
-
-}
-
-impl<'a> From<CertificateRequestExtensionExtensionDataInner<'a>> for CertificateRequestExtensionExtensionData<'a> {
-    fn ex_from(m: CertificateRequestExtensionExtensionDataInner<'a>) -> CertificateRequestExtensionExtensionData<'a> {
-        match m {
-            Either::Left(m) => CertificateRequestExtensionExtensionData::SignatureAlgorithms(m),
-            Either::Right(Either::Left(m)) => CertificateRequestExtensionExtensionData::CertificateAuthorities(m),
-            Either::Right(Either::Right(Either::Left(m))) => CertificateRequestExtensionExtensionData::SignatureAlgorithmsCert(m),
-            Either::Right(Either::Right(Either::Right(Either::Left(m)))) => CertificateRequestExtensionExtensionData::StatusRequest(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m))))) => CertificateRequestExtensionExtensionData::SignedCertificateTimeStamp(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Left(m)))))) => CertificateRequestExtensionExtensionData::OidFilters(m),
-            Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(Either::Right(m)))))) => CertificateRequestExtensionExtensionData::Unrecognized(m),
-        }
-    }
-    
-}
-
-
-pub struct CertificateRequestExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> CertificateRequestExtensionExtensionDataMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        CertificateRequestExtensionExtensionDataMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        CertificateRequestExtensionExtensionDataMapper(PhantomData)
-    }
-}
-impl View for CertificateRequestExtensionExtensionDataMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for CertificateRequestExtensionExtensionDataMapper<'_> {
-    type Src = SpecCertificateRequestExtensionExtensionDataInner;
-    type Dst = SpecCertificateRequestExtensionExtensionData;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for CertificateRequestExtensionExtensionDataMapper<'a> {
-    type Src = CertificateRequestExtensionExtensionDataInner<'a>;
-    type Dst = CertificateRequestExtensionExtensionData<'a>;
-}
-
-
-pub struct SpecCertificateRequestExtensionExtensionDataCombinator(SpecCertificateRequestExtensionExtensionDataCombinatorAlias);
-
-impl SpecCombinator for SpecCertificateRequestExtensionExtensionDataCombinator {
-    type Type = SpecCertificateRequestExtensionExtensionData;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCertificateRequestExtensionExtensionDataCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCertificateRequestExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCertificateRequestExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecSignatureSchemeListCombinator>, OrdChoice<Cond<SpecCertificateAuthoritiesExtensionCombinator>, OrdChoice<Cond<SpecSignatureSchemeListCombinator>, OrdChoice<Cond<SpecCertificateStatusRequestCombinator>, OrdChoice<Cond<SpecSignedCertificateTimestampListCombinator>, OrdChoice<Cond<SpecOidFilterExtensionCombinator>, Cond<Bytes>>>>>>>, CertificateRequestExtensionExtensionDataMapper<'static>>>;
-
-pub struct CertificateRequestExtensionExtensionDataCombinator<'a>(CertificateRequestExtensionExtensionDataCombinatorAlias<'a>);
-
-impl<'a> View for CertificateRequestExtensionExtensionDataCombinator<'a> {
-    type V = SpecCertificateRequestExtensionExtensionDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCertificateRequestExtensionExtensionDataCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateRequestExtensionExtensionDataCombinator<'a> {
-    type Type = CertificateRequestExtensionExtensionData<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CertificateRequestExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<SignatureSchemeListCombinator<'a>>, OrdChoice<Cond<CertificateAuthoritiesExtensionCombinator<'a>>, OrdChoice<Cond<SignatureSchemeListCombinator<'a>>, OrdChoice<Cond<CertificateStatusRequestCombinator<'a>>, OrdChoice<Cond<SignedCertificateTimestampListCombinator<'a>>, OrdChoice<Cond<OidFilterExtensionCombinator<'a>>, Cond<Bytes>>>>>>>, CertificateRequestExtensionExtensionDataMapper<'a>>>;
-
-
-pub closed spec fn spec_certificate_request_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecCertificateRequestExtensionExtensionDataCombinator {
-    SpecCertificateRequestExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 13, inner: spec_signature_scheme_list() }, OrdChoice(Cond { cond: extension_type == 47, inner: spec_certificate_authorities_extension() }, OrdChoice(Cond { cond: extension_type == 50, inner: spec_signature_scheme_list() }, OrdChoice(Cond { cond: extension_type == 5, inner: spec_certificate_status_request() }, OrdChoice(Cond { cond: extension_type == 18, inner: spec_signed_certificate_timestamp_list() }, OrdChoice(Cond { cond: extension_type == 48, inner: spec_oid_filter_extension() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) })))))), mapper: CertificateRequestExtensionExtensionDataMapper::spec_new() }))
-}
-
-pub fn certificate_request_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: CertificateRequestExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_certificate_request_extension_extension_data(extension_type@, ext_len@),
-{
-    CertificateRequestExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 13, inner: signature_scheme_list() }, OrdChoice::new(Cond { cond: extension_type == 47, inner: certificate_authorities_extension() }, OrdChoice::new(Cond { cond: extension_type == 50, inner: signature_scheme_list() }, OrdChoice::new(Cond { cond: extension_type == 5, inner: certificate_status_request() }, OrdChoice::new(Cond { cond: extension_type == 18, inner: signed_certificate_timestamp_list() }, OrdChoice::new(Cond { cond: extension_type == 48, inner: oid_filter_extension() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) })))))), mapper: CertificateRequestExtensionExtensionDataMapper::new() }))
-}
-
-
 pub enum SpecFinished {
     Hash12(Seq<u8>),
     Hash20(Seq<u8>),
@@ -10383,6 +11761,8 @@ impl View for FinishedMapper<'_> {
 impl SpecIso for FinishedMapper<'_> {
     type Src = SpecFinishedInner;
     type Dst = SpecFinished;
+}
+impl SpecIsoProof for FinishedMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -10448,188 +11828,15 @@ pub type FinishedCombinatorAlias<'a> = Mapped<OrdChoice<Cond<BytesN<12>>, OrdCho
 
 
 pub closed spec fn spec_finished(size: SpecDigestSize) -> SpecFinishedCombinator {
-    SpecFinishedCombinator(Mapped { inner: OrdChoice(Cond { cond: size.spec_as_u32() == 12, inner: BytesN::<12> }, OrdChoice(Cond { cond: size.spec_as_u32() == 20, inner: BytesN::<20> }, OrdChoice(Cond { cond: size.spec_as_u32() == 32, inner: BytesN::<32> }, OrdChoice(Cond { cond: size.spec_as_u32() == 48, inner: BytesN::<48> }, OrdChoice(Cond { cond: size.spec_as_u32() == 64, inner: BytesN::<64> }, Cond { cond: !(size.spec_as_u32() == 12 || size.spec_as_u32() == 20 || size.spec_as_u32() == 32 || size.spec_as_u32() == 48 || size.spec_as_u32() == 64 || size.spec_as_u32() == 16777215), inner: Bytes(size.spec_into()) }))))), mapper: FinishedMapper::spec_new() })
+    SpecFinishedCombinator(Mapped { inner: OrdChoice(Cond { cond: size.spec_as_u32() == 12, inner: BytesN::<12> }, OrdChoice(Cond { cond: size.spec_as_u32() == 20, inner: BytesN::<20> }, OrdChoice(Cond { cond: size.spec_as_u32() == 32, inner: BytesN::<32> }, OrdChoice(Cond { cond: size.spec_as_u32() == 48, inner: BytesN::<48> }, OrdChoice(Cond { cond: size.spec_as_u32() == 64, inner: BytesN::<64> }, Cond { cond: !(size.spec_as_u32() == 12 || size.spec_as_u32() == 20 || size.spec_as_u32() == 32 || size.spec_as_u32() == 48 || size.spec_as_u32() == 64), inner: Bytes(size.spec_into()) }))))), mapper: FinishedMapper::spec_new() })
 }
 
 pub fn finished<'a>(size: DigestSize) -> (o: FinishedCombinator<'a>)
     ensures o@ == spec_finished(size@),
 {
-    FinishedCombinator(Mapped { inner: OrdChoice::new(Cond { cond: size.as_u32() == 12, inner: BytesN::<12> }, OrdChoice::new(Cond { cond: size.as_u32() == 20, inner: BytesN::<20> }, OrdChoice::new(Cond { cond: size.as_u32() == 32, inner: BytesN::<32> }, OrdChoice::new(Cond { cond: size.as_u32() == 48, inner: BytesN::<48> }, OrdChoice::new(Cond { cond: size.as_u32() == 64, inner: BytesN::<64> }, Cond { cond: !(size.as_u32() == 12 || size.as_u32() == 20 || size.as_u32() == 32 || size.as_u32() == 48 || size.as_u32() == 64 || size.as_u32() == 16777215), inner: Bytes(size.ex_into()) }))))), mapper: FinishedMapper::new() })
+    FinishedCombinator(Mapped { inner: OrdChoice::new(Cond { cond: size.as_u32() == 12, inner: BytesN::<12> }, OrdChoice::new(Cond { cond: size.as_u32() == 20, inner: BytesN::<20> }, OrdChoice::new(Cond { cond: size.as_u32() == 32, inner: BytesN::<32> }, OrdChoice::new(Cond { cond: size.as_u32() == 48, inner: BytesN::<48> }, OrdChoice::new(Cond { cond: size.as_u32() == 64, inner: BytesN::<64> }, Cond { cond: !(size.as_u32() == 12 || size.as_u32() == 20 || size.as_u32() == 32 || size.as_u32() == 48 || size.as_u32() == 64), inner: Bytes(size.ex_into()) }))))), mapper: FinishedMapper::new() })
 }
 
-
-pub struct SpecOpaque0Ff {
-    pub l: u8,
-    pub data: Seq<u8>,
-}
-
-pub type SpecOpaque0FfInner = (u8, Seq<u8>);
-impl SpecFrom<SpecOpaque0Ff> for SpecOpaque0FfInner {
-    open spec fn spec_from(m: SpecOpaque0Ff) -> SpecOpaque0FfInner {
-        (m.l, m.data)
-    }
-}
-impl SpecFrom<SpecOpaque0FfInner> for SpecOpaque0Ff {
-    open spec fn spec_from(m: SpecOpaque0FfInner) -> SpecOpaque0Ff {
-        let (l, data) = m;
-        SpecOpaque0Ff { l, data }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct Opaque0Ff<'a> {
-    pub l: u8,
-    pub data: &'a [u8],
-}
-
-impl View for Opaque0Ff<'_> {
-    type V = SpecOpaque0Ff;
-
-    open spec fn view(&self) -> Self::V {
-        SpecOpaque0Ff {
-            l: self.l@,
-            data: self.data@,
-        }
-    }
-}
-pub type Opaque0FfInner<'a> = (u8, &'a [u8]);
-impl<'a> From<Opaque0Ff<'a>> for Opaque0FfInner<'a> {
-    fn ex_from(m: Opaque0Ff) -> Opaque0FfInner {
-        (m.l, m.data)
-    }
-}
-impl<'a> From<Opaque0FfInner<'a>> for Opaque0Ff<'a> {
-    fn ex_from(m: Opaque0FfInner) -> Opaque0Ff {
-        let (l, data) = m;
-        Opaque0Ff { l, data }
-    }
-}
-
-pub struct Opaque0FfMapper<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque0FfMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        Opaque0FfMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        Opaque0FfMapper(PhantomData)
-    }
-}
-impl View for Opaque0FfMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for Opaque0FfMapper<'_> {
-    type Src = SpecOpaque0FfInner;
-    type Dst = SpecOpaque0Ff;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for Opaque0FfMapper<'a> {
-    type Src = Opaque0FfInner<'a>;
-    type Dst = Opaque0Ff<'a>;
-}
-
-pub struct SpecOpaque0FfCombinator(SpecOpaque0FfCombinatorAlias);
-
-impl SpecCombinator for SpecOpaque0FfCombinator {
-    type Type = SpecOpaque0Ff;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecOpaque0FfCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecOpaque0FfCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecOpaque0FfCombinatorAlias = Mapped<SpecDepend<U8, Bytes>, Opaque0FfMapper<'static>>;
-
-pub struct Opaque0FfCombinator<'a>(Opaque0FfCombinatorAlias<'a>);
-
-impl<'a> View for Opaque0FfCombinator<'a> {
-    type V = SpecOpaque0FfCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOpaque0FfCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque0FfCombinator<'a> {
-    type Type = Opaque0Ff<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type Opaque0FfCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U8, Bytes, Opaque0FfCont0<'a>>, Opaque0FfMapper<'a>>;
-
-
-pub closed spec fn spec_opaque_0_ff() -> SpecOpaque0FfCombinator {
-    SpecOpaque0FfCombinator(
-    Mapped {
-        inner: SpecDepend { fst: U8, snd: |deps| spec_opaque0_ff_cont0(deps) },
-        mapper: Opaque0FfMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_opaque0_ff_cont0(deps: u8) -> Bytes {
-    let l = deps;
-    Bytes(l.spec_into())
-}
-                
-pub fn opaque_0_ff<'a>() -> (o: Opaque0FfCombinator<'a>)
-    ensures o@ == spec_opaque_0_ff(),
-{
-    Opaque0FfCombinator(
-    Mapped {
-        inner: Depend { fst: U8, snd: Opaque0FfCont0::new(), spec_snd: Ghost(|deps| spec_opaque0_ff_cont0(deps)) },
-        mapper: Opaque0FfMapper::new(),
-    })
-}
-
-pub struct Opaque0FfCont0<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque0FfCont0<'a> {
-    pub fn new() -> Self {
-        Opaque0FfCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u8> for Opaque0FfCont0<'a> {
-    type Output = Bytes;
-
-    open spec fn requires(&self, deps: &u8) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u8, o: Self::Output) -> bool {
-        o@ == spec_opaque0_ff_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u8) -> Self::Output {
-        let l = *deps;
-        Bytes(l.ex_into())
-    }
-}
-                
 
 pub struct SpecCertificateRequestExtension {
     pub extension_type: SpecExtensionType,
@@ -10699,6 +11906,8 @@ impl View for CertificateRequestExtensionMapper<'_> {
 impl SpecIso for CertificateRequestExtensionMapper<'_> {
     type Src = SpecCertificateRequestExtensionInner;
     type Dst = SpecCertificateRequestExtension;
+}
+impl SpecIsoProof for CertificateRequestExtensionMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -10776,7 +11985,7 @@ pub open spec fn spec_certificate_request_extension_cont1(deps: SpecExtensionTyp
 }
 pub open spec fn spec_certificate_request_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecCertificateRequestExtensionExtensionDataCombinator {
     let (extension_type, ext_len) = deps;
-    spec_certificate_request_extension_extension_data(extension_type, ext_len)
+    spec_certificate_request_extension_extension_data(ext_len, extension_type)
 }
                 
 pub fn certificate_request_extension<'a>() -> (o: CertificateRequestExtensionCombinator<'a>)
@@ -10826,7 +12035,7 @@ impl<'a> Continuation<&(ExtensionType, u16)> for CertificateRequestExtensionCont
 
     fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
         let (extension_type, ext_len) = *deps;
-        certificate_request_extension_extension_data(extension_type, ext_len)
+        certificate_request_extension_extension_data(ext_len, extension_type)
     }
 }
                 
@@ -10896,6 +12105,8 @@ impl View for CertificateRequestExtensionsMapper<'_> {
 impl SpecIso for CertificateRequestExtensionsMapper<'_> {
     type Src = SpecCertificateRequestExtensionsInner;
     type Dst = SpecCertificateRequestExtensions;
+}
+impl SpecIsoProof for CertificateRequestExtensionsMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -11004,220 +12215,73 @@ impl<'a> Continuation<&u16> for CertificateRequestExtensionsCont0<'a> {
 }
                 
 
-pub struct SpecCertificateRequest {
-    pub certificate_request_context: SpecOpaque0Ff,
-    pub extensions: SpecCertificateRequestExtensions,
+pub struct SpecOpaque1Ffffff {
+    pub l: u24,
+    pub data: Seq<u8>,
 }
 
-pub type SpecCertificateRequestInner = (SpecOpaque0Ff, SpecCertificateRequestExtensions);
-impl SpecFrom<SpecCertificateRequest> for SpecCertificateRequestInner {
-    open spec fn spec_from(m: SpecCertificateRequest) -> SpecCertificateRequestInner {
-        (m.certificate_request_context, m.extensions)
+pub type SpecOpaque1FfffffInner = (u24, Seq<u8>);
+impl SpecFrom<SpecOpaque1Ffffff> for SpecOpaque1FfffffInner {
+    open spec fn spec_from(m: SpecOpaque1Ffffff) -> SpecOpaque1FfffffInner {
+        (m.l, m.data)
     }
 }
-impl SpecFrom<SpecCertificateRequestInner> for SpecCertificateRequest {
-    open spec fn spec_from(m: SpecCertificateRequestInner) -> SpecCertificateRequest {
-        let (certificate_request_context, extensions) = m;
-        SpecCertificateRequest { certificate_request_context, extensions }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct CertificateRequest<'a> {
-    pub certificate_request_context: Opaque0Ff<'a>,
-    pub extensions: CertificateRequestExtensions<'a>,
-}
-
-impl View for CertificateRequest<'_> {
-    type V = SpecCertificateRequest;
-
-    open spec fn view(&self) -> Self::V {
-        SpecCertificateRequest {
-            certificate_request_context: self.certificate_request_context@,
-            extensions: self.extensions@,
-        }
-    }
-}
-pub type CertificateRequestInner<'a> = (Opaque0Ff<'a>, CertificateRequestExtensions<'a>);
-impl<'a> From<CertificateRequest<'a>> for CertificateRequestInner<'a> {
-    fn ex_from(m: CertificateRequest) -> CertificateRequestInner {
-        (m.certificate_request_context, m.extensions)
-    }
-}
-impl<'a> From<CertificateRequestInner<'a>> for CertificateRequest<'a> {
-    fn ex_from(m: CertificateRequestInner) -> CertificateRequest {
-        let (certificate_request_context, extensions) = m;
-        CertificateRequest { certificate_request_context, extensions }
-    }
-}
-
-pub struct CertificateRequestMapper<'a>(PhantomData<&'a ()>);
-impl<'a> CertificateRequestMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        CertificateRequestMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        CertificateRequestMapper(PhantomData)
-    }
-}
-impl View for CertificateRequestMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for CertificateRequestMapper<'_> {
-    type Src = SpecCertificateRequestInner;
-    type Dst = SpecCertificateRequest;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for CertificateRequestMapper<'a> {
-    type Src = CertificateRequestInner<'a>;
-    type Dst = CertificateRequest<'a>;
-}
-
-pub struct SpecCertificateRequestCombinator(SpecCertificateRequestCombinatorAlias);
-
-impl SpecCombinator for SpecCertificateRequestCombinator {
-    type Type = SpecCertificateRequest;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCertificateRequestCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCertificateRequestCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCertificateRequestCombinatorAlias = Mapped<(SpecOpaque0FfCombinator, SpecCertificateRequestExtensionsCombinator), CertificateRequestMapper<'static>>;
-
-pub struct CertificateRequestCombinator<'a>(CertificateRequestCombinatorAlias<'a>);
-
-impl<'a> View for CertificateRequestCombinator<'a> {
-    type V = SpecCertificateRequestCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCertificateRequestCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateRequestCombinator<'a> {
-    type Type = CertificateRequest<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CertificateRequestCombinatorAlias<'a> = Mapped<(Opaque0FfCombinator<'a>, CertificateRequestExtensionsCombinator<'a>), CertificateRequestMapper<'a>>;
-
-
-pub closed spec fn spec_certificate_request() -> SpecCertificateRequestCombinator {
-    SpecCertificateRequestCombinator(
-    Mapped {
-        inner: (spec_opaque_0_ff(), spec_certificate_request_extensions()),
-        mapper: CertificateRequestMapper::spec_new(),
-    })
-}
-
-                
-pub fn certificate_request<'a>() -> (o: CertificateRequestCombinator<'a>)
-    ensures o@ == spec_certificate_request(),
-{
-    CertificateRequestCombinator(
-    Mapped {
-        inner: (opaque_0_ff(), certificate_request_extensions()),
-        mapper: CertificateRequestMapper::new(),
-    })
-}
-
-                
-
-pub struct SpecServerExtensions {
-    pub l: u16,
-    pub list: Seq<SpecSeverHelloExtension>,
-}
-
-pub type SpecServerExtensionsInner = (u16, Seq<SpecSeverHelloExtension>);
-impl SpecFrom<SpecServerExtensions> for SpecServerExtensionsInner {
-    open spec fn spec_from(m: SpecServerExtensions) -> SpecServerExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecServerExtensionsInner> for SpecServerExtensions {
-    open spec fn spec_from(m: SpecServerExtensionsInner) -> SpecServerExtensions {
-        let (l, list) = m;
-        SpecServerExtensions { l, list }
+impl SpecFrom<SpecOpaque1FfffffInner> for SpecOpaque1Ffffff {
+    open spec fn spec_from(m: SpecOpaque1FfffffInner) -> SpecOpaque1Ffffff {
+        let (l, data) = m;
+        SpecOpaque1Ffffff { l, data }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 
-pub struct ServerExtensions<'a> {
-    pub l: u16,
-    pub list: RepeatResult<SeverHelloExtension<'a>>,
+pub struct Opaque1Ffffff<'a> {
+    pub l: u24,
+    pub data: &'a [u8],
 }
 
-impl View for ServerExtensions<'_> {
-    type V = SpecServerExtensions;
+impl View for Opaque1Ffffff<'_> {
+    type V = SpecOpaque1Ffffff;
 
     open spec fn view(&self) -> Self::V {
-        SpecServerExtensions {
+        SpecOpaque1Ffffff {
             l: self.l@,
-            list: self.list@,
+            data: self.data@,
         }
     }
 }
-pub type ServerExtensionsInner<'a> = (u16, RepeatResult<SeverHelloExtension<'a>>);
-impl<'a> From<ServerExtensions<'a>> for ServerExtensionsInner<'a> {
-    fn ex_from(m: ServerExtensions) -> ServerExtensionsInner {
-        (m.l, m.list)
+pub type Opaque1FfffffInner<'a> = (u24, &'a [u8]);
+impl<'a> From<Opaque1Ffffff<'a>> for Opaque1FfffffInner<'a> {
+    fn ex_from(m: Opaque1Ffffff) -> Opaque1FfffffInner {
+        (m.l, m.data)
     }
 }
-impl<'a> From<ServerExtensionsInner<'a>> for ServerExtensions<'a> {
-    fn ex_from(m: ServerExtensionsInner) -> ServerExtensions {
-        let (l, list) = m;
-        ServerExtensions { l, list }
+impl<'a> From<Opaque1FfffffInner<'a>> for Opaque1Ffffff<'a> {
+    fn ex_from(m: Opaque1FfffffInner) -> Opaque1Ffffff {
+        let (l, data) = m;
+        Opaque1Ffffff { l, data }
     }
 }
 
-pub struct ServerExtensionsMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ServerExtensionsMapper<'a> {
+pub struct Opaque1FfffffMapper<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque1FfffffMapper<'a> {
     pub closed spec fn spec_new() -> Self {
-        ServerExtensionsMapper(PhantomData)
+        Opaque1FfffffMapper(PhantomData)
     }
     pub fn new() -> Self {
-        ServerExtensionsMapper(PhantomData)
+        Opaque1FfffffMapper(PhantomData)
     }
 }
-impl View for ServerExtensionsMapper<'_> {
+impl View for Opaque1FfffffMapper<'_> {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for ServerExtensionsMapper<'_> {
-    type Src = SpecServerExtensionsInner;
-    type Dst = SpecServerExtensions;
+impl SpecIso for Opaque1FfffffMapper<'_> {
+    type Src = SpecOpaque1FfffffInner;
+    type Dst = SpecOpaque1Ffffff;
+}
+impl SpecIsoProof for Opaque1FfffffMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -11225,23 +12289,23 @@ impl SpecIso for ServerExtensionsMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for ServerExtensionsMapper<'a> {
-    type Src = ServerExtensionsInner<'a>;
-    type Dst = ServerExtensions<'a>;
+impl<'a> Iso for Opaque1FfffffMapper<'a> {
+    type Src = Opaque1FfffffInner<'a>;
+    type Dst = Opaque1Ffffff<'a>;
 }
 
-pub struct SpecServerExtensionsCombinator(SpecServerExtensionsCombinatorAlias);
+pub struct SpecOpaque1FfffffCombinator(SpecOpaque1FfffffCombinatorAlias);
 
-impl SpecCombinator for SpecServerExtensionsCombinator {
-    type Type = SpecServerExtensions;
+impl SpecCombinator for SpecOpaque1FfffffCombinator {
+    type Type = SpecOpaque1Ffffff;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecServerExtensionsCombinator {
+impl SecureSpecCombinator for SpecOpaque1FfffffCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecServerExtensionsCombinatorAlias::is_prefix_secure() }
+    { SpecOpaque1FfffffCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -11255,40 +12319,40 @@ impl SecureSpecCombinator for SpecServerExtensionsCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecServerExtensionsCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<SpecSeverHelloExtensionCombinator>>>, ServerExtensionsMapper<'static>>;
-pub struct Predicate14496530480760116989;
-impl View for Predicate14496530480760116989 {
+pub type SpecOpaque1FfffffCombinatorAlias = Mapped<SpecDepend<Refined<U24Be, Predicate15036445817960576151>, Bytes>, Opaque1FfffffMapper<'static>>;
+pub struct Predicate15036445817960576151;
+impl View for Predicate15036445817960576151 {
     type V = Self;
 
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl Pred for Predicate14496530480760116989 {
-    type Input = u16;
+impl Pred for Predicate15036445817960576151 {
+    type Input = u24;
 
     fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 6 && i <= 65535)
+        let i = (*i).as_u32();
+        (i >= 1 && i <= 16777215)
     }
 }
-impl SpecPred for Predicate14496530480760116989 {
-    type Input = u16;
+impl SpecPred for Predicate15036445817960576151 {
+    type Input = u24;
 
     open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 6 && i <= 65535)
+        let i = (*i).spec_as_u32();
+        (i >= 1 && i <= 16777215)
     }
 }
 
-pub struct ServerExtensionsCombinator<'a>(ServerExtensionsCombinatorAlias<'a>);
+pub struct Opaque1FfffffCombinator<'a>(Opaque1FfffffCombinatorAlias<'a>);
 
-impl<'a> View for ServerExtensionsCombinator<'a> {
-    type V = SpecServerExtensionsCombinator;
-    closed spec fn view(&self) -> Self::V { SpecServerExtensionsCombinator(self.0@) }
+impl<'a> View for Opaque1FfffffCombinator<'a> {
+    type V = SpecOpaque1FfffffCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOpaque1FfffffCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerExtensionsCombinator<'a> {
-    type Type = ServerExtensions<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque1FfffffCombinator<'a> {
+    type Type = Opaque1Ffffff<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -11302,672 +12366,78 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerExtensionsCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type ServerExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<SeverHelloExtensionCombinator<'a>>>, ServerExtensionsCont0<'a>>, ServerExtensionsMapper<'a>>;
+pub type Opaque1FfffffCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U24Be, Predicate15036445817960576151>, Bytes, Opaque1FfffffCont0<'a>>, Opaque1FfffffMapper<'a>>;
 
 
-pub closed spec fn spec_server_extensions() -> SpecServerExtensionsCombinator {
-    SpecServerExtensionsCombinator(
+pub closed spec fn spec_opaque_1_ffffff() -> SpecOpaque1FfffffCombinator {
+    SpecOpaque1FfffffCombinator(
     Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: |deps| spec_server_extensions_cont0(deps) },
-        mapper: ServerExtensionsMapper::spec_new(),
+        inner: SpecDepend { fst: Refined { inner: U24Be, predicate: Predicate15036445817960576151 }, snd: |deps| spec_opaque1_ffffff_cont0(deps) },
+        mapper: Opaque1FfffffMapper::spec_new(),
     })
 }
 
-pub open spec fn spec_server_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSeverHelloExtensionCombinator>> {
+pub open spec fn spec_opaque1_ffffff_cont0(deps: u24) -> Bytes {
     let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_sever_hello_extension()))
+    Bytes(l.spec_into())
 }
                 
-pub fn server_extensions<'a>() -> (o: ServerExtensionsCombinator<'a>)
-    ensures o@ == spec_server_extensions(),
+pub fn opaque_1_ffffff<'a>() -> (o: Opaque1FfffffCombinator<'a>)
+    ensures o@ == spec_opaque_1_ffffff(),
 {
-    ServerExtensionsCombinator(
+    Opaque1FfffffCombinator(
     Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: ServerExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_server_extensions_cont0(deps)) },
-        mapper: ServerExtensionsMapper::new(),
+        inner: Depend { fst: Refined { inner: U24Be, predicate: Predicate15036445817960576151 }, snd: Opaque1FfffffCont0::new(), spec_snd: Ghost(|deps| spec_opaque1_ffffff_cont0(deps)) },
+        mapper: Opaque1FfffffMapper::new(),
     })
 }
 
-pub struct ServerExtensionsCont0<'a>(PhantomData<&'a ()>);
-impl<'a> ServerExtensionsCont0<'a> {
+pub struct Opaque1FfffffCont0<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque1FfffffCont0<'a> {
     pub fn new() -> Self {
-        ServerExtensionsCont0(PhantomData)
+        Opaque1FfffffCont0(PhantomData)
     }
 }
-impl<'a> Continuation<&u16> for ServerExtensionsCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<SeverHelloExtensionCombinator<'a>>>;
+impl<'a> Continuation<&u24> for Opaque1FfffffCont0<'a> {
+    type Output = Bytes;
 
-    open spec fn requires(&self, deps: &u16) -> bool { true }
+    open spec fn requires(&self, deps: &u24) -> bool { true }
 
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_server_extensions_cont0(deps@)
+    open spec fn ensures(&self, deps: &u24, o: Self::Output) -> bool {
+        o@ == spec_opaque1_ffffff_cont0(deps@)
     }
 
-    fn apply(&self, deps: &u16) -> Self::Output {
+    fn apply(&self, deps: &u24) -> Self::Output {
         let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(sever_hello_extension()))
+        Bytes(l.ex_into())
     }
 }
                 
 
-pub struct SpecServerHello {
-    pub legacy_session_id_echo: SpecSessionId,
-    pub cipher_suite: SpecCipherSuite,
-    pub legacy_compression_method: u8,
-    pub extensions: SpecServerExtensions,
+pub enum SpecCertificateEntryData {
+    X509(SpecOpaque1Ffffff),
+    RawPublicKey(SpecOpaque1Ffffff),
 }
 
-pub type SpecServerHelloInner = (SpecSessionId, (SpecCipherSuite, (u8, SpecServerExtensions)));
-impl SpecFrom<SpecServerHello> for SpecServerHelloInner {
-    open spec fn spec_from(m: SpecServerHello) -> SpecServerHelloInner {
-        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
-    }
-}
-impl SpecFrom<SpecServerHelloInner> for SpecServerHello {
-    open spec fn spec_from(m: SpecServerHelloInner) -> SpecServerHello {
-        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
-        SpecServerHello { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct ServerHello<'a> {
-    pub legacy_session_id_echo: SessionId<'a>,
-    pub cipher_suite: CipherSuite,
-    pub legacy_compression_method: u8,
-    pub extensions: ServerExtensions<'a>,
-}
-
-impl View for ServerHello<'_> {
-    type V = SpecServerHello;
-
-    open spec fn view(&self) -> Self::V {
-        SpecServerHello {
-            legacy_session_id_echo: self.legacy_session_id_echo@,
-            cipher_suite: self.cipher_suite@,
-            legacy_compression_method: self.legacy_compression_method@,
-            extensions: self.extensions@,
-        }
-    }
-}
-pub type ServerHelloInner<'a> = (SessionId<'a>, (CipherSuite, (u8, ServerExtensions<'a>)));
-impl<'a> From<ServerHello<'a>> for ServerHelloInner<'a> {
-    fn ex_from(m: ServerHello) -> ServerHelloInner {
-        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
-    }
-}
-impl<'a> From<ServerHelloInner<'a>> for ServerHello<'a> {
-    fn ex_from(m: ServerHelloInner) -> ServerHello {
-        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
-        ServerHello { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
-    }
-}
-
-pub struct ServerHelloMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ServerHelloMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ServerHelloMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ServerHelloMapper(PhantomData)
-    }
-}
-impl View for ServerHelloMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ServerHelloMapper<'_> {
-    type Src = SpecServerHelloInner;
-    type Dst = SpecServerHello;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for ServerHelloMapper<'a> {
-    type Src = ServerHelloInner<'a>;
-    type Dst = ServerHello<'a>;
-}
-pub const SERVERHELLOLEGACY_COMPRESSION_METHOD_CONST: u8 = 0;
-
-pub struct SpecServerHelloCombinator(SpecServerHelloCombinatorAlias);
-
-impl SpecCombinator for SpecServerHelloCombinator {
-    type Type = SpecServerHello;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecServerHelloCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecServerHelloCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecServerHelloCombinatorAlias = Mapped<(SpecSessionIdCombinator, (SpecCipherSuiteCombinator, (Refined<U8, TagPred<u8>>, SpecServerExtensionsCombinator))), ServerHelloMapper<'static>>;
-
-pub struct ServerHelloCombinator<'a>(ServerHelloCombinatorAlias<'a>);
-
-impl<'a> View for ServerHelloCombinator<'a> {
-    type V = SpecServerHelloCombinator;
-    closed spec fn view(&self) -> Self::V { SpecServerHelloCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerHelloCombinator<'a> {
-    type Type = ServerHello<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ServerHelloCombinatorAlias<'a> = Mapped<(SessionIdCombinator<'a>, (CipherSuiteCombinator, (Refined<U8, TagPred<u8>>, ServerExtensionsCombinator<'a>))), ServerHelloMapper<'a>>;
-
-
-pub closed spec fn spec_server_hello() -> SpecServerHelloCombinator {
-    SpecServerHelloCombinator(
-    Mapped {
-        inner: (spec_session_id(), (spec_cipher_suite(), (Refined { inner: U8, predicate: TagPred(SERVERHELLOLEGACY_COMPRESSION_METHOD_CONST) }, spec_server_extensions()))),
-        mapper: ServerHelloMapper::spec_new(),
-    })
-}
-
-                
-pub fn server_hello<'a>() -> (o: ServerHelloCombinator<'a>)
-    ensures o@ == spec_server_hello(),
-{
-    ServerHelloCombinator(
-    Mapped {
-        inner: (session_id(), (cipher_suite(), (Refined { inner: U8, predicate: TagPred(SERVERHELLOLEGACY_COMPRESSION_METHOD_CONST) }, server_extensions()))),
-        mapper: ServerHelloMapper::new(),
-    })
-}
-
-                
-
-#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum AlertDescription {
-    CloseNotify = 0,
-UnexpectedMessage = 10,
-BadRecordMac = 20,
-RecordOverflow = 22,
-HandshakeFailure = 40,
-BadCertificate = 42,
-UnsupportedCertificate = 43,
-CertificateRevoked = 44,
-CertificateExpired = 45,
-CertificateUnknown = 46,
-IllegalParameter = 47,
-UnknownCA = 48,
-AccessDenied = 49,
-DecodeError = 50,
-DecryptError = 51,
-ProtocolVersion = 70,
-InsufficientSecurity = 71,
-InternalError = 80,
-InappropriateFallback = 86,
-UserCanceled = 90,
-MissingExtension = 109,
-UnsupportedExtension = 110,
-UnrecognizedName = 112,
-BadCertificateStatusResponse = 113,
-UnknownPSKIdentity = 115,
-CertificateRequired = 116,
-NoApplicationProtocol = 120
-}
-pub type SpecAlertDescription = AlertDescription;
-
-pub type AlertDescriptionInner = u8;
-
-impl View for AlertDescription {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFrom<AlertDescriptionInner> for AlertDescription {
-    type Error = ();
-
-    open spec fn spec_try_from(v: AlertDescriptionInner) -> Result<AlertDescription, ()> {
-        match v {
-            0u8 => Ok(AlertDescription::CloseNotify),
-            10u8 => Ok(AlertDescription::UnexpectedMessage),
-            20u8 => Ok(AlertDescription::BadRecordMac),
-            22u8 => Ok(AlertDescription::RecordOverflow),
-            40u8 => Ok(AlertDescription::HandshakeFailure),
-            42u8 => Ok(AlertDescription::BadCertificate),
-            43u8 => Ok(AlertDescription::UnsupportedCertificate),
-            44u8 => Ok(AlertDescription::CertificateRevoked),
-            45u8 => Ok(AlertDescription::CertificateExpired),
-            46u8 => Ok(AlertDescription::CertificateUnknown),
-            47u8 => Ok(AlertDescription::IllegalParameter),
-            48u8 => Ok(AlertDescription::UnknownCA),
-            49u8 => Ok(AlertDescription::AccessDenied),
-            50u8 => Ok(AlertDescription::DecodeError),
-            51u8 => Ok(AlertDescription::DecryptError),
-            70u8 => Ok(AlertDescription::ProtocolVersion),
-            71u8 => Ok(AlertDescription::InsufficientSecurity),
-            80u8 => Ok(AlertDescription::InternalError),
-            86u8 => Ok(AlertDescription::InappropriateFallback),
-            90u8 => Ok(AlertDescription::UserCanceled),
-            109u8 => Ok(AlertDescription::MissingExtension),
-            110u8 => Ok(AlertDescription::UnsupportedExtension),
-            112u8 => Ok(AlertDescription::UnrecognizedName),
-            113u8 => Ok(AlertDescription::BadCertificateStatusResponse),
-            115u8 => Ok(AlertDescription::UnknownPSKIdentity),
-            116u8 => Ok(AlertDescription::CertificateRequired),
-            120u8 => Ok(AlertDescription::NoApplicationProtocol),
-            _ => Err(()),
-        }
-    }
-}
-
-impl SpecTryFrom<AlertDescription> for AlertDescriptionInner {
-    type Error = ();
-
-    open spec fn spec_try_from(v: AlertDescription) -> Result<AlertDescriptionInner, ()> {
-        match v {
-            AlertDescription::CloseNotify => Ok(0u8),
-            AlertDescription::UnexpectedMessage => Ok(10u8),
-            AlertDescription::BadRecordMac => Ok(20u8),
-            AlertDescription::RecordOverflow => Ok(22u8),
-            AlertDescription::HandshakeFailure => Ok(40u8),
-            AlertDescription::BadCertificate => Ok(42u8),
-            AlertDescription::UnsupportedCertificate => Ok(43u8),
-            AlertDescription::CertificateRevoked => Ok(44u8),
-            AlertDescription::CertificateExpired => Ok(45u8),
-            AlertDescription::CertificateUnknown => Ok(46u8),
-            AlertDescription::IllegalParameter => Ok(47u8),
-            AlertDescription::UnknownCA => Ok(48u8),
-            AlertDescription::AccessDenied => Ok(49u8),
-            AlertDescription::DecodeError => Ok(50u8),
-            AlertDescription::DecryptError => Ok(51u8),
-            AlertDescription::ProtocolVersion => Ok(70u8),
-            AlertDescription::InsufficientSecurity => Ok(71u8),
-            AlertDescription::InternalError => Ok(80u8),
-            AlertDescription::InappropriateFallback => Ok(86u8),
-            AlertDescription::UserCanceled => Ok(90u8),
-            AlertDescription::MissingExtension => Ok(109u8),
-            AlertDescription::UnsupportedExtension => Ok(110u8),
-            AlertDescription::UnrecognizedName => Ok(112u8),
-            AlertDescription::BadCertificateStatusResponse => Ok(113u8),
-            AlertDescription::UnknownPSKIdentity => Ok(115u8),
-            AlertDescription::CertificateRequired => Ok(116u8),
-            AlertDescription::NoApplicationProtocol => Ok(120u8),
-        }
-    }
-}
-
-impl TryFrom<AlertDescriptionInner> for AlertDescription {
-    type Error = ();
-
-    fn ex_try_from(v: AlertDescriptionInner) -> Result<AlertDescription, ()> {
-        match v {
-            0u8 => Ok(AlertDescription::CloseNotify),
-            10u8 => Ok(AlertDescription::UnexpectedMessage),
-            20u8 => Ok(AlertDescription::BadRecordMac),
-            22u8 => Ok(AlertDescription::RecordOverflow),
-            40u8 => Ok(AlertDescription::HandshakeFailure),
-            42u8 => Ok(AlertDescription::BadCertificate),
-            43u8 => Ok(AlertDescription::UnsupportedCertificate),
-            44u8 => Ok(AlertDescription::CertificateRevoked),
-            45u8 => Ok(AlertDescription::CertificateExpired),
-            46u8 => Ok(AlertDescription::CertificateUnknown),
-            47u8 => Ok(AlertDescription::IllegalParameter),
-            48u8 => Ok(AlertDescription::UnknownCA),
-            49u8 => Ok(AlertDescription::AccessDenied),
-            50u8 => Ok(AlertDescription::DecodeError),
-            51u8 => Ok(AlertDescription::DecryptError),
-            70u8 => Ok(AlertDescription::ProtocolVersion),
-            71u8 => Ok(AlertDescription::InsufficientSecurity),
-            80u8 => Ok(AlertDescription::InternalError),
-            86u8 => Ok(AlertDescription::InappropriateFallback),
-            90u8 => Ok(AlertDescription::UserCanceled),
-            109u8 => Ok(AlertDescription::MissingExtension),
-            110u8 => Ok(AlertDescription::UnsupportedExtension),
-            112u8 => Ok(AlertDescription::UnrecognizedName),
-            113u8 => Ok(AlertDescription::BadCertificateStatusResponse),
-            115u8 => Ok(AlertDescription::UnknownPSKIdentity),
-            116u8 => Ok(AlertDescription::CertificateRequired),
-            120u8 => Ok(AlertDescription::NoApplicationProtocol),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<AlertDescription> for AlertDescriptionInner {
-    type Error = ();
-
-    fn ex_try_from(v: AlertDescription) -> Result<AlertDescriptionInner, ()> {
-        match v {
-            AlertDescription::CloseNotify => Ok(0u8),
-            AlertDescription::UnexpectedMessage => Ok(10u8),
-            AlertDescription::BadRecordMac => Ok(20u8),
-            AlertDescription::RecordOverflow => Ok(22u8),
-            AlertDescription::HandshakeFailure => Ok(40u8),
-            AlertDescription::BadCertificate => Ok(42u8),
-            AlertDescription::UnsupportedCertificate => Ok(43u8),
-            AlertDescription::CertificateRevoked => Ok(44u8),
-            AlertDescription::CertificateExpired => Ok(45u8),
-            AlertDescription::CertificateUnknown => Ok(46u8),
-            AlertDescription::IllegalParameter => Ok(47u8),
-            AlertDescription::UnknownCA => Ok(48u8),
-            AlertDescription::AccessDenied => Ok(49u8),
-            AlertDescription::DecodeError => Ok(50u8),
-            AlertDescription::DecryptError => Ok(51u8),
-            AlertDescription::ProtocolVersion => Ok(70u8),
-            AlertDescription::InsufficientSecurity => Ok(71u8),
-            AlertDescription::InternalError => Ok(80u8),
-            AlertDescription::InappropriateFallback => Ok(86u8),
-            AlertDescription::UserCanceled => Ok(90u8),
-            AlertDescription::MissingExtension => Ok(109u8),
-            AlertDescription::UnsupportedExtension => Ok(110u8),
-            AlertDescription::UnrecognizedName => Ok(112u8),
-            AlertDescription::BadCertificateStatusResponse => Ok(113u8),
-            AlertDescription::UnknownPSKIdentity => Ok(115u8),
-            AlertDescription::CertificateRequired => Ok(116u8),
-            AlertDescription::NoApplicationProtocol => Ok(120u8),
-        }
-    }
-}
-
-pub struct AlertDescriptionMapper;
-
-impl View for AlertDescriptionMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFromInto for AlertDescriptionMapper {
-    type Src = AlertDescriptionInner;
-    type Dst = AlertDescription;
-
-    proof fn spec_iso(s: Self::Src) { 
-        assert(
-            Self::spec_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_rev_apply(v) is Ok
-            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) { 
-        assert(
-            Self::spec_rev_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_apply(v) is Ok
-            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-}
-
-impl TryFromInto for AlertDescriptionMapper {
-    type Src = AlertDescriptionInner;
-    type Dst = AlertDescription;
-}
-
-
-pub struct SpecAlertDescriptionCombinator(SpecAlertDescriptionCombinatorAlias);
-
-impl SpecCombinator for SpecAlertDescriptionCombinator {
-    type Type = SpecAlertDescription;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecAlertDescriptionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecAlertDescriptionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecAlertDescriptionCombinatorAlias = TryMap<U8, AlertDescriptionMapper>;
-
-pub struct AlertDescriptionCombinator(AlertDescriptionCombinatorAlias);
-
-impl View for AlertDescriptionCombinator {
-    type V = SpecAlertDescriptionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecAlertDescriptionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for AlertDescriptionCombinator {
-    type Type = AlertDescription;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type AlertDescriptionCombinatorAlias = TryMap<U8, AlertDescriptionMapper>;
-
-
-pub closed spec fn spec_alert_description() -> SpecAlertDescriptionCombinator {
-    SpecAlertDescriptionCombinator(TryMap { inner: U8, mapper: AlertDescriptionMapper })
-}
-
-                
-pub fn alert_description() -> (o: AlertDescriptionCombinator)
-    ensures o@ == spec_alert_description(),
-{
-    AlertDescriptionCombinator(TryMap { inner: U8, mapper: AlertDescriptionMapper })
-}
-
-                
-
-pub struct SpecAlert {
-    pub level: SpecAlertLevel,
-    pub description: SpecAlertDescription,
-}
-
-pub type SpecAlertInner = (SpecAlertLevel, SpecAlertDescription);
-impl SpecFrom<SpecAlert> for SpecAlertInner {
-    open spec fn spec_from(m: SpecAlert) -> SpecAlertInner {
-        (m.level, m.description)
-    }
-}
-impl SpecFrom<SpecAlertInner> for SpecAlert {
-    open spec fn spec_from(m: SpecAlertInner) -> SpecAlert {
-        let (level, description) = m;
-        SpecAlert { level, description }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct Alert {
-    pub level: AlertLevel,
-    pub description: AlertDescription,
-}
-
-impl View for Alert {
-    type V = SpecAlert;
-
-    open spec fn view(&self) -> Self::V {
-        SpecAlert {
-            level: self.level@,
-            description: self.description@,
-        }
-    }
-}
-pub type AlertInner = (AlertLevel, AlertDescription);
-impl From<Alert> for AlertInner {
-    fn ex_from(m: Alert) -> AlertInner {
-        (m.level, m.description)
-    }
-}
-impl From<AlertInner> for Alert {
-    fn ex_from(m: AlertInner) -> Alert {
-        let (level, description) = m;
-        Alert { level, description }
-    }
-}
-
-pub struct AlertMapper;
-impl AlertMapper {
-    pub closed spec fn spec_new() -> Self {
-        AlertMapper
-    }
-    pub fn new() -> Self {
-        AlertMapper
-    }
-}
-impl View for AlertMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for AlertMapper {
-    type Src = SpecAlertInner;
-    type Dst = SpecAlert;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for AlertMapper {
-    type Src = AlertInner;
-    type Dst = Alert;
-}
-
-pub struct SpecAlertCombinator(SpecAlertCombinatorAlias);
-
-impl SpecCombinator for SpecAlertCombinator {
-    type Type = SpecAlert;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecAlertCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecAlertCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecAlertCombinatorAlias = Mapped<(SpecAlertLevelCombinator, SpecAlertDescriptionCombinator), AlertMapper>;
-
-pub struct AlertCombinator(AlertCombinatorAlias);
-
-impl View for AlertCombinator {
-    type V = SpecAlertCombinator;
-    closed spec fn view(&self) -> Self::V { SpecAlertCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for AlertCombinator {
-    type Type = Alert;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type AlertCombinatorAlias = Mapped<(AlertLevelCombinator, AlertDescriptionCombinator), AlertMapper>;
-
-
-pub closed spec fn spec_alert() -> SpecAlertCombinator {
-    SpecAlertCombinator(
-    Mapped {
-        inner: (spec_alert_level(), spec_alert_description()),
-        mapper: AlertMapper::spec_new(),
-    })
-}
-
-                
-pub fn alert() -> (o: AlertCombinator)
-    ensures o@ == spec_alert(),
-{
-    AlertCombinator(
-    Mapped {
-        inner: (alert_level(), alert_description()),
-        mapper: AlertMapper::new(),
-    })
-}
-
-                
-
-pub enum SpecNewSessionTicketExtensionExtensionData {
-    EarlyData(SpecEarlyDataIndicationNewSessionTicket),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecNewSessionTicketExtensionExtensionDataInner = Either<SpecEarlyDataIndicationNewSessionTicket, Seq<u8>>;
+pub type SpecCertificateEntryDataInner = Either<SpecOpaque1Ffffff, SpecOpaque1Ffffff>;
 
 
 
-impl SpecFrom<SpecNewSessionTicketExtensionExtensionData> for SpecNewSessionTicketExtensionExtensionDataInner {
-    open spec fn spec_from(m: SpecNewSessionTicketExtensionExtensionData) -> SpecNewSessionTicketExtensionExtensionDataInner {
+impl SpecFrom<SpecCertificateEntryData> for SpecCertificateEntryDataInner {
+    open spec fn spec_from(m: SpecCertificateEntryData) -> SpecCertificateEntryDataInner {
         match m {
-            SpecNewSessionTicketExtensionExtensionData::EarlyData(m) => Either::Left(m),
-            SpecNewSessionTicketExtensionExtensionData::Unrecognized(m) => Either::Right(m),
+            SpecCertificateEntryData::X509(m) => Either::Left(m),
+            SpecCertificateEntryData::RawPublicKey(m) => Either::Right(m),
         }
     }
 
 }
 
-impl SpecFrom<SpecNewSessionTicketExtensionExtensionDataInner> for SpecNewSessionTicketExtensionExtensionData {
-    open spec fn spec_from(m: SpecNewSessionTicketExtensionExtensionDataInner) -> SpecNewSessionTicketExtensionExtensionData {
+impl SpecFrom<SpecCertificateEntryDataInner> for SpecCertificateEntryData {
+    open spec fn spec_from(m: SpecCertificateEntryDataInner) -> SpecCertificateEntryData {
         match m {
-            Either::Left(m) => SpecNewSessionTicketExtensionExtensionData::EarlyData(m),
-            Either::Right(m) => SpecNewSessionTicketExtensionExtensionData::Unrecognized(m),
+            Either::Left(m) => SpecCertificateEntryData::X509(m),
+            Either::Right(m) => SpecCertificateEntryData::RawPublicKey(m),
         }
     }
 
@@ -11976,64 +12446,66 @@ impl SpecFrom<SpecNewSessionTicketExtensionExtensionDataInner> for SpecNewSessio
 
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NewSessionTicketExtensionExtensionData<'a> {
-    EarlyData(EarlyDataIndicationNewSessionTicket),
-    Unrecognized(&'a [u8]),
+pub enum CertificateEntryData<'a> {
+    X509(Opaque1Ffffff<'a>),
+    RawPublicKey(Opaque1Ffffff<'a>),
 }
 
-pub type NewSessionTicketExtensionExtensionDataInner<'a> = Either<EarlyDataIndicationNewSessionTicket, &'a [u8]>;
+pub type CertificateEntryDataInner<'a> = Either<Opaque1Ffffff<'a>, Opaque1Ffffff<'a>>;
 
 
-impl<'a> View for NewSessionTicketExtensionExtensionData<'a> {
-    type V = SpecNewSessionTicketExtensionExtensionData;
+impl<'a> View for CertificateEntryData<'a> {
+    type V = SpecCertificateEntryData;
     open spec fn view(&self) -> Self::V {
         match self {
-            NewSessionTicketExtensionExtensionData::EarlyData(m) => SpecNewSessionTicketExtensionExtensionData::EarlyData(m@),
-            NewSessionTicketExtensionExtensionData::Unrecognized(m) => SpecNewSessionTicketExtensionExtensionData::Unrecognized(m@),
+            CertificateEntryData::X509(m) => SpecCertificateEntryData::X509(m@),
+            CertificateEntryData::RawPublicKey(m) => SpecCertificateEntryData::RawPublicKey(m@),
         }
     }
 }
 
 
-impl<'a> From<NewSessionTicketExtensionExtensionData<'a>> for NewSessionTicketExtensionExtensionDataInner<'a> {
-    fn ex_from(m: NewSessionTicketExtensionExtensionData<'a>) -> NewSessionTicketExtensionExtensionDataInner<'a> {
+impl<'a> From<CertificateEntryData<'a>> for CertificateEntryDataInner<'a> {
+    fn ex_from(m: CertificateEntryData<'a>) -> CertificateEntryDataInner<'a> {
         match m {
-            NewSessionTicketExtensionExtensionData::EarlyData(m) => Either::Left(m),
-            NewSessionTicketExtensionExtensionData::Unrecognized(m) => Either::Right(m),
+            CertificateEntryData::X509(m) => Either::Left(m),
+            CertificateEntryData::RawPublicKey(m) => Either::Right(m),
         }
     }
 
 }
 
-impl<'a> From<NewSessionTicketExtensionExtensionDataInner<'a>> for NewSessionTicketExtensionExtensionData<'a> {
-    fn ex_from(m: NewSessionTicketExtensionExtensionDataInner<'a>) -> NewSessionTicketExtensionExtensionData<'a> {
+impl<'a> From<CertificateEntryDataInner<'a>> for CertificateEntryData<'a> {
+    fn ex_from(m: CertificateEntryDataInner<'a>) -> CertificateEntryData<'a> {
         match m {
-            Either::Left(m) => NewSessionTicketExtensionExtensionData::EarlyData(m),
-            Either::Right(m) => NewSessionTicketExtensionExtensionData::Unrecognized(m),
+            Either::Left(m) => CertificateEntryData::X509(m),
+            Either::Right(m) => CertificateEntryData::RawPublicKey(m),
         }
     }
     
 }
 
 
-pub struct NewSessionTicketExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketExtensionExtensionDataMapper<'a> {
+pub struct CertificateEntryDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> CertificateEntryDataMapper<'a> {
     pub closed spec fn spec_new() -> Self {
-        NewSessionTicketExtensionExtensionDataMapper(PhantomData)
+        CertificateEntryDataMapper(PhantomData)
     }
     pub fn new() -> Self {
-        NewSessionTicketExtensionExtensionDataMapper(PhantomData)
+        CertificateEntryDataMapper(PhantomData)
     }
 }
-impl View for NewSessionTicketExtensionExtensionDataMapper<'_> {
+impl View for CertificateEntryDataMapper<'_> {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for NewSessionTicketExtensionExtensionDataMapper<'_> {
-    type Src = SpecNewSessionTicketExtensionExtensionDataInner;
-    type Dst = SpecNewSessionTicketExtensionExtensionData;
+impl SpecIso for CertificateEntryDataMapper<'_> {
+    type Src = SpecCertificateEntryDataInner;
+    type Dst = SpecCertificateEntryData;
+}
+impl SpecIsoProof for CertificateEntryDataMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -12041,24 +12513,24 @@ impl SpecIso for NewSessionTicketExtensionExtensionDataMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for NewSessionTicketExtensionExtensionDataMapper<'a> {
-    type Src = NewSessionTicketExtensionExtensionDataInner<'a>;
-    type Dst = NewSessionTicketExtensionExtensionData<'a>;
+impl<'a> Iso for CertificateEntryDataMapper<'a> {
+    type Src = CertificateEntryDataInner<'a>;
+    type Dst = CertificateEntryData<'a>;
 }
 
 
-pub struct SpecNewSessionTicketExtensionExtensionDataCombinator(SpecNewSessionTicketExtensionExtensionDataCombinatorAlias);
+pub struct SpecCertificateEntryDataCombinator(SpecCertificateEntryDataCombinatorAlias);
 
-impl SpecCombinator for SpecNewSessionTicketExtensionExtensionDataCombinator {
-    type Type = SpecNewSessionTicketExtensionExtensionData;
+impl SpecCombinator for SpecCertificateEntryDataCombinator {
+    type Type = SpecCertificateEntryData;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecNewSessionTicketExtensionExtensionDataCombinator {
+impl SecureSpecCombinator for SpecCertificateEntryDataCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecNewSessionTicketExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
+    { SpecCertificateEntryDataCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -12072,16 +12544,16 @@ impl SecureSpecCombinator for SpecNewSessionTicketExtensionExtensionDataCombinat
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecNewSessionTicketExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecEarlyDataIndicationNewSessionTicketCombinator>, Cond<Bytes>>, NewSessionTicketExtensionExtensionDataMapper<'static>>>;
+pub type SpecCertificateEntryDataCombinatorAlias = Mapped<OrdChoice<Cond<SpecOpaque1FfffffCombinator>, Cond<SpecOpaque1FfffffCombinator>>, CertificateEntryDataMapper<'static>>;
 
-pub struct NewSessionTicketExtensionExtensionDataCombinator<'a>(NewSessionTicketExtensionExtensionDataCombinatorAlias<'a>);
+pub struct CertificateEntryDataCombinator<'a>(CertificateEntryDataCombinatorAlias<'a>);
 
-impl<'a> View for NewSessionTicketExtensionExtensionDataCombinator<'a> {
-    type V = SpecNewSessionTicketExtensionExtensionDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketExtensionExtensionDataCombinator(self.0@) }
+impl<'a> View for CertificateEntryDataCombinator<'a> {
+    type V = SpecCertificateEntryDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCertificateEntryDataCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionExtensionDataCombinator<'a> {
-    type Type = NewSessionTicketExtensionExtensionData<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateEntryDataCombinator<'a> {
+    type Type = CertificateEntryData<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -12095,112 +12567,35 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionExtensionDat
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type NewSessionTicketExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<EarlyDataIndicationNewSessionTicketCombinator>, Cond<Bytes>>, NewSessionTicketExtensionExtensionDataMapper<'a>>>;
+pub type CertificateEntryDataCombinatorAlias<'a> = Mapped<OrdChoice<Cond<Opaque1FfffffCombinator<'a>>, Cond<Opaque1FfffffCombinator<'a>>>, CertificateEntryDataMapper<'a>>;
 
 
-pub closed spec fn spec_new_session_ticket_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
-    SpecNewSessionTicketExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 42, inner: spec_early_data_indication_new_session_ticket() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) }), mapper: NewSessionTicketExtensionExtensionDataMapper::spec_new() }))
+pub closed spec fn spec_certificate_entry_data(cert_type: SpecCertificateType) -> SpecCertificateEntryDataCombinator {
+    SpecCertificateEntryDataCombinator(Mapped { inner: OrdChoice(Cond { cond: cert_type == 0, inner: spec_opaque_1_ffffff() }, Cond { cond: cert_type == 2, inner: spec_opaque_1_ffffff() }), mapper: CertificateEntryDataMapper::spec_new() })
 }
 
-pub fn new_session_ticket_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: NewSessionTicketExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@),
+pub fn certificate_entry_data<'a>(cert_type: CertificateType) -> (o: CertificateEntryDataCombinator<'a>)
+    ensures o@ == spec_certificate_entry_data(cert_type@),
 {
-    NewSessionTicketExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 42, inner: early_data_indication_new_session_ticket() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) }), mapper: NewSessionTicketExtensionExtensionDataMapper::new() }))
+    CertificateEntryDataCombinator(Mapped { inner: OrdChoice::new(Cond { cond: cert_type == 0, inner: opaque_1_ffffff() }, Cond { cond: cert_type == 2, inner: opaque_1_ffffff() }), mapper: CertificateEntryDataMapper::new() })
 }
 
+pub type SpecOcspResponse = SpecOpaque1Ffffff;
+pub type OcspResponse<'a> = Opaque1Ffffff<'a>;
 
-pub struct SpecNewSessionTicketExtension {
-    pub extension_type: SpecExtensionType,
-    pub ext_len: u16,
-    pub extension_data: SpecNewSessionTicketExtensionExtensionData,
-}
 
-pub type SpecNewSessionTicketExtensionInner = ((SpecExtensionType, u16), SpecNewSessionTicketExtensionExtensionData);
-impl SpecFrom<SpecNewSessionTicketExtension> for SpecNewSessionTicketExtensionInner {
-    open spec fn spec_from(m: SpecNewSessionTicketExtension) -> SpecNewSessionTicketExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl SpecFrom<SpecNewSessionTicketExtensionInner> for SpecNewSessionTicketExtension {
-    open spec fn spec_from(m: SpecNewSessionTicketExtensionInner) -> SpecNewSessionTicketExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        SpecNewSessionTicketExtension { extension_type, ext_len, extension_data }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecOcspResponseCombinator(SpecOcspResponseCombinatorAlias);
 
-pub struct NewSessionTicketExtension<'a> {
-    pub extension_type: ExtensionType,
-    pub ext_len: u16,
-    pub extension_data: NewSessionTicketExtensionExtensionData<'a>,
-}
-
-impl View for NewSessionTicketExtension<'_> {
-    type V = SpecNewSessionTicketExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecNewSessionTicketExtension {
-            extension_type: self.extension_type@,
-            ext_len: self.ext_len@,
-            extension_data: self.extension_data@,
-        }
-    }
-}
-pub type NewSessionTicketExtensionInner<'a> = ((ExtensionType, u16), NewSessionTicketExtensionExtensionData<'a>);
-impl<'a> From<NewSessionTicketExtension<'a>> for NewSessionTicketExtensionInner<'a> {
-    fn ex_from(m: NewSessionTicketExtension) -> NewSessionTicketExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl<'a> From<NewSessionTicketExtensionInner<'a>> for NewSessionTicketExtension<'a> {
-    fn ex_from(m: NewSessionTicketExtensionInner) -> NewSessionTicketExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        NewSessionTicketExtension { extension_type, ext_len, extension_data }
-    }
-}
-
-pub struct NewSessionTicketExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        NewSessionTicketExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        NewSessionTicketExtensionMapper(PhantomData)
-    }
-}
-impl View for NewSessionTicketExtensionMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for NewSessionTicketExtensionMapper<'_> {
-    type Src = SpecNewSessionTicketExtensionInner;
-    type Dst = SpecNewSessionTicketExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for NewSessionTicketExtensionMapper<'a> {
-    type Src = NewSessionTicketExtensionInner<'a>;
-    type Dst = NewSessionTicketExtension<'a>;
-}
-
-pub struct SpecNewSessionTicketExtensionCombinator(SpecNewSessionTicketExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecNewSessionTicketExtensionCombinator {
-    type Type = SpecNewSessionTicketExtension;
+impl SpecCombinator for SpecOcspResponseCombinator {
+    type Type = SpecOcspResponse;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecNewSessionTicketExtensionCombinator {
+impl SecureSpecCombinator for SpecOcspResponseCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecNewSessionTicketExtensionCombinatorAlias::is_prefix_secure() }
+    { SpecOcspResponseCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -12214,16 +12609,16 @@ impl SecureSpecCombinator for SpecNewSessionTicketExtensionCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecNewSessionTicketExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecNewSessionTicketExtensionExtensionDataCombinator>, NewSessionTicketExtensionMapper<'static>>;
+pub type SpecOcspResponseCombinatorAlias = SpecOpaque1FfffffCombinator;
 
-pub struct NewSessionTicketExtensionCombinator<'a>(NewSessionTicketExtensionCombinatorAlias<'a>);
+pub struct OcspResponseCombinator<'a>(OcspResponseCombinatorAlias<'a>);
 
-impl<'a> View for NewSessionTicketExtensionCombinator<'a> {
-    type V = SpecNewSessionTicketExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketExtensionCombinator(self.0@) }
+impl<'a> View for OcspResponseCombinator<'a> {
+    type V = SpecOcspResponseCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOcspResponseCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionCombinator<'a> {
-    type Type = NewSessionTicketExtension<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for OcspResponseCombinator<'a> {
+    type Type = OcspResponse<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -12237,76 +12632,20 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionCombinator<'
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type NewSessionTicketExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, NewSessionTicketExtensionCont1<'a>>, NewSessionTicketExtensionExtensionDataCombinator<'a>, NewSessionTicketExtensionCont0<'a>>, NewSessionTicketExtensionMapper<'a>>;
+pub type OcspResponseCombinatorAlias<'a> = Opaque1FfffffCombinator<'a>;
 
 
-pub closed spec fn spec_new_session_ticket_extension() -> SpecNewSessionTicketExtensionCombinator {
-    SpecNewSessionTicketExtensionCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_new_session_ticket_extension_cont1(deps) }, snd: |deps| spec_new_session_ticket_extension_cont0(deps) },
-        mapper: NewSessionTicketExtensionMapper::spec_new(),
-    })
+pub closed spec fn spec_ocsp_response() -> SpecOcspResponseCombinator {
+    SpecOcspResponseCombinator(spec_opaque_1_ffffff())
 }
 
-pub open spec fn spec_new_session_ticket_extension_cont1(deps: SpecExtensionType) -> U16Be {
-    let extension_type = deps;
-    U16Be
-}
-pub open spec fn spec_new_session_ticket_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
-    let (extension_type, ext_len) = deps;
-    spec_new_session_ticket_extension_extension_data(extension_type, ext_len)
-}
                 
-pub fn new_session_ticket_extension<'a>() -> (o: NewSessionTicketExtensionCombinator<'a>)
-    ensures o@ == spec_new_session_ticket_extension(),
+pub fn ocsp_response<'a>() -> (o: OcspResponseCombinator<'a>)
+    ensures o@ == spec_ocsp_response(),
 {
-    NewSessionTicketExtensionCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: extension_type(), snd: NewSessionTicketExtensionCont1::new(), spec_snd: Ghost(|deps| spec_new_session_ticket_extension_cont1(deps)) }, snd: NewSessionTicketExtensionCont0::new(), spec_snd: Ghost(|deps| spec_new_session_ticket_extension_cont0(deps)) },
-        mapper: NewSessionTicketExtensionMapper::new(),
-    })
+    OcspResponseCombinator(opaque_1_ffffff())
 }
 
-pub struct NewSessionTicketExtensionCont1<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketExtensionCont1<'a> {
-    pub fn new() -> Self {
-        NewSessionTicketExtensionCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&ExtensionType> for NewSessionTicketExtensionCont1<'a> {
-    type Output = U16Be;
-
-    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
-        o@ == spec_new_session_ticket_extension_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &ExtensionType) -> Self::Output {
-        let extension_type = *deps;
-        U16Be
-    }
-}
-pub struct NewSessionTicketExtensionCont0<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketExtensionCont0<'a> {
-    pub fn new() -> Self {
-        NewSessionTicketExtensionCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(ExtensionType, u16)> for NewSessionTicketExtensionCont0<'a> {
-    type Output = NewSessionTicketExtensionExtensionDataCombinator<'a>;
-
-    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
-        o@ == spec_new_session_ticket_extension_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
-        let (extension_type, ext_len) = *deps;
-        new_session_ticket_extension_extension_data(extension_type, ext_len)
-    }
-}
                 
 
 pub struct SpecCertificateStatus {
@@ -12374,6 +12713,8 @@ impl View for CertificateStatusMapper<'_> {
 impl SpecIso for CertificateStatusMapper<'_> {
     type Src = SpecCertificateStatusInner;
     type Dst = SpecCertificateStatus;
+}
+impl SpecIsoProof for CertificateStatusMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -12556,6 +12897,8 @@ impl View for CertificateExtensionExtensionDataMapper<'_> {
 impl SpecIso for CertificateExtensionExtensionDataMapper<'_> {
     type Src = SpecCertificateExtensionExtensionDataInner;
     type Dst = SpecCertificateExtensionExtensionData;
+}
+impl SpecIsoProof for CertificateExtensionExtensionDataMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -12620,14 +12963,14 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateExtensionExtensionDataComb
 pub type CertificateExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<CertificateStatusCombinator<'a>>, OrdChoice<Cond<SignedCertificateTimestampListCombinator<'a>>, Cond<Bytes>>>, CertificateExtensionExtensionDataMapper<'a>>>;
 
 
-pub closed spec fn spec_certificate_extension_extension_data(extension_type: SpecExtensionType, ext_len: u16) -> SpecCertificateExtensionExtensionDataCombinator {
-    SpecCertificateExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 5, inner: spec_certificate_status() }, OrdChoice(Cond { cond: extension_type == 18, inner: spec_signed_certificate_timestamp_list() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) })), mapper: CertificateExtensionExtensionDataMapper::spec_new() }))
+pub closed spec fn spec_certificate_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecCertificateExtensionExtensionDataCombinator {
+    SpecCertificateExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 5, inner: spec_certificate_status() }, OrdChoice(Cond { cond: extension_type == 18, inner: spec_signed_certificate_timestamp_list() }, Cond { cond: !(extension_type == 5 || extension_type == 18), inner: Bytes(ext_len.spec_into()) })), mapper: CertificateExtensionExtensionDataMapper::spec_new() }))
 }
 
-pub fn certificate_extension_extension_data<'a>(extension_type: ExtensionType, ext_len: u16) -> (o: CertificateExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_certificate_extension_extension_data(extension_type@, ext_len@),
+pub fn certificate_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: CertificateExtensionExtensionDataCombinator<'a>)
+    ensures o@ == spec_certificate_extension_extension_data(ext_len@, extension_type@),
 {
-    CertificateExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 5, inner: certificate_status() }, OrdChoice::new(Cond { cond: extension_type == 18, inner: signed_certificate_timestamp_list() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) })), mapper: CertificateExtensionExtensionDataMapper::new() }))
+    CertificateExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 5, inner: certificate_status() }, OrdChoice::new(Cond { cond: extension_type == 18, inner: signed_certificate_timestamp_list() }, Cond { cond: !(extension_type == 5 || extension_type == 18), inner: Bytes(ext_len.ex_into()) })), mapper: CertificateExtensionExtensionDataMapper::new() }))
 }
 
 
@@ -12699,6 +13042,8 @@ impl View for CertificateExtensionMapper<'_> {
 impl SpecIso for CertificateExtensionMapper<'_> {
     type Src = SpecCertificateExtensionInner;
     type Dst = SpecCertificateExtension;
+}
+impl SpecIsoProof for CertificateExtensionMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -12776,7 +13121,7 @@ pub open spec fn spec_certificate_extension_cont1(deps: SpecExtensionType) -> U1
 }
 pub open spec fn spec_certificate_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecCertificateExtensionExtensionDataCombinator {
     let (extension_type, ext_len) = deps;
-    spec_certificate_extension_extension_data(extension_type, ext_len)
+    spec_certificate_extension_extension_data(ext_len, extension_type)
 }
                 
 pub fn certificate_extension<'a>() -> (o: CertificateExtensionCombinator<'a>)
@@ -12826,7 +13171,7 @@ impl<'a> Continuation<&(ExtensionType, u16)> for CertificateExtensionCont0<'a> {
 
     fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
         let (extension_type, ext_len) = *deps;
-        certificate_extension_extension_data(extension_type, ext_len)
+        certificate_extension_extension_data(ext_len, extension_type)
     }
 }
                 
@@ -12896,6 +13241,8 @@ impl View for CertificateExtensionsMapper<'_> {
 impl SpecIso for CertificateExtensionsMapper<'_> {
     type Src = SpecCertificateExtensionsInner;
     type Dst = SpecCertificateExtensions;
+}
+impl SpecIsoProof for CertificateExtensionsMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -13004,6 +13351,1063 @@ impl<'a> Continuation<&u16> for CertificateExtensionsCont0<'a> {
 }
                 
 
+pub struct SpecCertificateEntry {
+    pub data: SpecCertificateEntryData,
+    pub extensions: SpecCertificateExtensions,
+}
+
+pub type SpecCertificateEntryInner = (SpecCertificateEntryData, SpecCertificateExtensions);
+impl SpecFrom<SpecCertificateEntry> for SpecCertificateEntryInner {
+    open spec fn spec_from(m: SpecCertificateEntry) -> SpecCertificateEntryInner {
+        (m.data, m.extensions)
+    }
+}
+impl SpecFrom<SpecCertificateEntryInner> for SpecCertificateEntry {
+    open spec fn spec_from(m: SpecCertificateEntryInner) -> SpecCertificateEntry {
+        let (data, extensions) = m;
+        SpecCertificateEntry { data, extensions }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct CertificateEntry<'a> {
+    pub data: CertificateEntryData<'a>,
+    pub extensions: CertificateExtensions<'a>,
+}
+
+impl View for CertificateEntry<'_> {
+    type V = SpecCertificateEntry;
+
+    open spec fn view(&self) -> Self::V {
+        SpecCertificateEntry {
+            data: self.data@,
+            extensions: self.extensions@,
+        }
+    }
+}
+pub type CertificateEntryInner<'a> = (CertificateEntryData<'a>, CertificateExtensions<'a>);
+impl<'a> From<CertificateEntry<'a>> for CertificateEntryInner<'a> {
+    fn ex_from(m: CertificateEntry) -> CertificateEntryInner {
+        (m.data, m.extensions)
+    }
+}
+impl<'a> From<CertificateEntryInner<'a>> for CertificateEntry<'a> {
+    fn ex_from(m: CertificateEntryInner) -> CertificateEntry {
+        let (data, extensions) = m;
+        CertificateEntry { data, extensions }
+    }
+}
+
+pub struct CertificateEntryMapper<'a>(PhantomData<&'a ()>);
+impl<'a> CertificateEntryMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        CertificateEntryMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        CertificateEntryMapper(PhantomData)
+    }
+}
+impl View for CertificateEntryMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for CertificateEntryMapper<'_> {
+    type Src = SpecCertificateEntryInner;
+    type Dst = SpecCertificateEntry;
+}
+impl SpecIsoProof for CertificateEntryMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for CertificateEntryMapper<'a> {
+    type Src = CertificateEntryInner<'a>;
+    type Dst = CertificateEntry<'a>;
+}
+
+pub struct SpecCertificateEntryCombinator(SpecCertificateEntryCombinatorAlias);
+
+impl SpecCombinator for SpecCertificateEntryCombinator {
+    type Type = SpecCertificateEntry;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecCertificateEntryCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecCertificateEntryCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecCertificateEntryCombinatorAlias = Mapped<(SpecCertificateEntryDataCombinator, SpecCertificateExtensionsCombinator), CertificateEntryMapper<'static>>;
+
+pub struct CertificateEntryCombinator<'a>(CertificateEntryCombinatorAlias<'a>);
+
+impl<'a> View for CertificateEntryCombinator<'a> {
+    type V = SpecCertificateEntryCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCertificateEntryCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateEntryCombinator<'a> {
+    type Type = CertificateEntry<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type CertificateEntryCombinatorAlias<'a> = Mapped<(CertificateEntryDataCombinator<'a>, CertificateExtensionsCombinator<'a>), CertificateEntryMapper<'a>>;
+
+
+pub closed spec fn spec_certificate_entry(cert_type: SpecCertificateType) -> SpecCertificateEntryCombinator {
+    SpecCertificateEntryCombinator(
+    Mapped {
+        inner: (spec_certificate_entry_data(cert_type), spec_certificate_extensions()),
+        mapper: CertificateEntryMapper::spec_new(),
+    })
+}
+
+pub fn certificate_entry<'a>(cert_type: CertificateType) -> (o: CertificateEntryCombinator<'a>)
+    ensures o@ == spec_certificate_entry(cert_type@),
+{
+    CertificateEntryCombinator(
+    Mapped {
+        inner: (certificate_entry_data(cert_type), certificate_extensions()),
+        mapper: CertificateEntryMapper::new(),
+    })
+}
+
+
+pub struct SpecClientCertTypeServerExtension {
+    pub client_certificate_type: SpecCertificateType,
+}
+
+pub type SpecClientCertTypeServerExtensionInner = SpecCertificateType;
+impl SpecFrom<SpecClientCertTypeServerExtension> for SpecClientCertTypeServerExtensionInner {
+    open spec fn spec_from(m: SpecClientCertTypeServerExtension) -> SpecClientCertTypeServerExtensionInner {
+        m.client_certificate_type
+    }
+}
+impl SpecFrom<SpecClientCertTypeServerExtensionInner> for SpecClientCertTypeServerExtension {
+    open spec fn spec_from(m: SpecClientCertTypeServerExtensionInner) -> SpecClientCertTypeServerExtension {
+        let client_certificate_type = m;
+        SpecClientCertTypeServerExtension { client_certificate_type }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ClientCertTypeServerExtension {
+    pub client_certificate_type: CertificateType,
+}
+
+impl View for ClientCertTypeServerExtension {
+    type V = SpecClientCertTypeServerExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecClientCertTypeServerExtension {
+            client_certificate_type: self.client_certificate_type@,
+        }
+    }
+}
+pub type ClientCertTypeServerExtensionInner = CertificateType;
+impl From<ClientCertTypeServerExtension> for ClientCertTypeServerExtensionInner {
+    fn ex_from(m: ClientCertTypeServerExtension) -> ClientCertTypeServerExtensionInner {
+        m.client_certificate_type
+    }
+}
+impl From<ClientCertTypeServerExtensionInner> for ClientCertTypeServerExtension {
+    fn ex_from(m: ClientCertTypeServerExtensionInner) -> ClientCertTypeServerExtension {
+        let client_certificate_type = m;
+        ClientCertTypeServerExtension { client_certificate_type }
+    }
+}
+
+pub struct ClientCertTypeServerExtensionMapper;
+impl ClientCertTypeServerExtensionMapper {
+    pub closed spec fn spec_new() -> Self {
+        ClientCertTypeServerExtensionMapper
+    }
+    pub fn new() -> Self {
+        ClientCertTypeServerExtensionMapper
+    }
+}
+impl View for ClientCertTypeServerExtensionMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ClientCertTypeServerExtensionMapper {
+    type Src = SpecClientCertTypeServerExtensionInner;
+    type Dst = SpecClientCertTypeServerExtension;
+}
+impl SpecIsoProof for ClientCertTypeServerExtensionMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for ClientCertTypeServerExtensionMapper {
+    type Src = ClientCertTypeServerExtensionInner;
+    type Dst = ClientCertTypeServerExtension;
+}
+
+pub struct SpecClientCertTypeServerExtensionCombinator(SpecClientCertTypeServerExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecClientCertTypeServerExtensionCombinator {
+    type Type = SpecClientCertTypeServerExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecClientCertTypeServerExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecClientCertTypeServerExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecClientCertTypeServerExtensionCombinatorAlias = Mapped<SpecCertificateTypeCombinator, ClientCertTypeServerExtensionMapper>;
+
+pub struct ClientCertTypeServerExtensionCombinator(ClientCertTypeServerExtensionCombinatorAlias);
+
+impl View for ClientCertTypeServerExtensionCombinator {
+    type V = SpecClientCertTypeServerExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecClientCertTypeServerExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ClientCertTypeServerExtensionCombinator {
+    type Type = ClientCertTypeServerExtension;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ClientCertTypeServerExtensionCombinatorAlias = Mapped<CertificateTypeCombinator, ClientCertTypeServerExtensionMapper>;
+
+
+pub closed spec fn spec_client_cert_type_server_extension() -> SpecClientCertTypeServerExtensionCombinator {
+    SpecClientCertTypeServerExtensionCombinator(
+    Mapped {
+        inner: spec_certificate_type(),
+        mapper: ClientCertTypeServerExtensionMapper::spec_new(),
+    })
+}
+
+                
+pub fn client_cert_type_server_extension() -> (o: ClientCertTypeServerExtensionCombinator)
+    ensures o@ == spec_client_cert_type_server_extension(),
+{
+    ClientCertTypeServerExtensionCombinator(
+    Mapped {
+        inner: certificate_type(),
+        mapper: ClientCertTypeServerExtensionMapper::new(),
+    })
+}
+
+                
+pub type SpecUnknownExtension = SpecOpaque0Ffff;
+pub type UnknownExtension<'a> = Opaque0Ffff<'a>;
+
+
+pub struct SpecUnknownExtensionCombinator(SpecUnknownExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecUnknownExtensionCombinator {
+    type Type = SpecUnknownExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecUnknownExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecUnknownExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecUnknownExtensionCombinatorAlias = SpecOpaque0FfffCombinator;
+
+pub struct UnknownExtensionCombinator<'a>(UnknownExtensionCombinatorAlias<'a>);
+
+impl<'a> View for UnknownExtensionCombinator<'a> {
+    type V = SpecUnknownExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecUnknownExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for UnknownExtensionCombinator<'a> {
+    type Type = UnknownExtension<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type UnknownExtensionCombinatorAlias<'a> = Opaque0FfffCombinator<'a>;
+
+
+pub closed spec fn spec_unknown_extension() -> SpecUnknownExtensionCombinator {
+    SpecUnknownExtensionCombinator(spec_opaque_0_ffff())
+}
+
+                
+pub fn unknown_extension<'a>() -> (o: UnknownExtensionCombinator<'a>)
+    ensures o@ == spec_unknown_extension(),
+{
+    UnknownExtensionCombinator(opaque_0_ffff())
+}
+
+                
+
+pub struct SpecCipherSuiteList {
+    pub l: u16,
+    pub list: Seq<SpecCipherSuite>,
+}
+
+pub type SpecCipherSuiteListInner = (u16, Seq<SpecCipherSuite>);
+impl SpecFrom<SpecCipherSuiteList> for SpecCipherSuiteListInner {
+    open spec fn spec_from(m: SpecCipherSuiteList) -> SpecCipherSuiteListInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecCipherSuiteListInner> for SpecCipherSuiteList {
+    open spec fn spec_from(m: SpecCipherSuiteListInner) -> SpecCipherSuiteList {
+        let (l, list) = m;
+        SpecCipherSuiteList { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct CipherSuiteList {
+    pub l: u16,
+    pub list: RepeatResult<CipherSuite>,
+}
+
+impl View for CipherSuiteList {
+    type V = SpecCipherSuiteList;
+
+    open spec fn view(&self) -> Self::V {
+        SpecCipherSuiteList {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type CipherSuiteListInner = (u16, RepeatResult<CipherSuite>);
+impl From<CipherSuiteList> for CipherSuiteListInner {
+    fn ex_from(m: CipherSuiteList) -> CipherSuiteListInner {
+        (m.l, m.list)
+    }
+}
+impl From<CipherSuiteListInner> for CipherSuiteList {
+    fn ex_from(m: CipherSuiteListInner) -> CipherSuiteList {
+        let (l, list) = m;
+        CipherSuiteList { l, list }
+    }
+}
+
+pub struct CipherSuiteListMapper;
+impl CipherSuiteListMapper {
+    pub closed spec fn spec_new() -> Self {
+        CipherSuiteListMapper
+    }
+    pub fn new() -> Self {
+        CipherSuiteListMapper
+    }
+}
+impl View for CipherSuiteListMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for CipherSuiteListMapper {
+    type Src = SpecCipherSuiteListInner;
+    type Dst = SpecCipherSuiteList;
+}
+impl SpecIsoProof for CipherSuiteListMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for CipherSuiteListMapper {
+    type Src = CipherSuiteListInner;
+    type Dst = CipherSuiteList;
+}
+
+pub struct SpecCipherSuiteListCombinator(SpecCipherSuiteListCombinatorAlias);
+
+impl SpecCombinator for SpecCipherSuiteListCombinator {
+    type Type = SpecCipherSuiteList;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecCipherSuiteListCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecCipherSuiteListCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecCipherSuiteListCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<SpecCipherSuiteCombinator>>>, CipherSuiteListMapper>;
+
+pub struct CipherSuiteListCombinator<'a>(CipherSuiteListCombinatorAlias<'a>);
+
+impl<'a> View for CipherSuiteListCombinator<'a> {
+    type V = SpecCipherSuiteListCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCipherSuiteListCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CipherSuiteListCombinator<'a> {
+    type Type = CipherSuiteList;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type CipherSuiteListCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate15206902916018849611>, AndThen<Bytes, Repeat<CipherSuiteCombinator>>, CipherSuiteListCont0<'a>>, CipherSuiteListMapper>;
+
+
+pub closed spec fn spec_cipher_suite_list() -> SpecCipherSuiteListCombinator {
+    SpecCipherSuiteListCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: |deps| spec_cipher_suite_list_cont0(deps) },
+        mapper: CipherSuiteListMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_cipher_suite_list_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecCipherSuiteCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_cipher_suite()))
+}
+                
+pub fn cipher_suite_list<'a>() -> (o: CipherSuiteListCombinator<'a>)
+    ensures o@ == spec_cipher_suite_list(),
+{
+    CipherSuiteListCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate15206902916018849611 }, snd: CipherSuiteListCont0::new(), spec_snd: Ghost(|deps| spec_cipher_suite_list_cont0(deps)) },
+        mapper: CipherSuiteListMapper::new(),
+    })
+}
+
+pub struct CipherSuiteListCont0<'a>(PhantomData<&'a ()>);
+impl<'a> CipherSuiteListCont0<'a> {
+    pub fn new() -> Self {
+        CipherSuiteListCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for CipherSuiteListCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<CipherSuiteCombinator>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_cipher_suite_list_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(cipher_suite()))
+    }
+}
+                
+
+pub struct SpecClientHello {
+    pub legacy_version: u16,
+    pub random: Seq<u8>,
+    pub legacy_session_id: SpecSessionId,
+    pub cipher_suites: SpecCipherSuiteList,
+    pub legacy_compression_methods: SpecOpaque1Ff,
+    pub extensions: SpecClientExtensions,
+}
+
+pub type SpecClientHelloInner = (u16, (Seq<u8>, (SpecSessionId, (SpecCipherSuiteList, (SpecOpaque1Ff, SpecClientExtensions)))));
+impl SpecFrom<SpecClientHello> for SpecClientHelloInner {
+    open spec fn spec_from(m: SpecClientHello) -> SpecClientHelloInner {
+        (m.legacy_version, (m.random, (m.legacy_session_id, (m.cipher_suites, (m.legacy_compression_methods, m.extensions)))))
+    }
+}
+impl SpecFrom<SpecClientHelloInner> for SpecClientHello {
+    open spec fn spec_from(m: SpecClientHelloInner) -> SpecClientHello {
+        let (legacy_version, (random, (legacy_session_id, (cipher_suites, (legacy_compression_methods, extensions))))) = m;
+        SpecClientHello { legacy_version, random, legacy_session_id, cipher_suites, legacy_compression_methods, extensions }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ClientHello<'a> {
+    pub legacy_version: u16,
+    pub random: &'a [u8],
+    pub legacy_session_id: SessionId<'a>,
+    pub cipher_suites: CipherSuiteList,
+    pub legacy_compression_methods: Opaque1Ff<'a>,
+    pub extensions: ClientExtensions<'a>,
+}
+
+impl View for ClientHello<'_> {
+    type V = SpecClientHello;
+
+    open spec fn view(&self) -> Self::V {
+        SpecClientHello {
+            legacy_version: self.legacy_version@,
+            random: self.random@,
+            legacy_session_id: self.legacy_session_id@,
+            cipher_suites: self.cipher_suites@,
+            legacy_compression_methods: self.legacy_compression_methods@,
+            extensions: self.extensions@,
+        }
+    }
+}
+pub type ClientHelloInner<'a> = (u16, (&'a [u8], (SessionId<'a>, (CipherSuiteList, (Opaque1Ff<'a>, ClientExtensions<'a>)))));
+impl<'a> From<ClientHello<'a>> for ClientHelloInner<'a> {
+    fn ex_from(m: ClientHello) -> ClientHelloInner {
+        (m.legacy_version, (m.random, (m.legacy_session_id, (m.cipher_suites, (m.legacy_compression_methods, m.extensions)))))
+    }
+}
+impl<'a> From<ClientHelloInner<'a>> for ClientHello<'a> {
+    fn ex_from(m: ClientHelloInner) -> ClientHello {
+        let (legacy_version, (random, (legacy_session_id, (cipher_suites, (legacy_compression_methods, extensions))))) = m;
+        ClientHello { legacy_version, random, legacy_session_id, cipher_suites, legacy_compression_methods, extensions }
+    }
+}
+
+pub struct ClientHelloMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ClientHelloMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ClientHelloMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ClientHelloMapper(PhantomData)
+    }
+}
+impl View for ClientHelloMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ClientHelloMapper<'_> {
+    type Src = SpecClientHelloInner;
+    type Dst = SpecClientHello;
+}
+impl SpecIsoProof for ClientHelloMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ClientHelloMapper<'a> {
+    type Src = ClientHelloInner<'a>;
+    type Dst = ClientHello<'a>;
+}
+pub const CLIENTHELLOLEGACY_VERSION_CONST: u16 = 771;
+
+pub struct SpecClientHelloCombinator(SpecClientHelloCombinatorAlias);
+
+impl SpecCombinator for SpecClientHelloCombinator {
+    type Type = SpecClientHello;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecClientHelloCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecClientHelloCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecClientHelloCombinatorAlias = Mapped<(Refined<U16Be, TagPred<u16>>, (BytesN<32>, (SpecSessionIdCombinator, (SpecCipherSuiteListCombinator, (SpecOpaque1FfCombinator, SpecClientExtensionsCombinator))))), ClientHelloMapper<'static>>;
+
+pub struct ClientHelloCombinator<'a>(ClientHelloCombinatorAlias<'a>);
+
+impl<'a> View for ClientHelloCombinator<'a> {
+    type V = SpecClientHelloCombinator;
+    closed spec fn view(&self) -> Self::V { SpecClientHelloCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ClientHelloCombinator<'a> {
+    type Type = ClientHello<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ClientHelloCombinatorAlias<'a> = Mapped<(Refined<U16Be, TagPred<u16>>, (BytesN<32>, (SessionIdCombinator<'a>, (CipherSuiteListCombinator<'a>, (Opaque1FfCombinator<'a>, ClientExtensionsCombinator<'a>))))), ClientHelloMapper<'a>>;
+
+
+pub closed spec fn spec_client_hello() -> SpecClientHelloCombinator {
+    SpecClientHelloCombinator(
+    Mapped {
+        inner: (Refined { inner: U16Be, predicate: TagPred(CLIENTHELLOLEGACY_VERSION_CONST) }, (BytesN::<32>, (spec_session_id(), (spec_cipher_suite_list(), (spec_opaque_1_ff(), spec_client_extensions()))))),
+        mapper: ClientHelloMapper::spec_new(),
+    })
+}
+
+                
+pub fn client_hello<'a>() -> (o: ClientHelloCombinator<'a>)
+    ensures o@ == spec_client_hello(),
+{
+    ClientHelloCombinator(
+    Mapped {
+        inner: (Refined { inner: U16Be, predicate: TagPred(CLIENTHELLOLEGACY_VERSION_CONST) }, (BytesN::<32>, (session_id(), (cipher_suite_list(), (opaque_1_ff(), client_extensions()))))),
+        mapper: ClientHelloMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecShOrHrr {
+    pub legacy_version: u16,
+    pub random: Seq<u8>,
+    pub payload: SpecShOrHrrPayload,
+}
+
+pub type SpecShOrHrrInner = ((u16, Seq<u8>), SpecShOrHrrPayload);
+impl SpecFrom<SpecShOrHrr> for SpecShOrHrrInner {
+    open spec fn spec_from(m: SpecShOrHrr) -> SpecShOrHrrInner {
+        ((m.legacy_version, m.random), m.payload)
+    }
+}
+impl SpecFrom<SpecShOrHrrInner> for SpecShOrHrr {
+    open spec fn spec_from(m: SpecShOrHrrInner) -> SpecShOrHrr {
+        let ((legacy_version, random), payload) = m;
+        SpecShOrHrr { legacy_version, random, payload }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ShOrHrr<'a> {
+    pub legacy_version: u16,
+    pub random: &'a [u8],
+    pub payload: ShOrHrrPayload<'a>,
+}
+
+impl View for ShOrHrr<'_> {
+    type V = SpecShOrHrr;
+
+    open spec fn view(&self) -> Self::V {
+        SpecShOrHrr {
+            legacy_version: self.legacy_version@,
+            random: self.random@,
+            payload: self.payload@,
+        }
+    }
+}
+pub type ShOrHrrInner<'a> = ((u16, &'a [u8]), ShOrHrrPayload<'a>);
+impl<'a> From<ShOrHrr<'a>> for ShOrHrrInner<'a> {
+    fn ex_from(m: ShOrHrr) -> ShOrHrrInner {
+        ((m.legacy_version, m.random), m.payload)
+    }
+}
+impl<'a> From<ShOrHrrInner<'a>> for ShOrHrr<'a> {
+    fn ex_from(m: ShOrHrrInner) -> ShOrHrr {
+        let ((legacy_version, random), payload) = m;
+        ShOrHrr { legacy_version, random, payload }
+    }
+}
+
+pub struct ShOrHrrMapper<'a>(PhantomData<&'a ()>);
+impl<'a> ShOrHrrMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        ShOrHrrMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        ShOrHrrMapper(PhantomData)
+    }
+}
+impl View for ShOrHrrMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ShOrHrrMapper<'_> {
+    type Src = SpecShOrHrrInner;
+    type Dst = SpecShOrHrr;
+}
+impl SpecIsoProof for ShOrHrrMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for ShOrHrrMapper<'a> {
+    type Src = ShOrHrrInner<'a>;
+    type Dst = ShOrHrr<'a>;
+}
+pub const SHORHRRLEGACY_VERSION_CONST: u16 = 771;
+
+pub struct SpecShOrHrrCombinator(SpecShOrHrrCombinatorAlias);
+
+impl SpecCombinator for SpecShOrHrrCombinator {
+    type Type = SpecShOrHrr;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecShOrHrrCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecShOrHrrCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecShOrHrrCombinatorAlias = Mapped<SpecDepend<(Refined<U16Be, TagPred<u16>>, BytesN<32>), SpecShOrHrrPayloadCombinator>, ShOrHrrMapper<'static>>;
+
+pub struct ShOrHrrCombinator<'a>(ShOrHrrCombinatorAlias<'a>);
+
+impl<'a> View for ShOrHrrCombinator<'a> {
+    type V = SpecShOrHrrCombinator;
+    closed spec fn view(&self) -> Self::V { SpecShOrHrrCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ShOrHrrCombinator<'a> {
+    type Type = ShOrHrr<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ShOrHrrCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, (Refined<U16Be, TagPred<u16>>, BytesN<32>), ShOrHrrPayloadCombinator<'a>, ShOrHrrCont0<'a>>, ShOrHrrMapper<'a>>;
+
+
+pub closed spec fn spec_sh_or_hrr() -> SpecShOrHrrCombinator {
+    SpecShOrHrrCombinator(
+    Mapped {
+        inner: SpecDepend { fst: (Refined { inner: U16Be, predicate: TagPred(SHORHRRLEGACY_VERSION_CONST) }, BytesN::<32>), snd: |deps| spec_sh_or_hrr_cont0(deps) },
+        mapper: ShOrHrrMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_sh_or_hrr_cont0(deps: (u16, Seq<u8>)) -> SpecShOrHrrPayloadCombinator {
+    let (_, random) = deps;
+    spec_sh_or_hrr_payload(random)
+}
+                
+pub fn sh_or_hrr<'a>() -> (o: ShOrHrrCombinator<'a>)
+    ensures o@ == spec_sh_or_hrr(),
+{
+    ShOrHrrCombinator(
+    Mapped {
+        inner: Depend { fst: (Refined { inner: U16Be, predicate: TagPred(SHORHRRLEGACY_VERSION_CONST) }, BytesN::<32>), snd: ShOrHrrCont0::new(), spec_snd: Ghost(|deps| spec_sh_or_hrr_cont0(deps)) },
+        mapper: ShOrHrrMapper::new(),
+    })
+}
+
+pub struct ShOrHrrCont0<'a>(PhantomData<&'a ()>);
+impl<'a> ShOrHrrCont0<'a> {
+    pub fn new() -> Self {
+        ShOrHrrCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(u16, &'a [u8])> for ShOrHrrCont0<'a> {
+    type Output = ShOrHrrPayloadCombinator<'a>;
+
+    open spec fn requires(&self, deps: &(u16, &'a [u8])) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(u16, &'a [u8]), o: Self::Output) -> bool {
+        o@ == spec_sh_or_hrr_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(u16, &'a [u8])) -> Self::Output {
+        let (_, random) = *deps;
+        sh_or_hrr_payload(random)
+    }
+}
+                
+
+pub struct SpecEncryptedExtensions {
+    pub l: u16,
+    pub list: Seq<SpecEncryptedExtension>,
+}
+
+pub type SpecEncryptedExtensionsInner = (u16, Seq<SpecEncryptedExtension>);
+impl SpecFrom<SpecEncryptedExtensions> for SpecEncryptedExtensionsInner {
+    open spec fn spec_from(m: SpecEncryptedExtensions) -> SpecEncryptedExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecEncryptedExtensionsInner> for SpecEncryptedExtensions {
+    open spec fn spec_from(m: SpecEncryptedExtensionsInner) -> SpecEncryptedExtensions {
+        let (l, list) = m;
+        SpecEncryptedExtensions { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct EncryptedExtensions<'a> {
+    pub l: u16,
+    pub list: RepeatResult<EncryptedExtension<'a>>,
+}
+
+impl View for EncryptedExtensions<'_> {
+    type V = SpecEncryptedExtensions;
+
+    open spec fn view(&self) -> Self::V {
+        SpecEncryptedExtensions {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type EncryptedExtensionsInner<'a> = (u16, RepeatResult<EncryptedExtension<'a>>);
+impl<'a> From<EncryptedExtensions<'a>> for EncryptedExtensionsInner<'a> {
+    fn ex_from(m: EncryptedExtensions) -> EncryptedExtensionsInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<EncryptedExtensionsInner<'a>> for EncryptedExtensions<'a> {
+    fn ex_from(m: EncryptedExtensionsInner) -> EncryptedExtensions {
+        let (l, list) = m;
+        EncryptedExtensions { l, list }
+    }
+}
+
+pub struct EncryptedExtensionsMapper<'a>(PhantomData<&'a ()>);
+impl<'a> EncryptedExtensionsMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        EncryptedExtensionsMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        EncryptedExtensionsMapper(PhantomData)
+    }
+}
+impl View for EncryptedExtensionsMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for EncryptedExtensionsMapper<'_> {
+    type Src = SpecEncryptedExtensionsInner;
+    type Dst = SpecEncryptedExtensions;
+}
+impl SpecIsoProof for EncryptedExtensionsMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for EncryptedExtensionsMapper<'a> {
+    type Src = EncryptedExtensionsInner<'a>;
+    type Dst = EncryptedExtensions<'a>;
+}
+
+pub struct SpecEncryptedExtensionsCombinator(SpecEncryptedExtensionsCombinatorAlias);
+
+impl SpecCombinator for SpecEncryptedExtensionsCombinator {
+    type Type = SpecEncryptedExtensions;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecEncryptedExtensionsCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecEncryptedExtensionsCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecEncryptedExtensionsCombinatorAlias = Mapped<SpecDepend<U16Be, AndThen<Bytes, Repeat<SpecEncryptedExtensionCombinator>>>, EncryptedExtensionsMapper<'static>>;
+
+pub struct EncryptedExtensionsCombinator<'a>(EncryptedExtensionsCombinatorAlias<'a>);
+
+impl<'a> View for EncryptedExtensionsCombinator<'a> {
+    type V = SpecEncryptedExtensionsCombinator;
+    closed spec fn view(&self) -> Self::V { SpecEncryptedExtensionsCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for EncryptedExtensionsCombinator<'a> {
+    type Type = EncryptedExtensions<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type EncryptedExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U16Be, AndThen<Bytes, Repeat<EncryptedExtensionCombinator<'a>>>, EncryptedExtensionsCont0<'a>>, EncryptedExtensionsMapper<'a>>;
+
+
+pub closed spec fn spec_encrypted_extensions() -> SpecEncryptedExtensionsCombinator {
+    SpecEncryptedExtensionsCombinator(
+    Mapped {
+        inner: SpecDepend { fst: U16Be, snd: |deps| spec_encrypted_extensions_cont0(deps) },
+        mapper: EncryptedExtensionsMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_encrypted_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecEncryptedExtensionCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_encrypted_extension()))
+}
+                
+pub fn encrypted_extensions<'a>() -> (o: EncryptedExtensionsCombinator<'a>)
+    ensures o@ == spec_encrypted_extensions(),
+{
+    EncryptedExtensionsCombinator(
+    Mapped {
+        inner: Depend { fst: U16Be, snd: EncryptedExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_encrypted_extensions_cont0(deps)) },
+        mapper: EncryptedExtensionsMapper::new(),
+    })
+}
+
+pub struct EncryptedExtensionsCont0<'a>(PhantomData<&'a ()>);
+impl<'a> EncryptedExtensionsCont0<'a> {
+    pub fn new() -> Self {
+        EncryptedExtensionsCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for EncryptedExtensionsCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<EncryptedExtensionCombinator<'a>>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_encrypted_extensions_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(encrypted_extension()))
+    }
+}
+                
+
 pub struct SpecCertificateEntryOpaque {
     pub cert_data: SpecOpaque1Ffffff,
     pub extensions: SpecCertificateExtensions,
@@ -13069,6 +14473,8 @@ impl View for CertificateEntryOpaqueMapper<'_> {
 impl SpecIso for CertificateEntryOpaqueMapper<'_> {
     type Src = SpecCertificateEntryOpaqueInner;
     type Dst = SpecCertificateEntryOpaque;
+}
+impl SpecIsoProof for CertificateEntryOpaqueMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -13218,6 +14624,8 @@ impl View for CertificateListMapper<'_> {
 impl SpecIso for CertificateListMapper<'_> {
     type Src = SpecCertificateListInner;
     type Dst = SpecCertificateList;
+}
+impl SpecIsoProof for CertificateListMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -13391,6 +14799,8 @@ impl View for CertificateMapper<'_> {
 impl SpecIso for CertificateMapper<'_> {
     type Src = SpecCertificateInner;
     type Dst = SpecCertificate;
+}
+impl SpecIsoProof for CertificateMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -13475,1329 +14885,73 @@ pub fn certificate<'a>() -> (o: CertificateCombinator<'a>)
 
                 
 
-pub enum SpecCertificateEntryData {
-    X509(SpecOpaque1Ffffff),
-    RawPublicKey(SpecOpaque1Ffffff),
+pub struct SpecCertificateRequest {
+    pub certificate_request_context: SpecOpaque0Ff,
+    pub extensions: SpecCertificateRequestExtensions,
 }
 
-pub type SpecCertificateEntryDataInner = Either<SpecOpaque1Ffffff, SpecOpaque1Ffffff>;
-
-
-
-impl SpecFrom<SpecCertificateEntryData> for SpecCertificateEntryDataInner {
-    open spec fn spec_from(m: SpecCertificateEntryData) -> SpecCertificateEntryDataInner {
-        match m {
-            SpecCertificateEntryData::X509(m) => Either::Left(m),
-            SpecCertificateEntryData::RawPublicKey(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecCertificateEntryDataInner> for SpecCertificateEntryData {
-    open spec fn spec_from(m: SpecCertificateEntryDataInner) -> SpecCertificateEntryData {
-        match m {
-            Either::Left(m) => SpecCertificateEntryData::X509(m),
-            Either::Right(m) => SpecCertificateEntryData::RawPublicKey(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CertificateEntryData<'a> {
-    X509(Opaque1Ffffff<'a>),
-    RawPublicKey(Opaque1Ffffff<'a>),
-}
-
-pub type CertificateEntryDataInner<'a> = Either<Opaque1Ffffff<'a>, Opaque1Ffffff<'a>>;
-
-
-impl<'a> View for CertificateEntryData<'a> {
-    type V = SpecCertificateEntryData;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            CertificateEntryData::X509(m) => SpecCertificateEntryData::X509(m@),
-            CertificateEntryData::RawPublicKey(m) => SpecCertificateEntryData::RawPublicKey(m@),
-        }
+pub type SpecCertificateRequestInner = (SpecOpaque0Ff, SpecCertificateRequestExtensions);
+impl SpecFrom<SpecCertificateRequest> for SpecCertificateRequestInner {
+    open spec fn spec_from(m: SpecCertificateRequest) -> SpecCertificateRequestInner {
+        (m.certificate_request_context, m.extensions)
     }
 }
-
-
-impl<'a> From<CertificateEntryData<'a>> for CertificateEntryDataInner<'a> {
-    fn ex_from(m: CertificateEntryData<'a>) -> CertificateEntryDataInner<'a> {
-        match m {
-            CertificateEntryData::X509(m) => Either::Left(m),
-            CertificateEntryData::RawPublicKey(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl<'a> From<CertificateEntryDataInner<'a>> for CertificateEntryData<'a> {
-    fn ex_from(m: CertificateEntryDataInner<'a>) -> CertificateEntryData<'a> {
-        match m {
-            Either::Left(m) => CertificateEntryData::X509(m),
-            Either::Right(m) => CertificateEntryData::RawPublicKey(m),
-        }
-    }
-    
-}
-
-
-pub struct CertificateEntryDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> CertificateEntryDataMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        CertificateEntryDataMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        CertificateEntryDataMapper(PhantomData)
-    }
-}
-impl View for CertificateEntryDataMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for CertificateEntryDataMapper<'_> {
-    type Src = SpecCertificateEntryDataInner;
-    type Dst = SpecCertificateEntryData;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for CertificateEntryDataMapper<'a> {
-    type Src = CertificateEntryDataInner<'a>;
-    type Dst = CertificateEntryData<'a>;
-}
-
-
-pub struct SpecCertificateEntryDataCombinator(SpecCertificateEntryDataCombinatorAlias);
-
-impl SpecCombinator for SpecCertificateEntryDataCombinator {
-    type Type = SpecCertificateEntryData;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCertificateEntryDataCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCertificateEntryDataCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCertificateEntryDataCombinatorAlias = Mapped<OrdChoice<Cond<SpecOpaque1FfffffCombinator>, Cond<SpecOpaque1FfffffCombinator>>, CertificateEntryDataMapper<'static>>;
-
-pub struct CertificateEntryDataCombinator<'a>(CertificateEntryDataCombinatorAlias<'a>);
-
-impl<'a> View for CertificateEntryDataCombinator<'a> {
-    type V = SpecCertificateEntryDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCertificateEntryDataCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateEntryDataCombinator<'a> {
-    type Type = CertificateEntryData<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CertificateEntryDataCombinatorAlias<'a> = Mapped<OrdChoice<Cond<Opaque1FfffffCombinator<'a>>, Cond<Opaque1FfffffCombinator<'a>>>, CertificateEntryDataMapper<'a>>;
-
-
-pub closed spec fn spec_certificate_entry_data(cert_type: SpecCertificateType) -> SpecCertificateEntryDataCombinator {
-    SpecCertificateEntryDataCombinator(Mapped { inner: OrdChoice(Cond { cond: cert_type == 0, inner: spec_opaque_1_ffffff() }, Cond { cond: cert_type == 2, inner: spec_opaque_1_ffffff() }), mapper: CertificateEntryDataMapper::spec_new() })
-}
-
-pub fn certificate_entry_data<'a>(cert_type: CertificateType) -> (o: CertificateEntryDataCombinator<'a>)
-    ensures o@ == spec_certificate_entry_data(cert_type@),
-{
-    CertificateEntryDataCombinator(Mapped { inner: OrdChoice::new(Cond { cond: cert_type == 0, inner: opaque_1_ffffff() }, Cond { cond: cert_type == 2, inner: opaque_1_ffffff() }), mapper: CertificateEntryDataMapper::new() })
-}
-
-
-pub enum SpecHelloRetryExtensionExtensionData {
-    SupportedVersions(SpecSupportedVersionsServer),
-    Cookie(SpecCookie),
-    KeyShare(SpecNamedGroup),
-    Unrecognized(Seq<u8>),
-}
-
-pub type SpecHelloRetryExtensionExtensionDataInner = Either<SpecSupportedVersionsServer, Either<SpecCookie, Either<SpecNamedGroup, Seq<u8>>>>;
-
-
-
-impl SpecFrom<SpecHelloRetryExtensionExtensionData> for SpecHelloRetryExtensionExtensionDataInner {
-    open spec fn spec_from(m: SpecHelloRetryExtensionExtensionData) -> SpecHelloRetryExtensionExtensionDataInner {
-        match m {
-            SpecHelloRetryExtensionExtensionData::SupportedVersions(m) => Either::Left(m),
-            SpecHelloRetryExtensionExtensionData::Cookie(m) => Either::Right(Either::Left(m)),
-            SpecHelloRetryExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
-            SpecHelloRetryExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecHelloRetryExtensionExtensionDataInner> for SpecHelloRetryExtensionExtensionData {
-    open spec fn spec_from(m: SpecHelloRetryExtensionExtensionDataInner) -> SpecHelloRetryExtensionExtensionData {
-        match m {
-            Either::Left(m) => SpecHelloRetryExtensionExtensionData::SupportedVersions(m),
-            Either::Right(Either::Left(m)) => SpecHelloRetryExtensionExtensionData::Cookie(m),
-            Either::Right(Either::Right(Either::Left(m))) => SpecHelloRetryExtensionExtensionData::KeyShare(m),
-            Either::Right(Either::Right(Either::Right(m))) => SpecHelloRetryExtensionExtensionData::Unrecognized(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HelloRetryExtensionExtensionData<'a> {
-    SupportedVersions(SupportedVersionsServer),
-    Cookie(Cookie<'a>),
-    KeyShare(NamedGroup),
-    Unrecognized(&'a [u8]),
-}
-
-pub type HelloRetryExtensionExtensionDataInner<'a> = Either<SupportedVersionsServer, Either<Cookie<'a>, Either<NamedGroup, &'a [u8]>>>;
-
-
-impl<'a> View for HelloRetryExtensionExtensionData<'a> {
-    type V = SpecHelloRetryExtensionExtensionData;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            HelloRetryExtensionExtensionData::SupportedVersions(m) => SpecHelloRetryExtensionExtensionData::SupportedVersions(m@),
-            HelloRetryExtensionExtensionData::Cookie(m) => SpecHelloRetryExtensionExtensionData::Cookie(m@),
-            HelloRetryExtensionExtensionData::KeyShare(m) => SpecHelloRetryExtensionExtensionData::KeyShare(m@),
-            HelloRetryExtensionExtensionData::Unrecognized(m) => SpecHelloRetryExtensionExtensionData::Unrecognized(m@),
-        }
-    }
-}
-
-
-impl<'a> From<HelloRetryExtensionExtensionData<'a>> for HelloRetryExtensionExtensionDataInner<'a> {
-    fn ex_from(m: HelloRetryExtensionExtensionData<'a>) -> HelloRetryExtensionExtensionDataInner<'a> {
-        match m {
-            HelloRetryExtensionExtensionData::SupportedVersions(m) => Either::Left(m),
-            HelloRetryExtensionExtensionData::Cookie(m) => Either::Right(Either::Left(m)),
-            HelloRetryExtensionExtensionData::KeyShare(m) => Either::Right(Either::Right(Either::Left(m))),
-            HelloRetryExtensionExtensionData::Unrecognized(m) => Either::Right(Either::Right(Either::Right(m))),
-        }
-    }
-
-}
-
-impl<'a> From<HelloRetryExtensionExtensionDataInner<'a>> for HelloRetryExtensionExtensionData<'a> {
-    fn ex_from(m: HelloRetryExtensionExtensionDataInner<'a>) -> HelloRetryExtensionExtensionData<'a> {
-        match m {
-            Either::Left(m) => HelloRetryExtensionExtensionData::SupportedVersions(m),
-            Either::Right(Either::Left(m)) => HelloRetryExtensionExtensionData::Cookie(m),
-            Either::Right(Either::Right(Either::Left(m))) => HelloRetryExtensionExtensionData::KeyShare(m),
-            Either::Right(Either::Right(Either::Right(m))) => HelloRetryExtensionExtensionData::Unrecognized(m),
-        }
-    }
-    
-}
-
-
-pub struct HelloRetryExtensionExtensionDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryExtensionExtensionDataMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        HelloRetryExtensionExtensionDataMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        HelloRetryExtensionExtensionDataMapper(PhantomData)
-    }
-}
-impl View for HelloRetryExtensionExtensionDataMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for HelloRetryExtensionExtensionDataMapper<'_> {
-    type Src = SpecHelloRetryExtensionExtensionDataInner;
-    type Dst = SpecHelloRetryExtensionExtensionData;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for HelloRetryExtensionExtensionDataMapper<'a> {
-    type Src = HelloRetryExtensionExtensionDataInner<'a>;
-    type Dst = HelloRetryExtensionExtensionData<'a>;
-}
-
-
-pub struct SpecHelloRetryExtensionExtensionDataCombinator(SpecHelloRetryExtensionExtensionDataCombinatorAlias);
-
-impl SpecCombinator for SpecHelloRetryExtensionExtensionDataCombinator {
-    type Type = SpecHelloRetryExtensionExtensionData;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecHelloRetryExtensionExtensionDataCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecHelloRetryExtensionExtensionDataCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecHelloRetryExtensionExtensionDataCombinatorAlias = AndThen<Bytes, Mapped<OrdChoice<Cond<SpecSupportedVersionsServerCombinator>, OrdChoice<Cond<SpecCookieCombinator>, OrdChoice<Cond<SpecNamedGroupCombinator>, Cond<Bytes>>>>, HelloRetryExtensionExtensionDataMapper<'static>>>;
-
-pub struct HelloRetryExtensionExtensionDataCombinator<'a>(HelloRetryExtensionExtensionDataCombinatorAlias<'a>);
-
-impl<'a> View for HelloRetryExtensionExtensionDataCombinator<'a> {
-    type V = SpecHelloRetryExtensionExtensionDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHelloRetryExtensionExtensionDataCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryExtensionExtensionDataCombinator<'a> {
-    type Type = HelloRetryExtensionExtensionData<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type HelloRetryExtensionExtensionDataCombinatorAlias<'a> = AndThen<Bytes, Mapped<OrdChoice<Cond<SupportedVersionsServerCombinator>, OrdChoice<Cond<CookieCombinator<'a>>, OrdChoice<Cond<NamedGroupCombinator>, Cond<Bytes>>>>, HelloRetryExtensionExtensionDataMapper<'a>>>;
-
-
-pub closed spec fn spec_hello_retry_extension_extension_data(ext_len: u16, extension_type: SpecExtensionType) -> SpecHelloRetryExtensionExtensionDataCombinator {
-    SpecHelloRetryExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.spec_into()), Mapped { inner: OrdChoice(Cond { cond: extension_type == 43, inner: spec_supported_versions_server() }, OrdChoice(Cond { cond: extension_type == 44, inner: spec_cookie() }, OrdChoice(Cond { cond: extension_type == 51, inner: spec_named_group() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.spec_into()) }))), mapper: HelloRetryExtensionExtensionDataMapper::spec_new() }))
-}
-
-pub fn hello_retry_extension_extension_data<'a>(ext_len: u16, extension_type: ExtensionType) -> (o: HelloRetryExtensionExtensionDataCombinator<'a>)
-    ensures o@ == spec_hello_retry_extension_extension_data(ext_len@, extension_type@),
-{
-    HelloRetryExtensionExtensionDataCombinator(AndThen(Bytes(ext_len.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: extension_type == 43, inner: supported_versions_server() }, OrdChoice::new(Cond { cond: extension_type == 44, inner: cookie() }, OrdChoice::new(Cond { cond: extension_type == 51, inner: named_group() }, Cond { cond: !(extension_type == 0 || extension_type == 1 || extension_type == 5 || extension_type == 10 || extension_type == 11 || extension_type == 13 || extension_type == 14 || extension_type == 15 || extension_type == 16 || extension_type == 18 || extension_type == 19 || extension_type == 20 || extension_type == 21 || extension_type == 22 || extension_type == 23 || extension_type == 35 || extension_type == 41 || extension_type == 42 || extension_type == 43 || extension_type == 44 || extension_type == 45 || extension_type == 47 || extension_type == 48 || extension_type == 49 || extension_type == 50 || extension_type == 51 || extension_type == 65535), inner: Bytes(ext_len.ex_into()) }))), mapper: HelloRetryExtensionExtensionDataMapper::new() }))
-}
-
-
-pub struct SpecHelloRetryExtension {
-    pub extension_type: SpecExtensionType,
-    pub ext_len: u16,
-    pub extension_data: SpecHelloRetryExtensionExtensionData,
-}
-
-pub type SpecHelloRetryExtensionInner = ((SpecExtensionType, u16), SpecHelloRetryExtensionExtensionData);
-impl SpecFrom<SpecHelloRetryExtension> for SpecHelloRetryExtensionInner {
-    open spec fn spec_from(m: SpecHelloRetryExtension) -> SpecHelloRetryExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl SpecFrom<SpecHelloRetryExtensionInner> for SpecHelloRetryExtension {
-    open spec fn spec_from(m: SpecHelloRetryExtensionInner) -> SpecHelloRetryExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        SpecHelloRetryExtension { extension_type, ext_len, extension_data }
+impl SpecFrom<SpecCertificateRequestInner> for SpecCertificateRequest {
+    open spec fn spec_from(m: SpecCertificateRequestInner) -> SpecCertificateRequest {
+        let (certificate_request_context, extensions) = m;
+        SpecCertificateRequest { certificate_request_context, extensions }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 
-pub struct HelloRetryExtension<'a> {
-    pub extension_type: ExtensionType,
-    pub ext_len: u16,
-    pub extension_data: HelloRetryExtensionExtensionData<'a>,
+pub struct CertificateRequest<'a> {
+    pub certificate_request_context: Opaque0Ff<'a>,
+    pub extensions: CertificateRequestExtensions<'a>,
 }
 
-impl View for HelloRetryExtension<'_> {
-    type V = SpecHelloRetryExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecHelloRetryExtension {
-            extension_type: self.extension_type@,
-            ext_len: self.ext_len@,
-            extension_data: self.extension_data@,
-        }
-    }
-}
-pub type HelloRetryExtensionInner<'a> = ((ExtensionType, u16), HelloRetryExtensionExtensionData<'a>);
-impl<'a> From<HelloRetryExtension<'a>> for HelloRetryExtensionInner<'a> {
-    fn ex_from(m: HelloRetryExtension) -> HelloRetryExtensionInner {
-        ((m.extension_type, m.ext_len), m.extension_data)
-    }
-}
-impl<'a> From<HelloRetryExtensionInner<'a>> for HelloRetryExtension<'a> {
-    fn ex_from(m: HelloRetryExtensionInner) -> HelloRetryExtension {
-        let ((extension_type, ext_len), extension_data) = m;
-        HelloRetryExtension { extension_type, ext_len, extension_data }
-    }
-}
-
-pub struct HelloRetryExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        HelloRetryExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        HelloRetryExtensionMapper(PhantomData)
-    }
-}
-impl View for HelloRetryExtensionMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for HelloRetryExtensionMapper<'_> {
-    type Src = SpecHelloRetryExtensionInner;
-    type Dst = SpecHelloRetryExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for HelloRetryExtensionMapper<'a> {
-    type Src = HelloRetryExtensionInner<'a>;
-    type Dst = HelloRetryExtension<'a>;
-}
-
-pub struct SpecHelloRetryExtensionCombinator(SpecHelloRetryExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecHelloRetryExtensionCombinator {
-    type Type = SpecHelloRetryExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecHelloRetryExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecHelloRetryExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecHelloRetryExtensionCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecExtensionTypeCombinator, U16Be>, SpecHelloRetryExtensionExtensionDataCombinator>, HelloRetryExtensionMapper<'static>>;
-
-pub struct HelloRetryExtensionCombinator<'a>(HelloRetryExtensionCombinatorAlias<'a>);
-
-impl<'a> View for HelloRetryExtensionCombinator<'a> {
-    type V = SpecHelloRetryExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHelloRetryExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryExtensionCombinator<'a> {
-    type Type = HelloRetryExtension<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type HelloRetryExtensionCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, ExtensionTypeCombinator, U16Be, HelloRetryExtensionCont1<'a>>, HelloRetryExtensionExtensionDataCombinator<'a>, HelloRetryExtensionCont0<'a>>, HelloRetryExtensionMapper<'a>>;
-
-
-pub closed spec fn spec_hello_retry_extension() -> SpecHelloRetryExtensionCombinator {
-    SpecHelloRetryExtensionCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_extension_type(), snd: |deps| spec_hello_retry_extension_cont1(deps) }, snd: |deps| spec_hello_retry_extension_cont0(deps) },
-        mapper: HelloRetryExtensionMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_hello_retry_extension_cont1(deps: SpecExtensionType) -> U16Be {
-    let extension_type = deps;
-    U16Be
-}
-pub open spec fn spec_hello_retry_extension_cont0(deps: (SpecExtensionType, u16)) -> SpecHelloRetryExtensionExtensionDataCombinator {
-    let (extension_type, ext_len) = deps;
-    spec_hello_retry_extension_extension_data(ext_len, extension_type)
-}
-                
-pub fn hello_retry_extension<'a>() -> (o: HelloRetryExtensionCombinator<'a>)
-    ensures o@ == spec_hello_retry_extension(),
-{
-    HelloRetryExtensionCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: extension_type(), snd: HelloRetryExtensionCont1::new(), spec_snd: Ghost(|deps| spec_hello_retry_extension_cont1(deps)) }, snd: HelloRetryExtensionCont0::new(), spec_snd: Ghost(|deps| spec_hello_retry_extension_cont0(deps)) },
-        mapper: HelloRetryExtensionMapper::new(),
-    })
-}
-
-pub struct HelloRetryExtensionCont1<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryExtensionCont1<'a> {
-    pub fn new() -> Self {
-        HelloRetryExtensionCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&ExtensionType> for HelloRetryExtensionCont1<'a> {
-    type Output = U16Be;
-
-    open spec fn requires(&self, deps: &ExtensionType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &ExtensionType, o: Self::Output) -> bool {
-        o@ == spec_hello_retry_extension_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &ExtensionType) -> Self::Output {
-        let extension_type = *deps;
-        U16Be
-    }
-}
-pub struct HelloRetryExtensionCont0<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryExtensionCont0<'a> {
-    pub fn new() -> Self {
-        HelloRetryExtensionCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(ExtensionType, u16)> for HelloRetryExtensionCont0<'a> {
-    type Output = HelloRetryExtensionExtensionDataCombinator<'a>;
-
-    open spec fn requires(&self, deps: &(ExtensionType, u16)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(ExtensionType, u16), o: Self::Output) -> bool {
-        o@ == spec_hello_retry_extension_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(ExtensionType, u16)) -> Self::Output {
-        let (extension_type, ext_len) = *deps;
-        hello_retry_extension_extension_data(ext_len, extension_type)
-    }
-}
-                
-pub type SpecSrtpProtectionProfile = Seq<u8>;
-pub type SrtpProtectionProfile<'a> = &'a [u8];
-
-
-pub struct SpecSrtpProtectionProfileCombinator(SpecSrtpProtectionProfileCombinatorAlias);
-
-impl SpecCombinator for SpecSrtpProtectionProfileCombinator {
-    type Type = SpecSrtpProtectionProfile;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSrtpProtectionProfileCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSrtpProtectionProfileCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSrtpProtectionProfileCombinatorAlias = BytesN<2>;
-
-pub struct SrtpProtectionProfileCombinator(SrtpProtectionProfileCombinatorAlias);
-
-impl View for SrtpProtectionProfileCombinator {
-    type V = SpecSrtpProtectionProfileCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSrtpProtectionProfileCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SrtpProtectionProfileCombinator {
-    type Type = SrtpProtectionProfile<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SrtpProtectionProfileCombinatorAlias = BytesN<2>;
-
-
-pub closed spec fn spec_srtp_protection_profile() -> SpecSrtpProtectionProfileCombinator {
-    SpecSrtpProtectionProfileCombinator(BytesN::<2>)
-}
-
-                
-pub fn srtp_protection_profile() -> (o: SrtpProtectionProfileCombinator)
-    ensures o@ == spec_srtp_protection_profile(),
-{
-    SrtpProtectionProfileCombinator(BytesN::<2>)
-}
-
-                
-
-pub struct SpecSrtpProtectionProfiles {
-    pub l: u16,
-    pub list: Seq<SpecSrtpProtectionProfile>,
-}
-
-pub type SpecSrtpProtectionProfilesInner = (u16, Seq<SpecSrtpProtectionProfile>);
-impl SpecFrom<SpecSrtpProtectionProfiles> for SpecSrtpProtectionProfilesInner {
-    open spec fn spec_from(m: SpecSrtpProtectionProfiles) -> SpecSrtpProtectionProfilesInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecSrtpProtectionProfilesInner> for SpecSrtpProtectionProfiles {
-    open spec fn spec_from(m: SpecSrtpProtectionProfilesInner) -> SpecSrtpProtectionProfiles {
-        let (l, list) = m;
-        SpecSrtpProtectionProfiles { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct SrtpProtectionProfiles<'a> {
-    pub l: u16,
-    pub list: RepeatResult<SrtpProtectionProfile<'a>>,
-}
-
-impl View for SrtpProtectionProfiles<'_> {
-    type V = SpecSrtpProtectionProfiles;
+impl View for CertificateRequest<'_> {
+    type V = SpecCertificateRequest;
 
     open spec fn view(&self) -> Self::V {
-        SpecSrtpProtectionProfiles {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type SrtpProtectionProfilesInner<'a> = (u16, RepeatResult<SrtpProtectionProfile<'a>>);
-impl<'a> From<SrtpProtectionProfiles<'a>> for SrtpProtectionProfilesInner<'a> {
-    fn ex_from(m: SrtpProtectionProfiles) -> SrtpProtectionProfilesInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<SrtpProtectionProfilesInner<'a>> for SrtpProtectionProfiles<'a> {
-    fn ex_from(m: SrtpProtectionProfilesInner) -> SrtpProtectionProfiles {
-        let (l, list) = m;
-        SrtpProtectionProfiles { l, list }
-    }
-}
-
-pub struct SrtpProtectionProfilesMapper<'a>(PhantomData<&'a ()>);
-impl<'a> SrtpProtectionProfilesMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        SrtpProtectionProfilesMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        SrtpProtectionProfilesMapper(PhantomData)
-    }
-}
-impl View for SrtpProtectionProfilesMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for SrtpProtectionProfilesMapper<'_> {
-    type Src = SpecSrtpProtectionProfilesInner;
-    type Dst = SpecSrtpProtectionProfiles;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for SrtpProtectionProfilesMapper<'a> {
-    type Src = SrtpProtectionProfilesInner<'a>;
-    type Dst = SrtpProtectionProfiles<'a>;
-}
-
-pub struct SpecSrtpProtectionProfilesCombinator(SpecSrtpProtectionProfilesCombinatorAlias);
-
-impl SpecCombinator for SpecSrtpProtectionProfilesCombinator {
-    type Type = SpecSrtpProtectionProfiles;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecSrtpProtectionProfilesCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecSrtpProtectionProfilesCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecSrtpProtectionProfilesCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<SpecSrtpProtectionProfileCombinator>>>, SrtpProtectionProfilesMapper<'static>>;
-
-pub struct SrtpProtectionProfilesCombinator<'a>(SrtpProtectionProfilesCombinatorAlias<'a>);
-
-impl<'a> View for SrtpProtectionProfilesCombinator<'a> {
-    type V = SpecSrtpProtectionProfilesCombinator;
-    closed spec fn view(&self) -> Self::V { SpecSrtpProtectionProfilesCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for SrtpProtectionProfilesCombinator<'a> {
-    type Type = SrtpProtectionProfiles<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type SrtpProtectionProfilesCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<SrtpProtectionProfileCombinator>>, SrtpProtectionProfilesCont0<'a>>, SrtpProtectionProfilesMapper<'a>>;
-
-
-pub closed spec fn spec_srtp_protection_profiles() -> SpecSrtpProtectionProfilesCombinator {
-    SpecSrtpProtectionProfilesCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: |deps| spec_srtp_protection_profiles_cont0(deps) },
-        mapper: SrtpProtectionProfilesMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_srtp_protection_profiles_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSrtpProtectionProfileCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_srtp_protection_profile()))
-}
-                
-pub fn srtp_protection_profiles<'a>() -> (o: SrtpProtectionProfilesCombinator<'a>)
-    ensures o@ == spec_srtp_protection_profiles(),
-{
-    SrtpProtectionProfilesCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: SrtpProtectionProfilesCont0::new(), spec_snd: Ghost(|deps| spec_srtp_protection_profiles_cont0(deps)) },
-        mapper: SrtpProtectionProfilesMapper::new(),
-    })
-}
-
-pub struct SrtpProtectionProfilesCont0<'a>(PhantomData<&'a ()>);
-impl<'a> SrtpProtectionProfilesCont0<'a> {
-    pub fn new() -> Self {
-        SrtpProtectionProfilesCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for SrtpProtectionProfilesCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<SrtpProtectionProfileCombinator>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_srtp_protection_profiles_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(srtp_protection_profile()))
-    }
-}
-                
-
-pub struct SpecServerCertTypeServerExtension {
-    pub server_certificate_type: SpecCertificateType,
-}
-
-pub type SpecServerCertTypeServerExtensionInner = SpecCertificateType;
-impl SpecFrom<SpecServerCertTypeServerExtension> for SpecServerCertTypeServerExtensionInner {
-    open spec fn spec_from(m: SpecServerCertTypeServerExtension) -> SpecServerCertTypeServerExtensionInner {
-        m.server_certificate_type
-    }
-}
-impl SpecFrom<SpecServerCertTypeServerExtensionInner> for SpecServerCertTypeServerExtension {
-    open spec fn spec_from(m: SpecServerCertTypeServerExtensionInner) -> SpecServerCertTypeServerExtension {
-        let server_certificate_type = m;
-        SpecServerCertTypeServerExtension { server_certificate_type }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct ServerCertTypeServerExtension {
-    pub server_certificate_type: CertificateType,
-}
-
-impl View for ServerCertTypeServerExtension {
-    type V = SpecServerCertTypeServerExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecServerCertTypeServerExtension {
-            server_certificate_type: self.server_certificate_type@,
-        }
-    }
-}
-pub type ServerCertTypeServerExtensionInner = CertificateType;
-impl From<ServerCertTypeServerExtension> for ServerCertTypeServerExtensionInner {
-    fn ex_from(m: ServerCertTypeServerExtension) -> ServerCertTypeServerExtensionInner {
-        m.server_certificate_type
-    }
-}
-impl From<ServerCertTypeServerExtensionInner> for ServerCertTypeServerExtension {
-    fn ex_from(m: ServerCertTypeServerExtensionInner) -> ServerCertTypeServerExtension {
-        let server_certificate_type = m;
-        ServerCertTypeServerExtension { server_certificate_type }
-    }
-}
-
-pub struct ServerCertTypeServerExtensionMapper;
-impl ServerCertTypeServerExtensionMapper {
-    pub closed spec fn spec_new() -> Self {
-        ServerCertTypeServerExtensionMapper
-    }
-    pub fn new() -> Self {
-        ServerCertTypeServerExtensionMapper
-    }
-}
-impl View for ServerCertTypeServerExtensionMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ServerCertTypeServerExtensionMapper {
-    type Src = SpecServerCertTypeServerExtensionInner;
-    type Dst = SpecServerCertTypeServerExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl Iso for ServerCertTypeServerExtensionMapper {
-    type Src = ServerCertTypeServerExtensionInner;
-    type Dst = ServerCertTypeServerExtension;
-}
-
-pub struct SpecServerCertTypeServerExtensionCombinator(SpecServerCertTypeServerExtensionCombinatorAlias);
-
-impl SpecCombinator for SpecServerCertTypeServerExtensionCombinator {
-    type Type = SpecServerCertTypeServerExtension;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecServerCertTypeServerExtensionCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecServerCertTypeServerExtensionCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecServerCertTypeServerExtensionCombinatorAlias = Mapped<SpecCertificateTypeCombinator, ServerCertTypeServerExtensionMapper>;
-
-pub struct ServerCertTypeServerExtensionCombinator(ServerCertTypeServerExtensionCombinatorAlias);
-
-impl View for ServerCertTypeServerExtensionCombinator {
-    type V = SpecServerCertTypeServerExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecServerCertTypeServerExtensionCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerCertTypeServerExtensionCombinator {
-    type Type = ServerCertTypeServerExtension;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ServerCertTypeServerExtensionCombinatorAlias = Mapped<CertificateTypeCombinator, ServerCertTypeServerExtensionMapper>;
-
-
-pub closed spec fn spec_server_cert_type_server_extension() -> SpecServerCertTypeServerExtensionCombinator {
-    SpecServerCertTypeServerExtensionCombinator(
-    Mapped {
-        inner: spec_certificate_type(),
-        mapper: ServerCertTypeServerExtensionMapper::spec_new(),
-    })
-}
-
-                
-pub fn server_cert_type_server_extension() -> (o: ServerCertTypeServerExtensionCombinator)
-    ensures o@ == spec_server_cert_type_server_extension(),
-{
-    ServerCertTypeServerExtensionCombinator(
-    Mapped {
-        inner: certificate_type(),
-        mapper: ServerCertTypeServerExtensionMapper::new(),
-    })
-}
-
-                
-
-pub struct SpecUseSrtpData {
-    pub profiles: SpecSrtpProtectionProfiles,
-    pub srtp_mki: SpecOpaque0Ff,
-}
-
-pub type SpecUseSrtpDataInner = (SpecSrtpProtectionProfiles, SpecOpaque0Ff);
-impl SpecFrom<SpecUseSrtpData> for SpecUseSrtpDataInner {
-    open spec fn spec_from(m: SpecUseSrtpData) -> SpecUseSrtpDataInner {
-        (m.profiles, m.srtp_mki)
-    }
-}
-impl SpecFrom<SpecUseSrtpDataInner> for SpecUseSrtpData {
-    open spec fn spec_from(m: SpecUseSrtpDataInner) -> SpecUseSrtpData {
-        let (profiles, srtp_mki) = m;
-        SpecUseSrtpData { profiles, srtp_mki }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct UseSrtpData<'a> {
-    pub profiles: SrtpProtectionProfiles<'a>,
-    pub srtp_mki: Opaque0Ff<'a>,
-}
-
-impl View for UseSrtpData<'_> {
-    type V = SpecUseSrtpData;
-
-    open spec fn view(&self) -> Self::V {
-        SpecUseSrtpData {
-            profiles: self.profiles@,
-            srtp_mki: self.srtp_mki@,
-        }
-    }
-}
-pub type UseSrtpDataInner<'a> = (SrtpProtectionProfiles<'a>, Opaque0Ff<'a>);
-impl<'a> From<UseSrtpData<'a>> for UseSrtpDataInner<'a> {
-    fn ex_from(m: UseSrtpData) -> UseSrtpDataInner {
-        (m.profiles, m.srtp_mki)
-    }
-}
-impl<'a> From<UseSrtpDataInner<'a>> for UseSrtpData<'a> {
-    fn ex_from(m: UseSrtpDataInner) -> UseSrtpData {
-        let (profiles, srtp_mki) = m;
-        UseSrtpData { profiles, srtp_mki }
-    }
-}
-
-pub struct UseSrtpDataMapper<'a>(PhantomData<&'a ()>);
-impl<'a> UseSrtpDataMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        UseSrtpDataMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        UseSrtpDataMapper(PhantomData)
-    }
-}
-impl View for UseSrtpDataMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for UseSrtpDataMapper<'_> {
-    type Src = SpecUseSrtpDataInner;
-    type Dst = SpecUseSrtpData;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for UseSrtpDataMapper<'a> {
-    type Src = UseSrtpDataInner<'a>;
-    type Dst = UseSrtpData<'a>;
-}
-
-pub struct SpecUseSrtpDataCombinator(SpecUseSrtpDataCombinatorAlias);
-
-impl SpecCombinator for SpecUseSrtpDataCombinator {
-    type Type = SpecUseSrtpData;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecUseSrtpDataCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecUseSrtpDataCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecUseSrtpDataCombinatorAlias = Mapped<(SpecSrtpProtectionProfilesCombinator, SpecOpaque0FfCombinator), UseSrtpDataMapper<'static>>;
-
-pub struct UseSrtpDataCombinator<'a>(UseSrtpDataCombinatorAlias<'a>);
-
-impl<'a> View for UseSrtpDataCombinator<'a> {
-    type V = SpecUseSrtpDataCombinator;
-    closed spec fn view(&self) -> Self::V { SpecUseSrtpDataCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for UseSrtpDataCombinator<'a> {
-    type Type = UseSrtpData<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type UseSrtpDataCombinatorAlias<'a> = Mapped<(SrtpProtectionProfilesCombinator<'a>, Opaque0FfCombinator<'a>), UseSrtpDataMapper<'a>>;
-
-
-pub closed spec fn spec_use_srtp_data() -> SpecUseSrtpDataCombinator {
-    SpecUseSrtpDataCombinator(
-    Mapped {
-        inner: (spec_srtp_protection_profiles(), spec_opaque_0_ff()),
-        mapper: UseSrtpDataMapper::spec_new(),
-    })
-}
-
-                
-pub fn use_srtp_data<'a>() -> (o: UseSrtpDataCombinator<'a>)
-    ensures o@ == spec_use_srtp_data(),
-{
-    UseSrtpDataCombinator(
-    Mapped {
-        inner: (srtp_protection_profiles(), opaque_0_ff()),
-        mapper: UseSrtpDataMapper::new(),
-    })
-}
-
-                
-
-pub struct SpecHelloRetryExtensions {
-    pub l: u16,
-    pub list: Seq<SpecHelloRetryExtension>,
-}
-
-pub type SpecHelloRetryExtensionsInner = (u16, Seq<SpecHelloRetryExtension>);
-impl SpecFrom<SpecHelloRetryExtensions> for SpecHelloRetryExtensionsInner {
-    open spec fn spec_from(m: SpecHelloRetryExtensions) -> SpecHelloRetryExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecHelloRetryExtensionsInner> for SpecHelloRetryExtensions {
-    open spec fn spec_from(m: SpecHelloRetryExtensionsInner) -> SpecHelloRetryExtensions {
-        let (l, list) = m;
-        SpecHelloRetryExtensions { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct HelloRetryExtensions<'a> {
-    pub l: u16,
-    pub list: RepeatResult<HelloRetryExtension<'a>>,
-}
-
-impl View for HelloRetryExtensions<'_> {
-    type V = SpecHelloRetryExtensions;
-
-    open spec fn view(&self) -> Self::V {
-        SpecHelloRetryExtensions {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type HelloRetryExtensionsInner<'a> = (u16, RepeatResult<HelloRetryExtension<'a>>);
-impl<'a> From<HelloRetryExtensions<'a>> for HelloRetryExtensionsInner<'a> {
-    fn ex_from(m: HelloRetryExtensions) -> HelloRetryExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<HelloRetryExtensionsInner<'a>> for HelloRetryExtensions<'a> {
-    fn ex_from(m: HelloRetryExtensionsInner) -> HelloRetryExtensions {
-        let (l, list) = m;
-        HelloRetryExtensions { l, list }
-    }
-}
-
-pub struct HelloRetryExtensionsMapper<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryExtensionsMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        HelloRetryExtensionsMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        HelloRetryExtensionsMapper(PhantomData)
-    }
-}
-impl View for HelloRetryExtensionsMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for HelloRetryExtensionsMapper<'_> {
-    type Src = SpecHelloRetryExtensionsInner;
-    type Dst = SpecHelloRetryExtensions;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for HelloRetryExtensionsMapper<'a> {
-    type Src = HelloRetryExtensionsInner<'a>;
-    type Dst = HelloRetryExtensions<'a>;
-}
-
-pub struct SpecHelloRetryExtensionsCombinator(SpecHelloRetryExtensionsCombinatorAlias);
-
-impl SpecCombinator for SpecHelloRetryExtensionsCombinator {
-    type Type = SpecHelloRetryExtensions;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecHelloRetryExtensionsCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecHelloRetryExtensionsCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecHelloRetryExtensionsCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<SpecHelloRetryExtensionCombinator>>>, HelloRetryExtensionsMapper<'static>>;
-
-pub struct HelloRetryExtensionsCombinator<'a>(HelloRetryExtensionsCombinatorAlias<'a>);
-
-impl<'a> View for HelloRetryExtensionsCombinator<'a> {
-    type V = SpecHelloRetryExtensionsCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHelloRetryExtensionsCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryExtensionsCombinator<'a> {
-    type Type = HelloRetryExtensions<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type HelloRetryExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate14496530480760116989>, AndThen<Bytes, Repeat<HelloRetryExtensionCombinator<'a>>>, HelloRetryExtensionsCont0<'a>>, HelloRetryExtensionsMapper<'a>>;
-
-
-pub closed spec fn spec_hello_retry_extensions() -> SpecHelloRetryExtensionsCombinator {
-    SpecHelloRetryExtensionsCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: |deps| spec_hello_retry_extensions_cont0(deps) },
-        mapper: HelloRetryExtensionsMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_hello_retry_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecHelloRetryExtensionCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_hello_retry_extension()))
-}
-                
-pub fn hello_retry_extensions<'a>() -> (o: HelloRetryExtensionsCombinator<'a>)
-    ensures o@ == spec_hello_retry_extensions(),
-{
-    HelloRetryExtensionsCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate14496530480760116989 }, snd: HelloRetryExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_hello_retry_extensions_cont0(deps)) },
-        mapper: HelloRetryExtensionsMapper::new(),
-    })
-}
-
-pub struct HelloRetryExtensionsCont0<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryExtensionsCont0<'a> {
-    pub fn new() -> Self {
-        HelloRetryExtensionsCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for HelloRetryExtensionsCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<HelloRetryExtensionCombinator<'a>>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_hello_retry_extensions_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(hello_retry_extension()))
-    }
-}
-                
-
-pub struct SpecHelloRetryRequest {
-    pub legacy_session_id_echo: SpecSessionId,
-    pub cipher_suite: SpecCipherSuite,
-    pub legacy_compression_method: u8,
-    pub extensions: SpecHelloRetryExtensions,
-}
-
-pub type SpecHelloRetryRequestInner = (SpecSessionId, (SpecCipherSuite, (u8, SpecHelloRetryExtensions)));
-impl SpecFrom<SpecHelloRetryRequest> for SpecHelloRetryRequestInner {
-    open spec fn spec_from(m: SpecHelloRetryRequest) -> SpecHelloRetryRequestInner {
-        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
-    }
-}
-impl SpecFrom<SpecHelloRetryRequestInner> for SpecHelloRetryRequest {
-    open spec fn spec_from(m: SpecHelloRetryRequestInner) -> SpecHelloRetryRequest {
-        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
-        SpecHelloRetryRequest { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct HelloRetryRequest<'a> {
-    pub legacy_session_id_echo: SessionId<'a>,
-    pub cipher_suite: CipherSuite,
-    pub legacy_compression_method: u8,
-    pub extensions: HelloRetryExtensions<'a>,
-}
-
-impl View for HelloRetryRequest<'_> {
-    type V = SpecHelloRetryRequest;
-
-    open spec fn view(&self) -> Self::V {
-        SpecHelloRetryRequest {
-            legacy_session_id_echo: self.legacy_session_id_echo@,
-            cipher_suite: self.cipher_suite@,
-            legacy_compression_method: self.legacy_compression_method@,
+        SpecCertificateRequest {
+            certificate_request_context: self.certificate_request_context@,
             extensions: self.extensions@,
         }
     }
 }
-pub type HelloRetryRequestInner<'a> = (SessionId<'a>, (CipherSuite, (u8, HelloRetryExtensions<'a>)));
-impl<'a> From<HelloRetryRequest<'a>> for HelloRetryRequestInner<'a> {
-    fn ex_from(m: HelloRetryRequest) -> HelloRetryRequestInner {
-        (m.legacy_session_id_echo, (m.cipher_suite, (m.legacy_compression_method, m.extensions)))
+pub type CertificateRequestInner<'a> = (Opaque0Ff<'a>, CertificateRequestExtensions<'a>);
+impl<'a> From<CertificateRequest<'a>> for CertificateRequestInner<'a> {
+    fn ex_from(m: CertificateRequest) -> CertificateRequestInner {
+        (m.certificate_request_context, m.extensions)
     }
 }
-impl<'a> From<HelloRetryRequestInner<'a>> for HelloRetryRequest<'a> {
-    fn ex_from(m: HelloRetryRequestInner) -> HelloRetryRequest {
-        let (legacy_session_id_echo, (cipher_suite, (legacy_compression_method, extensions))) = m;
-        HelloRetryRequest { legacy_session_id_echo, cipher_suite, legacy_compression_method, extensions }
+impl<'a> From<CertificateRequestInner<'a>> for CertificateRequest<'a> {
+    fn ex_from(m: CertificateRequestInner) -> CertificateRequest {
+        let (certificate_request_context, extensions) = m;
+        CertificateRequest { certificate_request_context, extensions }
     }
 }
 
-pub struct HelloRetryRequestMapper<'a>(PhantomData<&'a ()>);
-impl<'a> HelloRetryRequestMapper<'a> {
+pub struct CertificateRequestMapper<'a>(PhantomData<&'a ()>);
+impl<'a> CertificateRequestMapper<'a> {
     pub closed spec fn spec_new() -> Self {
-        HelloRetryRequestMapper(PhantomData)
+        CertificateRequestMapper(PhantomData)
     }
     pub fn new() -> Self {
-        HelloRetryRequestMapper(PhantomData)
+        CertificateRequestMapper(PhantomData)
     }
 }
-impl View for HelloRetryRequestMapper<'_> {
+impl View for CertificateRequestMapper<'_> {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for HelloRetryRequestMapper<'_> {
-    type Src = SpecHelloRetryRequestInner;
-    type Dst = SpecHelloRetryRequest;
+impl SpecIso for CertificateRequestMapper<'_> {
+    type Src = SpecCertificateRequestInner;
+    type Dst = SpecCertificateRequest;
+}
+impl SpecIsoProof for CertificateRequestMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -14805,24 +14959,23 @@ impl SpecIso for HelloRetryRequestMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for HelloRetryRequestMapper<'a> {
-    type Src = HelloRetryRequestInner<'a>;
-    type Dst = HelloRetryRequest<'a>;
+impl<'a> Iso for CertificateRequestMapper<'a> {
+    type Src = CertificateRequestInner<'a>;
+    type Dst = CertificateRequest<'a>;
 }
-pub const HELLORETRYREQUESTLEGACY_COMPRESSION_METHOD_CONST: u8 = 0;
 
-pub struct SpecHelloRetryRequestCombinator(SpecHelloRetryRequestCombinatorAlias);
+pub struct SpecCertificateRequestCombinator(SpecCertificateRequestCombinatorAlias);
 
-impl SpecCombinator for SpecHelloRetryRequestCombinator {
-    type Type = SpecHelloRetryRequest;
+impl SpecCombinator for SpecCertificateRequestCombinator {
+    type Type = SpecCertificateRequest;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecHelloRetryRequestCombinator {
+impl SecureSpecCombinator for SpecCertificateRequestCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecHelloRetryRequestCombinatorAlias::is_prefix_secure() }
+    { SpecCertificateRequestCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -14836,16 +14989,16 @@ impl SecureSpecCombinator for SpecHelloRetryRequestCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecHelloRetryRequestCombinatorAlias = Mapped<(SpecSessionIdCombinator, (SpecCipherSuiteCombinator, (Refined<U8, TagPred<u8>>, SpecHelloRetryExtensionsCombinator))), HelloRetryRequestMapper<'static>>;
+pub type SpecCertificateRequestCombinatorAlias = Mapped<(SpecOpaque0FfCombinator, SpecCertificateRequestExtensionsCombinator), CertificateRequestMapper<'static>>;
 
-pub struct HelloRetryRequestCombinator<'a>(HelloRetryRequestCombinatorAlias<'a>);
+pub struct CertificateRequestCombinator<'a>(CertificateRequestCombinatorAlias<'a>);
 
-impl<'a> View for HelloRetryRequestCombinator<'a> {
-    type V = SpecHelloRetryRequestCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHelloRetryRequestCombinator(self.0@) }
+impl<'a> View for CertificateRequestCombinator<'a> {
+    type V = SpecCertificateRequestCombinator;
+    closed spec fn view(&self) -> Self::V { SpecCertificateRequestCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryRequestCombinator<'a> {
-    type Type = HelloRetryRequest<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateRequestCombinator<'a> {
+    type Type = CertificateRequest<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -14859,1102 +15012,28 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for HelloRetryRequestCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type HelloRetryRequestCombinatorAlias<'a> = Mapped<(SessionIdCombinator<'a>, (CipherSuiteCombinator, (Refined<U8, TagPred<u8>>, HelloRetryExtensionsCombinator<'a>))), HelloRetryRequestMapper<'a>>;
+pub type CertificateRequestCombinatorAlias<'a> = Mapped<(Opaque0FfCombinator<'a>, CertificateRequestExtensionsCombinator<'a>), CertificateRequestMapper<'a>>;
 
 
-pub closed spec fn spec_hello_retry_request() -> SpecHelloRetryRequestCombinator {
-    SpecHelloRetryRequestCombinator(
+pub closed spec fn spec_certificate_request() -> SpecCertificateRequestCombinator {
+    SpecCertificateRequestCombinator(
     Mapped {
-        inner: (spec_session_id(), (spec_cipher_suite(), (Refined { inner: U8, predicate: TagPred(HELLORETRYREQUESTLEGACY_COMPRESSION_METHOD_CONST) }, spec_hello_retry_extensions()))),
-        mapper: HelloRetryRequestMapper::spec_new(),
+        inner: (spec_opaque_0_ff(), spec_certificate_request_extensions()),
+        mapper: CertificateRequestMapper::spec_new(),
     })
 }
 
                 
-pub fn hello_retry_request<'a>() -> (o: HelloRetryRequestCombinator<'a>)
-    ensures o@ == spec_hello_retry_request(),
+pub fn certificate_request<'a>() -> (o: CertificateRequestCombinator<'a>)
+    ensures o@ == spec_certificate_request(),
 {
-    HelloRetryRequestCombinator(
+    CertificateRequestCombinator(
     Mapped {
-        inner: (session_id(), (cipher_suite(), (Refined { inner: U8, predicate: TagPred(HELLORETRYREQUESTLEGACY_COMPRESSION_METHOD_CONST) }, hello_retry_extensions()))),
-        mapper: HelloRetryRequestMapper::new(),
+        inner: (opaque_0_ff(), certificate_request_extensions()),
+        mapper: CertificateRequestMapper::new(),
     })
 }
 
-                
-
-#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum HandshakeType {
-    ClientHello = 1,
-ServerHello = 2,
-NewSessionTicket = 4,
-EndOfEarlyData = 5,
-EncryptedExtensions = 8,
-Certificate = 11,
-CertificateRequest = 13,
-CertificateVerify = 15,
-Finished = 20,
-KeyUpdate = 24
-}
-pub type SpecHandshakeType = HandshakeType;
-
-pub type HandshakeTypeInner = u8;
-
-impl View for HandshakeType {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFrom<HandshakeTypeInner> for HandshakeType {
-    type Error = ();
-
-    open spec fn spec_try_from(v: HandshakeTypeInner) -> Result<HandshakeType, ()> {
-        match v {
-            1u8 => Ok(HandshakeType::ClientHello),
-            2u8 => Ok(HandshakeType::ServerHello),
-            4u8 => Ok(HandshakeType::NewSessionTicket),
-            5u8 => Ok(HandshakeType::EndOfEarlyData),
-            8u8 => Ok(HandshakeType::EncryptedExtensions),
-            11u8 => Ok(HandshakeType::Certificate),
-            13u8 => Ok(HandshakeType::CertificateRequest),
-            15u8 => Ok(HandshakeType::CertificateVerify),
-            20u8 => Ok(HandshakeType::Finished),
-            24u8 => Ok(HandshakeType::KeyUpdate),
-            _ => Err(()),
-        }
-    }
-}
-
-impl SpecTryFrom<HandshakeType> for HandshakeTypeInner {
-    type Error = ();
-
-    open spec fn spec_try_from(v: HandshakeType) -> Result<HandshakeTypeInner, ()> {
-        match v {
-            HandshakeType::ClientHello => Ok(1u8),
-            HandshakeType::ServerHello => Ok(2u8),
-            HandshakeType::NewSessionTicket => Ok(4u8),
-            HandshakeType::EndOfEarlyData => Ok(5u8),
-            HandshakeType::EncryptedExtensions => Ok(8u8),
-            HandshakeType::Certificate => Ok(11u8),
-            HandshakeType::CertificateRequest => Ok(13u8),
-            HandshakeType::CertificateVerify => Ok(15u8),
-            HandshakeType::Finished => Ok(20u8),
-            HandshakeType::KeyUpdate => Ok(24u8),
-        }
-    }
-}
-
-impl TryFrom<HandshakeTypeInner> for HandshakeType {
-    type Error = ();
-
-    fn ex_try_from(v: HandshakeTypeInner) -> Result<HandshakeType, ()> {
-        match v {
-            1u8 => Ok(HandshakeType::ClientHello),
-            2u8 => Ok(HandshakeType::ServerHello),
-            4u8 => Ok(HandshakeType::NewSessionTicket),
-            5u8 => Ok(HandshakeType::EndOfEarlyData),
-            8u8 => Ok(HandshakeType::EncryptedExtensions),
-            11u8 => Ok(HandshakeType::Certificate),
-            13u8 => Ok(HandshakeType::CertificateRequest),
-            15u8 => Ok(HandshakeType::CertificateVerify),
-            20u8 => Ok(HandshakeType::Finished),
-            24u8 => Ok(HandshakeType::KeyUpdate),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<HandshakeType> for HandshakeTypeInner {
-    type Error = ();
-
-    fn ex_try_from(v: HandshakeType) -> Result<HandshakeTypeInner, ()> {
-        match v {
-            HandshakeType::ClientHello => Ok(1u8),
-            HandshakeType::ServerHello => Ok(2u8),
-            HandshakeType::NewSessionTicket => Ok(4u8),
-            HandshakeType::EndOfEarlyData => Ok(5u8),
-            HandshakeType::EncryptedExtensions => Ok(8u8),
-            HandshakeType::Certificate => Ok(11u8),
-            HandshakeType::CertificateRequest => Ok(13u8),
-            HandshakeType::CertificateVerify => Ok(15u8),
-            HandshakeType::Finished => Ok(20u8),
-            HandshakeType::KeyUpdate => Ok(24u8),
-        }
-    }
-}
-
-pub struct HandshakeTypeMapper;
-
-impl View for HandshakeTypeMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFromInto for HandshakeTypeMapper {
-    type Src = HandshakeTypeInner;
-    type Dst = HandshakeType;
-
-    proof fn spec_iso(s: Self::Src) { 
-        assert(
-            Self::spec_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_rev_apply(v) is Ok
-            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) { 
-        assert(
-            Self::spec_rev_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_apply(v) is Ok
-            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-}
-
-impl TryFromInto for HandshakeTypeMapper {
-    type Src = HandshakeTypeInner;
-    type Dst = HandshakeType;
-}
-
-
-pub struct SpecHandshakeTypeCombinator(SpecHandshakeTypeCombinatorAlias);
-
-impl SpecCombinator for SpecHandshakeTypeCombinator {
-    type Type = SpecHandshakeType;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecHandshakeTypeCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecHandshakeTypeCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecHandshakeTypeCombinatorAlias = TryMap<U8, HandshakeTypeMapper>;
-
-pub struct HandshakeTypeCombinator(HandshakeTypeCombinatorAlias);
-
-impl View for HandshakeTypeCombinator {
-    type V = SpecHandshakeTypeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHandshakeTypeCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HandshakeTypeCombinator {
-    type Type = HandshakeType;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type HandshakeTypeCombinatorAlias = TryMap<U8, HandshakeTypeMapper>;
-
-
-pub closed spec fn spec_handshake_type() -> SpecHandshakeTypeCombinator {
-    SpecHandshakeTypeCombinator(TryMap { inner: U8, mapper: HandshakeTypeMapper })
-}
-
-                
-pub fn handshake_type() -> (o: HandshakeTypeCombinator)
-    ensures o@ == spec_handshake_type(),
-{
-    HandshakeTypeCombinator(TryMap { inner: U8, mapper: HandshakeTypeMapper })
-}
-
-                
-
-pub enum SpecShOrHrrPayload {
-    Variant0(SpecHelloRetryRequest),
-    Variant1(SpecServerHello),
-}
-
-pub type SpecShOrHrrPayloadInner = Either<SpecHelloRetryRequest, SpecServerHello>;
-
-
-
-impl SpecFrom<SpecShOrHrrPayload> for SpecShOrHrrPayloadInner {
-    open spec fn spec_from(m: SpecShOrHrrPayload) -> SpecShOrHrrPayloadInner {
-        match m {
-            SpecShOrHrrPayload::Variant0(m) => Either::Left(m),
-            SpecShOrHrrPayload::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl SpecFrom<SpecShOrHrrPayloadInner> for SpecShOrHrrPayload {
-    open spec fn spec_from(m: SpecShOrHrrPayloadInner) -> SpecShOrHrrPayload {
-        match m {
-            Either::Left(m) => SpecShOrHrrPayload::Variant0(m),
-            Either::Right(m) => SpecShOrHrrPayload::Variant1(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ShOrHrrPayload<'a> {
-    Variant0(HelloRetryRequest<'a>),
-    Variant1(ServerHello<'a>),
-}
-
-pub type ShOrHrrPayloadInner<'a> = Either<HelloRetryRequest<'a>, ServerHello<'a>>;
-
-
-impl<'a> View for ShOrHrrPayload<'a> {
-    type V = SpecShOrHrrPayload;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            ShOrHrrPayload::Variant0(m) => SpecShOrHrrPayload::Variant0(m@),
-            ShOrHrrPayload::Variant1(m) => SpecShOrHrrPayload::Variant1(m@),
-        }
-    }
-}
-
-
-impl<'a> From<ShOrHrrPayload<'a>> for ShOrHrrPayloadInner<'a> {
-    fn ex_from(m: ShOrHrrPayload<'a>) -> ShOrHrrPayloadInner<'a> {
-        match m {
-            ShOrHrrPayload::Variant0(m) => Either::Left(m),
-            ShOrHrrPayload::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl<'a> From<ShOrHrrPayloadInner<'a>> for ShOrHrrPayload<'a> {
-    fn ex_from(m: ShOrHrrPayloadInner<'a>) -> ShOrHrrPayload<'a> {
-        match m {
-            Either::Left(m) => ShOrHrrPayload::Variant0(m),
-            Either::Right(m) => ShOrHrrPayload::Variant1(m),
-        }
-    }
-    
-}
-
-
-pub struct ShOrHrrPayloadMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ShOrHrrPayloadMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ShOrHrrPayloadMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ShOrHrrPayloadMapper(PhantomData)
-    }
-}
-impl View for ShOrHrrPayloadMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ShOrHrrPayloadMapper<'_> {
-    type Src = SpecShOrHrrPayloadInner;
-    type Dst = SpecShOrHrrPayload;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for ShOrHrrPayloadMapper<'a> {
-    type Src = ShOrHrrPayloadInner<'a>;
-    type Dst = ShOrHrrPayload<'a>;
-}
-
-
-pub struct SpecShOrHrrPayloadCombinator(SpecShOrHrrPayloadCombinatorAlias);
-
-impl SpecCombinator for SpecShOrHrrPayloadCombinator {
-    type Type = SpecShOrHrrPayload;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecShOrHrrPayloadCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecShOrHrrPayloadCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecShOrHrrPayloadCombinatorAlias = Mapped<OrdChoice<Cond<SpecHelloRetryRequestCombinator>, Cond<SpecServerHelloCombinator>>, ShOrHrrPayloadMapper<'static>>;
-
-pub struct ShOrHrrPayloadCombinator<'a>(ShOrHrrPayloadCombinatorAlias<'a>);
-
-impl<'a> View for ShOrHrrPayloadCombinator<'a> {
-    type V = SpecShOrHrrPayloadCombinator;
-    closed spec fn view(&self) -> Self::V { SpecShOrHrrPayloadCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ShOrHrrPayloadCombinator<'a> {
-    type Type = ShOrHrrPayload<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ShOrHrrPayloadCombinatorAlias<'a> = Mapped<OrdChoice<Cond<HelloRetryRequestCombinator<'a>>, Cond<ServerHelloCombinator<'a>>>, ShOrHrrPayloadMapper<'a>>;
-
-
-pub closed spec fn spec_sh_or_hrr_payload(random: Seq<u8>) -> SpecShOrHrrPayloadCombinator {
-    SpecShOrHrrPayloadCombinator(Mapped { inner: OrdChoice(Cond { cond: random == seq![207u8, 33u8, 173u8, 116u8, 229u8, 154u8, 97u8, 17u8, 190u8, 29u8, 140u8, 2u8, 30u8, 101u8, 184u8, 145u8, 194u8, 162u8, 17u8, 22u8, 122u8, 187u8, 140u8, 94u8, 7u8, 158u8, 9u8, 226u8, 200u8, 168u8, 51u8, 156u8], inner: spec_hello_retry_request() }, Cond { cond: !(random == seq![207u8, 33u8, 173u8, 116u8, 229u8, 154u8, 97u8, 17u8, 190u8, 29u8, 140u8, 2u8, 30u8, 101u8, 184u8, 145u8, 194u8, 162u8, 17u8, 22u8, 122u8, 187u8, 140u8, 94u8, 7u8, 158u8, 9u8, 226u8, 200u8, 168u8, 51u8, 156u8]), inner: spec_server_hello() }), mapper: ShOrHrrPayloadMapper::spec_new() })
-}
-
-pub fn sh_or_hrr_payload<'a>(random: &'a [u8]) -> (o: ShOrHrrPayloadCombinator<'a>)
-    ensures o@ == spec_sh_or_hrr_payload(random@),
-{
-    ShOrHrrPayloadCombinator(Mapped { inner: OrdChoice::new(Cond { cond: compare_slice(random, [207, 33, 173, 116, 229, 154, 97, 17, 190, 29, 140, 2, 30, 101, 184, 145, 194, 162, 17, 22, 122, 187, 140, 94, 7, 158, 9, 226, 200, 168, 51, 156].as_slice()), inner: hello_retry_request() }, Cond { cond: !(compare_slice(random, [207, 33, 173, 116, 229, 154, 97, 17, 190, 29, 140, 2, 30, 101, 184, 145, 194, 162, 17, 22, 122, 187, 140, 94, 7, 158, 9, 226, 200, 168, 51, 156].as_slice())), inner: server_hello() }), mapper: ShOrHrrPayloadMapper::new() })
-}
-
-
-pub struct SpecShOrHrr {
-    pub legacy_version: u16,
-    pub random: Seq<u8>,
-    pub payload: SpecShOrHrrPayload,
-}
-
-pub type SpecShOrHrrInner = ((u16, Seq<u8>), SpecShOrHrrPayload);
-impl SpecFrom<SpecShOrHrr> for SpecShOrHrrInner {
-    open spec fn spec_from(m: SpecShOrHrr) -> SpecShOrHrrInner {
-        ((m.legacy_version, m.random), m.payload)
-    }
-}
-impl SpecFrom<SpecShOrHrrInner> for SpecShOrHrr {
-    open spec fn spec_from(m: SpecShOrHrrInner) -> SpecShOrHrr {
-        let ((legacy_version, random), payload) = m;
-        SpecShOrHrr { legacy_version, random, payload }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct ShOrHrr<'a> {
-    pub legacy_version: u16,
-    pub random: &'a [u8],
-    pub payload: ShOrHrrPayload<'a>,
-}
-
-impl View for ShOrHrr<'_> {
-    type V = SpecShOrHrr;
-
-    open spec fn view(&self) -> Self::V {
-        SpecShOrHrr {
-            legacy_version: self.legacy_version@,
-            random: self.random@,
-            payload: self.payload@,
-        }
-    }
-}
-pub type ShOrHrrInner<'a> = ((u16, &'a [u8]), ShOrHrrPayload<'a>);
-impl<'a> From<ShOrHrr<'a>> for ShOrHrrInner<'a> {
-    fn ex_from(m: ShOrHrr) -> ShOrHrrInner {
-        ((m.legacy_version, m.random), m.payload)
-    }
-}
-impl<'a> From<ShOrHrrInner<'a>> for ShOrHrr<'a> {
-    fn ex_from(m: ShOrHrrInner) -> ShOrHrr {
-        let ((legacy_version, random), payload) = m;
-        ShOrHrr { legacy_version, random, payload }
-    }
-}
-
-pub struct ShOrHrrMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ShOrHrrMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ShOrHrrMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ShOrHrrMapper(PhantomData)
-    }
-}
-impl View for ShOrHrrMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for ShOrHrrMapper<'_> {
-    type Src = SpecShOrHrrInner;
-    type Dst = SpecShOrHrr;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for ShOrHrrMapper<'a> {
-    type Src = ShOrHrrInner<'a>;
-    type Dst = ShOrHrr<'a>;
-}
-pub const SHORHRRLEGACY_VERSION_CONST: u16 = 771;
-
-pub struct SpecShOrHrrCombinator(SpecShOrHrrCombinatorAlias);
-
-impl SpecCombinator for SpecShOrHrrCombinator {
-    type Type = SpecShOrHrr;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecShOrHrrCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecShOrHrrCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecShOrHrrCombinatorAlias = Mapped<SpecDepend<(Refined<U16Be, TagPred<u16>>, BytesN<32>), SpecShOrHrrPayloadCombinator>, ShOrHrrMapper<'static>>;
-
-pub struct ShOrHrrCombinator<'a>(ShOrHrrCombinatorAlias<'a>);
-
-impl<'a> View for ShOrHrrCombinator<'a> {
-    type V = SpecShOrHrrCombinator;
-    closed spec fn view(&self) -> Self::V { SpecShOrHrrCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ShOrHrrCombinator<'a> {
-    type Type = ShOrHrr<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ShOrHrrCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, (Refined<U16Be, TagPred<u16>>, BytesN<32>), ShOrHrrPayloadCombinator<'a>, ShOrHrrCont0<'a>>, ShOrHrrMapper<'a>>;
-
-
-pub closed spec fn spec_sh_or_hrr() -> SpecShOrHrrCombinator {
-    SpecShOrHrrCombinator(
-    Mapped {
-        inner: SpecDepend { fst: (Refined { inner: U16Be, predicate: TagPred(SHORHRRLEGACY_VERSION_CONST) }, BytesN::<32>), snd: |deps| spec_sh_or_hrr_cont0(deps) },
-        mapper: ShOrHrrMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_sh_or_hrr_cont0(deps: (u16, Seq<u8>)) -> SpecShOrHrrPayloadCombinator {
-    let (_, random) = deps;
-    spec_sh_or_hrr_payload(random)
-}
-                
-pub fn sh_or_hrr<'a>() -> (o: ShOrHrrCombinator<'a>)
-    ensures o@ == spec_sh_or_hrr(),
-{
-    ShOrHrrCombinator(
-    Mapped {
-        inner: Depend { fst: (Refined { inner: U16Be, predicate: TagPred(SHORHRRLEGACY_VERSION_CONST) }, BytesN::<32>), snd: ShOrHrrCont0::new(), spec_snd: Ghost(|deps| spec_sh_or_hrr_cont0(deps)) },
-        mapper: ShOrHrrMapper::new(),
-    })
-}
-
-pub struct ShOrHrrCont0<'a>(PhantomData<&'a ()>);
-impl<'a> ShOrHrrCont0<'a> {
-    pub fn new() -> Self {
-        ShOrHrrCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(u16, &'a [u8])> for ShOrHrrCont0<'a> {
-    type Output = ShOrHrrPayloadCombinator<'a>;
-
-    open spec fn requires(&self, deps: &(u16, &'a [u8])) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(u16, &'a [u8]), o: Self::Output) -> bool {
-        o@ == spec_sh_or_hrr_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(u16, &'a [u8])) -> Self::Output {
-        let (_, random) = *deps;
-        sh_or_hrr_payload(random)
-    }
-}
-                
-
-pub struct SpecNewSessionTicketExtensions {
-    pub l: u16,
-    pub list: Seq<SpecNewSessionTicketExtension>,
-}
-
-pub type SpecNewSessionTicketExtensionsInner = (u16, Seq<SpecNewSessionTicketExtension>);
-impl SpecFrom<SpecNewSessionTicketExtensions> for SpecNewSessionTicketExtensionsInner {
-    open spec fn spec_from(m: SpecNewSessionTicketExtensions) -> SpecNewSessionTicketExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecNewSessionTicketExtensionsInner> for SpecNewSessionTicketExtensions {
-    open spec fn spec_from(m: SpecNewSessionTicketExtensionsInner) -> SpecNewSessionTicketExtensions {
-        let (l, list) = m;
-        SpecNewSessionTicketExtensions { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct NewSessionTicketExtensions<'a> {
-    pub l: u16,
-    pub list: RepeatResult<NewSessionTicketExtension<'a>>,
-}
-
-impl View for NewSessionTicketExtensions<'_> {
-    type V = SpecNewSessionTicketExtensions;
-
-    open spec fn view(&self) -> Self::V {
-        SpecNewSessionTicketExtensions {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type NewSessionTicketExtensionsInner<'a> = (u16, RepeatResult<NewSessionTicketExtension<'a>>);
-impl<'a> From<NewSessionTicketExtensions<'a>> for NewSessionTicketExtensionsInner<'a> {
-    fn ex_from(m: NewSessionTicketExtensions) -> NewSessionTicketExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<NewSessionTicketExtensionsInner<'a>> for NewSessionTicketExtensions<'a> {
-    fn ex_from(m: NewSessionTicketExtensionsInner) -> NewSessionTicketExtensions {
-        let (l, list) = m;
-        NewSessionTicketExtensions { l, list }
-    }
-}
-
-pub struct NewSessionTicketExtensionsMapper<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketExtensionsMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        NewSessionTicketExtensionsMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        NewSessionTicketExtensionsMapper(PhantomData)
-    }
-}
-impl View for NewSessionTicketExtensionsMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for NewSessionTicketExtensionsMapper<'_> {
-    type Src = SpecNewSessionTicketExtensionsInner;
-    type Dst = SpecNewSessionTicketExtensions;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for NewSessionTicketExtensionsMapper<'a> {
-    type Src = NewSessionTicketExtensionsInner<'a>;
-    type Dst = NewSessionTicketExtensions<'a>;
-}
-
-pub struct SpecNewSessionTicketExtensionsCombinator(SpecNewSessionTicketExtensionsCombinatorAlias);
-
-impl SpecCombinator for SpecNewSessionTicketExtensionsCombinator {
-    type Type = SpecNewSessionTicketExtensions;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecNewSessionTicketExtensionsCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecNewSessionTicketExtensionsCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecNewSessionTicketExtensionsCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate14514213152276180162>, AndThen<Bytes, Repeat<SpecNewSessionTicketExtensionCombinator>>>, NewSessionTicketExtensionsMapper<'static>>;
-pub struct Predicate14514213152276180162;
-impl View for Predicate14514213152276180162 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred for Predicate14514213152276180162 {
-    type Input = u16;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 0 && i <= 65534)
-    }
-}
-impl SpecPred for Predicate14514213152276180162 {
-    type Input = u16;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 0 && i <= 65534)
-    }
-}
-
-pub struct NewSessionTicketExtensionsCombinator<'a>(NewSessionTicketExtensionsCombinatorAlias<'a>);
-
-impl<'a> View for NewSessionTicketExtensionsCombinator<'a> {
-    type V = SpecNewSessionTicketExtensionsCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketExtensionsCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketExtensionsCombinator<'a> {
-    type Type = NewSessionTicketExtensions<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type NewSessionTicketExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate14514213152276180162>, AndThen<Bytes, Repeat<NewSessionTicketExtensionCombinator<'a>>>, NewSessionTicketExtensionsCont0<'a>>, NewSessionTicketExtensionsMapper<'a>>;
-
-
-pub closed spec fn spec_new_session_ticket_extensions() -> SpecNewSessionTicketExtensionsCombinator {
-    SpecNewSessionTicketExtensionsCombinator(
-    Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate14514213152276180162 }, snd: |deps| spec_new_session_ticket_extensions_cont0(deps) },
-        mapper: NewSessionTicketExtensionsMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_new_session_ticket_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecNewSessionTicketExtensionCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_new_session_ticket_extension()))
-}
-                
-pub fn new_session_ticket_extensions<'a>() -> (o: NewSessionTicketExtensionsCombinator<'a>)
-    ensures o@ == spec_new_session_ticket_extensions(),
-{
-    NewSessionTicketExtensionsCombinator(
-    Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate14514213152276180162 }, snd: NewSessionTicketExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_new_session_ticket_extensions_cont0(deps)) },
-        mapper: NewSessionTicketExtensionsMapper::new(),
-    })
-}
-
-pub struct NewSessionTicketExtensionsCont0<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketExtensionsCont0<'a> {
-    pub fn new() -> Self {
-        NewSessionTicketExtensionsCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for NewSessionTicketExtensionsCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<NewSessionTicketExtensionCombinator<'a>>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_new_session_ticket_extensions_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(new_session_ticket_extension()))
-    }
-}
-                
-
-pub struct SpecNewSessionTicket {
-    pub ticket_lifetime: u32,
-    pub ticket_age_add: u32,
-    pub ticket_nonce: SpecOpaque0Ff,
-    pub ticket: SpecOpaque1Ffff,
-    pub extensions: SpecNewSessionTicketExtensions,
-}
-
-pub type SpecNewSessionTicketInner = (u32, (u32, (SpecOpaque0Ff, (SpecOpaque1Ffff, SpecNewSessionTicketExtensions))));
-impl SpecFrom<SpecNewSessionTicket> for SpecNewSessionTicketInner {
-    open spec fn spec_from(m: SpecNewSessionTicket) -> SpecNewSessionTicketInner {
-        (m.ticket_lifetime, (m.ticket_age_add, (m.ticket_nonce, (m.ticket, m.extensions))))
-    }
-}
-impl SpecFrom<SpecNewSessionTicketInner> for SpecNewSessionTicket {
-    open spec fn spec_from(m: SpecNewSessionTicketInner) -> SpecNewSessionTicket {
-        let (ticket_lifetime, (ticket_age_add, (ticket_nonce, (ticket, extensions)))) = m;
-        SpecNewSessionTicket { ticket_lifetime, ticket_age_add, ticket_nonce, ticket, extensions }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct NewSessionTicket<'a> {
-    pub ticket_lifetime: u32,
-    pub ticket_age_add: u32,
-    pub ticket_nonce: Opaque0Ff<'a>,
-    pub ticket: Opaque1Ffff<'a>,
-    pub extensions: NewSessionTicketExtensions<'a>,
-}
-
-impl View for NewSessionTicket<'_> {
-    type V = SpecNewSessionTicket;
-
-    open spec fn view(&self) -> Self::V {
-        SpecNewSessionTicket {
-            ticket_lifetime: self.ticket_lifetime@,
-            ticket_age_add: self.ticket_age_add@,
-            ticket_nonce: self.ticket_nonce@,
-            ticket: self.ticket@,
-            extensions: self.extensions@,
-        }
-    }
-}
-pub type NewSessionTicketInner<'a> = (u32, (u32, (Opaque0Ff<'a>, (Opaque1Ffff<'a>, NewSessionTicketExtensions<'a>))));
-impl<'a> From<NewSessionTicket<'a>> for NewSessionTicketInner<'a> {
-    fn ex_from(m: NewSessionTicket) -> NewSessionTicketInner {
-        (m.ticket_lifetime, (m.ticket_age_add, (m.ticket_nonce, (m.ticket, m.extensions))))
-    }
-}
-impl<'a> From<NewSessionTicketInner<'a>> for NewSessionTicket<'a> {
-    fn ex_from(m: NewSessionTicketInner) -> NewSessionTicket {
-        let (ticket_lifetime, (ticket_age_add, (ticket_nonce, (ticket, extensions)))) = m;
-        NewSessionTicket { ticket_lifetime, ticket_age_add, ticket_nonce, ticket, extensions }
-    }
-}
-
-pub struct NewSessionTicketMapper<'a>(PhantomData<&'a ()>);
-impl<'a> NewSessionTicketMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        NewSessionTicketMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        NewSessionTicketMapper(PhantomData)
-    }
-}
-impl View for NewSessionTicketMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for NewSessionTicketMapper<'_> {
-    type Src = SpecNewSessionTicketInner;
-    type Dst = SpecNewSessionTicket;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for NewSessionTicketMapper<'a> {
-    type Src = NewSessionTicketInner<'a>;
-    type Dst = NewSessionTicket<'a>;
-}
-
-pub struct SpecNewSessionTicketCombinator(SpecNewSessionTicketCombinatorAlias);
-
-impl SpecCombinator for SpecNewSessionTicketCombinator {
-    type Type = SpecNewSessionTicket;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecNewSessionTicketCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecNewSessionTicketCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecNewSessionTicketCombinatorAlias = Mapped<(U32Be, (U32Be, (SpecOpaque0FfCombinator, (SpecOpaque1FfffCombinator, SpecNewSessionTicketExtensionsCombinator)))), NewSessionTicketMapper<'static>>;
-
-pub struct NewSessionTicketCombinator<'a>(NewSessionTicketCombinatorAlias<'a>);
-
-impl<'a> View for NewSessionTicketCombinator<'a> {
-    type V = SpecNewSessionTicketCombinator;
-    closed spec fn view(&self) -> Self::V { SpecNewSessionTicketCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for NewSessionTicketCombinator<'a> {
-    type Type = NewSessionTicket<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type NewSessionTicketCombinatorAlias<'a> = Mapped<(U32Be, (U32Be, (Opaque0FfCombinator<'a>, (Opaque1FfffCombinator<'a>, NewSessionTicketExtensionsCombinator<'a>)))), NewSessionTicketMapper<'a>>;
-
-
-pub closed spec fn spec_new_session_ticket() -> SpecNewSessionTicketCombinator {
-    SpecNewSessionTicketCombinator(
-    Mapped {
-        inner: (U32Be, (U32Be, (spec_opaque_0_ff(), (spec_opaque_1_ffff(), spec_new_session_ticket_extensions())))),
-        mapper: NewSessionTicketMapper::spec_new(),
-    })
-}
-
-                
-pub fn new_session_ticket<'a>() -> (o: NewSessionTicketCombinator<'a>)
-    ensures o@ == spec_new_session_ticket(),
-{
-    NewSessionTicketCombinator(
-    Mapped {
-        inner: (U32Be, (U32Be, (opaque_0_ff(), (opaque_1_ffff(), new_session_ticket_extensions())))),
-        mapper: NewSessionTicketMapper::new(),
-    })
-}
-
-                
-
-pub struct SpecEncryptedExtensions {
-    pub l: u16,
-    pub list: Seq<SpecEncryptedExtension>,
-}
-
-pub type SpecEncryptedExtensionsInner = (u16, Seq<SpecEncryptedExtension>);
-impl SpecFrom<SpecEncryptedExtensions> for SpecEncryptedExtensionsInner {
-    open spec fn spec_from(m: SpecEncryptedExtensions) -> SpecEncryptedExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl SpecFrom<SpecEncryptedExtensionsInner> for SpecEncryptedExtensions {
-    open spec fn spec_from(m: SpecEncryptedExtensionsInner) -> SpecEncryptedExtensions {
-        let (l, list) = m;
-        SpecEncryptedExtensions { l, list }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct EncryptedExtensions<'a> {
-    pub l: u16,
-    pub list: RepeatResult<EncryptedExtension<'a>>,
-}
-
-impl View for EncryptedExtensions<'_> {
-    type V = SpecEncryptedExtensions;
-
-    open spec fn view(&self) -> Self::V {
-        SpecEncryptedExtensions {
-            l: self.l@,
-            list: self.list@,
-        }
-    }
-}
-pub type EncryptedExtensionsInner<'a> = (u16, RepeatResult<EncryptedExtension<'a>>);
-impl<'a> From<EncryptedExtensions<'a>> for EncryptedExtensionsInner<'a> {
-    fn ex_from(m: EncryptedExtensions) -> EncryptedExtensionsInner {
-        (m.l, m.list)
-    }
-}
-impl<'a> From<EncryptedExtensionsInner<'a>> for EncryptedExtensions<'a> {
-    fn ex_from(m: EncryptedExtensionsInner) -> EncryptedExtensions {
-        let (l, list) = m;
-        EncryptedExtensions { l, list }
-    }
-}
-
-pub struct EncryptedExtensionsMapper<'a>(PhantomData<&'a ()>);
-impl<'a> EncryptedExtensionsMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        EncryptedExtensionsMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        EncryptedExtensionsMapper(PhantomData)
-    }
-}
-impl View for EncryptedExtensionsMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for EncryptedExtensionsMapper<'_> {
-    type Src = SpecEncryptedExtensionsInner;
-    type Dst = SpecEncryptedExtensions;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for EncryptedExtensionsMapper<'a> {
-    type Src = EncryptedExtensionsInner<'a>;
-    type Dst = EncryptedExtensions<'a>;
-}
-
-pub struct SpecEncryptedExtensionsCombinator(SpecEncryptedExtensionsCombinatorAlias);
-
-impl SpecCombinator for SpecEncryptedExtensionsCombinator {
-    type Type = SpecEncryptedExtensions;
-    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
-    { self.0.spec_parse(s) }
-    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecEncryptedExtensionsCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecEncryptedExtensionsCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    closed spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecEncryptedExtensionsCombinatorAlias = Mapped<SpecDepend<U16Be, AndThen<Bytes, Repeat<SpecEncryptedExtensionCombinator>>>, EncryptedExtensionsMapper<'static>>;
-
-pub struct EncryptedExtensionsCombinator<'a>(EncryptedExtensionsCombinatorAlias<'a>);
-
-impl<'a> View for EncryptedExtensionsCombinator<'a> {
-    type V = SpecEncryptedExtensionsCombinator;
-    closed spec fn view(&self) -> Self::V { SpecEncryptedExtensionsCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for EncryptedExtensionsCombinator<'a> {
-    type Type = EncryptedExtensions<'a>;
-    closed spec fn spec_length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
-    fn length(&self) -> Option<usize> 
-    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
-    closed spec fn parse_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
-    closed spec fn serialize_requires(&self) -> bool 
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
-    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type EncryptedExtensionsCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U16Be, AndThen<Bytes, Repeat<EncryptedExtensionCombinator<'a>>>, EncryptedExtensionsCont0<'a>>, EncryptedExtensionsMapper<'a>>;
-
-
-pub closed spec fn spec_encrypted_extensions() -> SpecEncryptedExtensionsCombinator {
-    SpecEncryptedExtensionsCombinator(
-    Mapped {
-        inner: SpecDepend { fst: U16Be, snd: |deps| spec_encrypted_extensions_cont0(deps) },
-        mapper: EncryptedExtensionsMapper::spec_new(),
-    })
-}
-
-pub open spec fn spec_encrypted_extensions_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecEncryptedExtensionCombinator>> {
-    let l = deps;
-    AndThen(Bytes(l.spec_into()), Repeat(spec_encrypted_extension()))
-}
-                
-pub fn encrypted_extensions<'a>() -> (o: EncryptedExtensionsCombinator<'a>)
-    ensures o@ == spec_encrypted_extensions(),
-{
-    EncryptedExtensionsCombinator(
-    Mapped {
-        inner: Depend { fst: U16Be, snd: EncryptedExtensionsCont0::new(), spec_snd: Ghost(|deps| spec_encrypted_extensions_cont0(deps)) },
-        mapper: EncryptedExtensionsMapper::new(),
-    })
-}
-
-pub struct EncryptedExtensionsCont0<'a>(PhantomData<&'a ()>);
-impl<'a> EncryptedExtensionsCont0<'a> {
-    pub fn new() -> Self {
-        EncryptedExtensionsCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&u16> for EncryptedExtensionsCont0<'a> {
-    type Output = AndThen<Bytes, Repeat<EncryptedExtensionCombinator<'a>>>;
-
-    open spec fn requires(&self, deps: &u16) -> bool { true }
-
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_encrypted_extensions_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &u16) -> Self::Output {
-        let l = *deps;
-        AndThen(Bytes(l.ex_into()), Repeat::new(encrypted_extension()))
-    }
-}
                 
 
 pub struct SpecCertificateVerify {
@@ -16022,6 +15101,8 @@ impl View for CertificateVerifyMapper<'_> {
 impl SpecIso for CertificateVerifyMapper<'_> {
     type Src = SpecCertificateVerifyInner;
     type Dst = SpecCertificateVerify;
+}
+impl SpecIsoProof for CertificateVerifyMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -16179,10 +15260,12 @@ impl View for KeyUpdateRequestMapper {
     }
 }
 
-impl SpecTryFromInto for KeyUpdateRequestMapper {
+impl SpecPartialIso for KeyUpdateRequestMapper {
     type Src = KeyUpdateRequestInner;
     type Dst = KeyUpdateRequest;
+}
 
+impl SpecPartialIsoProof for KeyUpdateRequestMapper {
     proof fn spec_iso(s: Self::Src) { 
         assert(
             Self::spec_apply(s) matches Ok(v) ==> {
@@ -16200,7 +15283,7 @@ impl SpecTryFromInto for KeyUpdateRequestMapper {
     }
 }
 
-impl TryFromInto for KeyUpdateRequestMapper {
+impl PartialIso for KeyUpdateRequestMapper {
     type Src = KeyUpdateRequestInner;
     type Dst = KeyUpdateRequest;
 }
@@ -16332,6 +15415,8 @@ impl View for KeyUpdateMapper {
 impl SpecIso for KeyUpdateMapper {
     type Src = SpecKeyUpdateInner;
     type Dst = SpecKeyUpdate;
+}
+impl SpecIsoProof for KeyUpdateMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -16562,6 +15647,8 @@ impl View for HandshakeMsgMapper<'_> {
 impl SpecIso for HandshakeMsgMapper<'_> {
     type Src = SpecHandshakeMsgInner;
     type Dst = SpecHandshakeMsg;
+}
+impl SpecIsoProof for HandshakeMsgMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -16636,99 +15723,22 @@ pub fn handshake_msg<'a>(length: u24, msg_type: HandshakeType) -> (o: HandshakeM
     HandshakeMsgCombinator(AndThen(Bytes(length.ex_into()), Mapped { inner: OrdChoice::new(Cond { cond: msg_type == HandshakeType::ClientHello, inner: client_hello() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::ServerHello, inner: sh_or_hrr() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::NewSessionTicket, inner: new_session_ticket() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::EndOfEarlyData, inner: empty() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::EncryptedExtensions, inner: encrypted_extensions() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::Certificate, inner: certificate() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::CertificateRequest, inner: certificate_request() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::CertificateVerify, inner: certificate_verify() }, OrdChoice::new(Cond { cond: msg_type == HandshakeType::Finished, inner: finished(length) }, Cond { cond: msg_type == HandshakeType::KeyUpdate, inner: key_update() }))))))))), mapper: HandshakeMsgMapper::new() }))
 }
 
+pub type SpecDigestSize = u24;
+pub type DigestSize = u24;
 
-pub struct SpecHandshake {
-    pub msg_type: SpecHandshakeType,
-    pub length: u24,
-    pub msg: SpecHandshakeMsg,
-}
 
-pub type SpecHandshakeInner = ((SpecHandshakeType, u24), SpecHandshakeMsg);
-impl SpecFrom<SpecHandshake> for SpecHandshakeInner {
-    open spec fn spec_from(m: SpecHandshake) -> SpecHandshakeInner {
-        ((m.msg_type, m.length), m.msg)
-    }
-}
-impl SpecFrom<SpecHandshakeInner> for SpecHandshake {
-    open spec fn spec_from(m: SpecHandshakeInner) -> SpecHandshake {
-        let ((msg_type, length), msg) = m;
-        SpecHandshake { msg_type, length, msg }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpecDigestSizeCombinator(SpecDigestSizeCombinatorAlias);
 
-pub struct Handshake<'a> {
-    pub msg_type: HandshakeType,
-    pub length: u24,
-    pub msg: HandshakeMsg<'a>,
-}
-
-impl View for Handshake<'_> {
-    type V = SpecHandshake;
-
-    open spec fn view(&self) -> Self::V {
-        SpecHandshake {
-            msg_type: self.msg_type@,
-            length: self.length@,
-            msg: self.msg@,
-        }
-    }
-}
-pub type HandshakeInner<'a> = ((HandshakeType, u24), HandshakeMsg<'a>);
-impl<'a> From<Handshake<'a>> for HandshakeInner<'a> {
-    fn ex_from(m: Handshake) -> HandshakeInner {
-        ((m.msg_type, m.length), m.msg)
-    }
-}
-impl<'a> From<HandshakeInner<'a>> for Handshake<'a> {
-    fn ex_from(m: HandshakeInner) -> Handshake {
-        let ((msg_type, length), msg) = m;
-        Handshake { msg_type, length, msg }
-    }
-}
-
-pub struct HandshakeMapper<'a>(PhantomData<&'a ()>);
-impl<'a> HandshakeMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        HandshakeMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        HandshakeMapper(PhantomData)
-    }
-}
-impl View for HandshakeMapper<'_> {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for HandshakeMapper<'_> {
-    type Src = SpecHandshakeInner;
-    type Dst = SpecHandshake;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso for HandshakeMapper<'a> {
-    type Src = HandshakeInner<'a>;
-    type Dst = Handshake<'a>;
-}
-
-pub struct SpecHandshakeCombinator(SpecHandshakeCombinatorAlias);
-
-impl SpecCombinator for SpecHandshakeCombinator {
-    type Type = SpecHandshake;
+impl SpecCombinator for SpecDigestSizeCombinator {
+    type Type = SpecDigestSize;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecHandshakeCombinator {
+impl SecureSpecCombinator for SpecDigestSizeCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecHandshakeCombinatorAlias::is_prefix_secure() }
+    { SpecDigestSizeCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -16742,16 +15752,16 @@ impl SecureSpecCombinator for SpecHandshakeCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecHandshakeCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecHandshakeTypeCombinator, U24Be>, SpecHandshakeMsgCombinator>, HandshakeMapper<'static>>;
+pub type SpecDigestSizeCombinatorAlias = U24Be;
 
-pub struct HandshakeCombinator<'a>(HandshakeCombinatorAlias<'a>);
+pub struct DigestSizeCombinator(DigestSizeCombinatorAlias);
 
-impl<'a> View for HandshakeCombinator<'a> {
-    type V = SpecHandshakeCombinator;
-    closed spec fn view(&self) -> Self::V { SpecHandshakeCombinator(self.0@) }
+impl View for DigestSizeCombinator {
+    type V = SpecDigestSizeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecDigestSizeCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for HandshakeCombinator<'a> {
-    type Type = Handshake<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for DigestSizeCombinator {
+    type Type = DigestSize;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -16765,164 +15775,136 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for HandshakeCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type HandshakeCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, HandshakeTypeCombinator, U24Be, HandshakeCont1<'a>>, HandshakeMsgCombinator<'a>, HandshakeCont0<'a>>, HandshakeMapper<'a>>;
+pub type DigestSizeCombinatorAlias = U24Be;
 
 
-pub closed spec fn spec_handshake() -> SpecHandshakeCombinator {
-    SpecHandshakeCombinator(
-    Mapped {
-        inner: SpecDepend { fst: SpecDepend { fst: spec_handshake_type(), snd: |deps| spec_handshake_cont1(deps) }, snd: |deps| spec_handshake_cont0(deps) },
-        mapper: HandshakeMapper::spec_new(),
-    })
+pub closed spec fn spec_digest_size() -> SpecDigestSizeCombinator {
+    SpecDigestSizeCombinator(U24Be)
 }
 
-pub open spec fn spec_handshake_cont1(deps: SpecHandshakeType) -> U24Be {
-    let msg_type = deps;
-    U24Be
-}
-pub open spec fn spec_handshake_cont0(deps: (SpecHandshakeType, u24)) -> SpecHandshakeMsgCombinator {
-    let (msg_type, length) = deps;
-    spec_handshake_msg(length, msg_type)
-}
                 
-pub fn handshake<'a>() -> (o: HandshakeCombinator<'a>)
-    ensures o@ == spec_handshake(),
+pub fn digest_size() -> (o: DigestSizeCombinator)
+    ensures o@ == spec_digest_size(),
 {
-    HandshakeCombinator(
-    Mapped {
-        inner: Depend { fst: Depend { fst: handshake_type(), snd: HandshakeCont1::new(), spec_snd: Ghost(|deps| spec_handshake_cont1(deps)) }, snd: HandshakeCont0::new(), spec_snd: Ghost(|deps| spec_handshake_cont0(deps)) },
-        mapper: HandshakeMapper::new(),
-    })
+    DigestSizeCombinator(U24Be)
 }
 
-pub struct HandshakeCont1<'a>(PhantomData<&'a ()>);
-impl<'a> HandshakeCont1<'a> {
-    pub fn new() -> Self {
-        HandshakeCont1(PhantomData)
-    }
-}
-impl<'a> Continuation<&HandshakeType> for HandshakeCont1<'a> {
-    type Output = U24Be;
-
-    open spec fn requires(&self, deps: &HandshakeType) -> bool { true }
-
-    open spec fn ensures(&self, deps: &HandshakeType, o: Self::Output) -> bool {
-        o@ == spec_handshake_cont1(deps@)
-    }
-
-    fn apply(&self, deps: &HandshakeType) -> Self::Output {
-        let msg_type = *deps;
-        U24Be
-    }
-}
-pub struct HandshakeCont0<'a>(PhantomData<&'a ()>);
-impl<'a> HandshakeCont0<'a> {
-    pub fn new() -> Self {
-        HandshakeCont0(PhantomData)
-    }
-}
-impl<'a> Continuation<&(HandshakeType, u24)> for HandshakeCont0<'a> {
-    type Output = HandshakeMsgCombinator<'a>;
-
-    open spec fn requires(&self, deps: &(HandshakeType, u24)) -> bool { true }
-
-    open spec fn ensures(&self, deps: &(HandshakeType, u24), o: Self::Output) -> bool {
-        o@ == spec_handshake_cont0(deps@)
-    }
-
-    fn apply(&self, deps: &(HandshakeType, u24)) -> Self::Output {
-        let (msg_type, length) = *deps;
-        handshake_msg(length, msg_type)
-    }
-}
                 
 
-pub struct SpecClientCertTypeServerExtension {
-    pub client_certificate_type: SpecCertificateType,
+#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AlertLevel {
+    Warning = 1,
+Fatal = 2
 }
+pub type SpecAlertLevel = AlertLevel;
 
-pub type SpecClientCertTypeServerExtensionInner = SpecCertificateType;
-impl SpecFrom<SpecClientCertTypeServerExtension> for SpecClientCertTypeServerExtensionInner {
-    open spec fn spec_from(m: SpecClientCertTypeServerExtension) -> SpecClientCertTypeServerExtensionInner {
-        m.client_certificate_type
-    }
-}
-impl SpecFrom<SpecClientCertTypeServerExtensionInner> for SpecClientCertTypeServerExtension {
-    open spec fn spec_from(m: SpecClientCertTypeServerExtensionInner) -> SpecClientCertTypeServerExtension {
-        let client_certificate_type = m;
-        SpecClientCertTypeServerExtension { client_certificate_type }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
+pub type AlertLevelInner = u8;
 
-pub struct ClientCertTypeServerExtension {
-    pub client_certificate_type: CertificateType,
-}
-
-impl View for ClientCertTypeServerExtension {
-    type V = SpecClientCertTypeServerExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecClientCertTypeServerExtension {
-            client_certificate_type: self.client_certificate_type@,
-        }
-    }
-}
-pub type ClientCertTypeServerExtensionInner = CertificateType;
-impl From<ClientCertTypeServerExtension> for ClientCertTypeServerExtensionInner {
-    fn ex_from(m: ClientCertTypeServerExtension) -> ClientCertTypeServerExtensionInner {
-        m.client_certificate_type
-    }
-}
-impl From<ClientCertTypeServerExtensionInner> for ClientCertTypeServerExtension {
-    fn ex_from(m: ClientCertTypeServerExtensionInner) -> ClientCertTypeServerExtension {
-        let client_certificate_type = m;
-        ClientCertTypeServerExtension { client_certificate_type }
-    }
-}
-
-pub struct ClientCertTypeServerExtensionMapper;
-impl ClientCertTypeServerExtensionMapper {
-    pub closed spec fn spec_new() -> Self {
-        ClientCertTypeServerExtensionMapper
-    }
-    pub fn new() -> Self {
-        ClientCertTypeServerExtensionMapper
-    }
-}
-impl View for ClientCertTypeServerExtensionMapper {
+impl View for AlertLevel {
     type V = Self;
+
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for ClientCertTypeServerExtensionMapper {
-    type Src = SpecClientCertTypeServerExtensionInner;
-    type Dst = SpecClientCertTypeServerExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+
+impl SpecTryFrom<AlertLevelInner> for AlertLevel {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AlertLevelInner) -> Result<AlertLevel, ()> {
+        match v {
+            1u8 => Ok(AlertLevel::Warning),
+            2u8 => Ok(AlertLevel::Fatal),
+            _ => Err(()),
+        }
     }
 }
-impl Iso for ClientCertTypeServerExtensionMapper {
-    type Src = ClientCertTypeServerExtensionInner;
-    type Dst = ClientCertTypeServerExtension;
+
+impl SpecTryFrom<AlertLevel> for AlertLevelInner {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AlertLevel) -> Result<AlertLevelInner, ()> {
+        match v {
+            AlertLevel::Warning => Ok(1u8),
+            AlertLevel::Fatal => Ok(2u8),
+        }
+    }
 }
 
-pub struct SpecClientCertTypeServerExtensionCombinator(SpecClientCertTypeServerExtensionCombinatorAlias);
+impl TryFrom<AlertLevelInner> for AlertLevel {
+    type Error = ();
 
-impl SpecCombinator for SpecClientCertTypeServerExtensionCombinator {
-    type Type = SpecClientCertTypeServerExtension;
+    fn ex_try_from(v: AlertLevelInner) -> Result<AlertLevel, ()> {
+        match v {
+            1u8 => Ok(AlertLevel::Warning),
+            2u8 => Ok(AlertLevel::Fatal),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<AlertLevel> for AlertLevelInner {
+    type Error = ();
+
+    fn ex_try_from(v: AlertLevel) -> Result<AlertLevelInner, ()> {
+        match v {
+            AlertLevel::Warning => Ok(1u8),
+            AlertLevel::Fatal => Ok(2u8),
+        }
+    }
+}
+
+pub struct AlertLevelMapper;
+
+impl View for AlertLevelMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecPartialIso for AlertLevelMapper {
+    type Src = AlertLevelInner;
+    type Dst = AlertLevel;
+}
+
+impl SpecPartialIsoProof for AlertLevelMapper {
+    proof fn spec_iso(s: Self::Src) { 
+        assert(
+            Self::spec_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_rev_apply(v) is Ok
+            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) { 
+        assert(
+            Self::spec_rev_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_apply(v) is Ok
+            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+}
+
+impl PartialIso for AlertLevelMapper {
+    type Src = AlertLevelInner;
+    type Dst = AlertLevel;
+}
+
+
+pub struct SpecAlertLevelCombinator(SpecAlertLevelCombinatorAlias);
+
+impl SpecCombinator for SpecAlertLevelCombinator {
+    type Type = SpecAlertLevel;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecClientCertTypeServerExtensionCombinator {
+impl SecureSpecCombinator for SpecAlertLevelCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecClientCertTypeServerExtensionCombinatorAlias::is_prefix_secure() }
+    { SpecAlertLevelCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -16936,16 +15918,16 @@ impl SecureSpecCombinator for SpecClientCertTypeServerExtensionCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecClientCertTypeServerExtensionCombinatorAlias = Mapped<SpecCertificateTypeCombinator, ClientCertTypeServerExtensionMapper>;
+pub type SpecAlertLevelCombinatorAlias = TryMap<U8, AlertLevelMapper>;
 
-pub struct ClientCertTypeServerExtensionCombinator(ClientCertTypeServerExtensionCombinatorAlias);
+pub struct AlertLevelCombinator(AlertLevelCombinatorAlias);
 
-impl View for ClientCertTypeServerExtensionCombinator {
-    type V = SpecClientCertTypeServerExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecClientCertTypeServerExtensionCombinator(self.0@) }
+impl View for AlertLevelCombinator {
+    type V = SpecAlertLevelCombinator;
+    closed spec fn view(&self) -> Self::V { SpecAlertLevelCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ClientCertTypeServerExtensionCombinator {
-    type Type = ClientCertTypeServerExtension;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for AlertLevelCombinator {
+    type Type = AlertLevel;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -16959,119 +15941,261 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for ClientCertTypeServerExtensionCombinat
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type ClientCertTypeServerExtensionCombinatorAlias = Mapped<CertificateTypeCombinator, ClientCertTypeServerExtensionMapper>;
+pub type AlertLevelCombinatorAlias = TryMap<U8, AlertLevelMapper>;
 
 
-pub closed spec fn spec_client_cert_type_server_extension() -> SpecClientCertTypeServerExtensionCombinator {
-    SpecClientCertTypeServerExtensionCombinator(
-    Mapped {
-        inner: spec_certificate_type(),
-        mapper: ClientCertTypeServerExtensionMapper::spec_new(),
-    })
+pub closed spec fn spec_alert_level() -> SpecAlertLevelCombinator {
+    SpecAlertLevelCombinator(TryMap { inner: U8, mapper: AlertLevelMapper })
 }
 
                 
-pub fn client_cert_type_server_extension() -> (o: ClientCertTypeServerExtensionCombinator)
-    ensures o@ == spec_client_cert_type_server_extension(),
+pub fn alert_level() -> (o: AlertLevelCombinator)
+    ensures o@ == spec_alert_level(),
 {
-    ClientCertTypeServerExtensionCombinator(
-    Mapped {
-        inner: certificate_type(),
-        mapper: ClientCertTypeServerExtensionMapper::new(),
-    })
+    AlertLevelCombinator(TryMap { inner: U8, mapper: AlertLevelMapper })
 }
 
                 
 
-pub struct SpecExtension {
-    pub extension_type: SpecExtensionType,
-    pub extension_data: SpecOpaque0Ffff,
+#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AlertDescription {
+    CloseNotify = 0,
+UnexpectedMessage = 10,
+BadRecordMac = 20,
+RecordOverflow = 22,
+HandshakeFailure = 40,
+BadCertificate = 42,
+UnsupportedCertificate = 43,
+CertificateRevoked = 44,
+CertificateExpired = 45,
+CertificateUnknown = 46,
+IllegalParameter = 47,
+UnknownCA = 48,
+AccessDenied = 49,
+DecodeError = 50,
+DecryptError = 51,
+ProtocolVersion = 70,
+InsufficientSecurity = 71,
+InternalError = 80,
+InappropriateFallback = 86,
+UserCanceled = 90,
+MissingExtension = 109,
+UnsupportedExtension = 110,
+UnrecognizedName = 112,
+BadCertificateStatusResponse = 113,
+UnknownPSKIdentity = 115,
+CertificateRequired = 116,
+NoApplicationProtocol = 120
 }
+pub type SpecAlertDescription = AlertDescription;
 
-pub type SpecExtensionInner = (SpecExtensionType, SpecOpaque0Ffff);
-impl SpecFrom<SpecExtension> for SpecExtensionInner {
-    open spec fn spec_from(m: SpecExtension) -> SpecExtensionInner {
-        (m.extension_type, m.extension_data)
-    }
-}
-impl SpecFrom<SpecExtensionInner> for SpecExtension {
-    open spec fn spec_from(m: SpecExtensionInner) -> SpecExtension {
-        let (extension_type, extension_data) = m;
-        SpecExtension { extension_type, extension_data }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
+pub type AlertDescriptionInner = u8;
 
-pub struct Extension<'a> {
-    pub extension_type: ExtensionType,
-    pub extension_data: Opaque0Ffff<'a>,
-}
-
-impl View for Extension<'_> {
-    type V = SpecExtension;
-
-    open spec fn view(&self) -> Self::V {
-        SpecExtension {
-            extension_type: self.extension_type@,
-            extension_data: self.extension_data@,
-        }
-    }
-}
-pub type ExtensionInner<'a> = (ExtensionType, Opaque0Ffff<'a>);
-impl<'a> From<Extension<'a>> for ExtensionInner<'a> {
-    fn ex_from(m: Extension) -> ExtensionInner {
-        (m.extension_type, m.extension_data)
-    }
-}
-impl<'a> From<ExtensionInner<'a>> for Extension<'a> {
-    fn ex_from(m: ExtensionInner) -> Extension {
-        let (extension_type, extension_data) = m;
-        Extension { extension_type, extension_data }
-    }
-}
-
-pub struct ExtensionMapper<'a>(PhantomData<&'a ()>);
-impl<'a> ExtensionMapper<'a> {
-    pub closed spec fn spec_new() -> Self {
-        ExtensionMapper(PhantomData)
-    }
-    pub fn new() -> Self {
-        ExtensionMapper(PhantomData)
-    }
-}
-impl View for ExtensionMapper<'_> {
+impl View for AlertDescription {
     type V = Self;
+
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for ExtensionMapper<'_> {
-    type Src = SpecExtensionInner;
-    type Dst = SpecExtension;
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+
+impl SpecTryFrom<AlertDescriptionInner> for AlertDescription {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AlertDescriptionInner) -> Result<AlertDescription, ()> {
+        match v {
+            0u8 => Ok(AlertDescription::CloseNotify),
+            10u8 => Ok(AlertDescription::UnexpectedMessage),
+            20u8 => Ok(AlertDescription::BadRecordMac),
+            22u8 => Ok(AlertDescription::RecordOverflow),
+            40u8 => Ok(AlertDescription::HandshakeFailure),
+            42u8 => Ok(AlertDescription::BadCertificate),
+            43u8 => Ok(AlertDescription::UnsupportedCertificate),
+            44u8 => Ok(AlertDescription::CertificateRevoked),
+            45u8 => Ok(AlertDescription::CertificateExpired),
+            46u8 => Ok(AlertDescription::CertificateUnknown),
+            47u8 => Ok(AlertDescription::IllegalParameter),
+            48u8 => Ok(AlertDescription::UnknownCA),
+            49u8 => Ok(AlertDescription::AccessDenied),
+            50u8 => Ok(AlertDescription::DecodeError),
+            51u8 => Ok(AlertDescription::DecryptError),
+            70u8 => Ok(AlertDescription::ProtocolVersion),
+            71u8 => Ok(AlertDescription::InsufficientSecurity),
+            80u8 => Ok(AlertDescription::InternalError),
+            86u8 => Ok(AlertDescription::InappropriateFallback),
+            90u8 => Ok(AlertDescription::UserCanceled),
+            109u8 => Ok(AlertDescription::MissingExtension),
+            110u8 => Ok(AlertDescription::UnsupportedExtension),
+            112u8 => Ok(AlertDescription::UnrecognizedName),
+            113u8 => Ok(AlertDescription::BadCertificateStatusResponse),
+            115u8 => Ok(AlertDescription::UnknownPSKIdentity),
+            116u8 => Ok(AlertDescription::CertificateRequired),
+            120u8 => Ok(AlertDescription::NoApplicationProtocol),
+            _ => Err(()),
+        }
     }
 }
-impl<'a> Iso for ExtensionMapper<'a> {
-    type Src = ExtensionInner<'a>;
-    type Dst = Extension<'a>;
+
+impl SpecTryFrom<AlertDescription> for AlertDescriptionInner {
+    type Error = ();
+
+    open spec fn spec_try_from(v: AlertDescription) -> Result<AlertDescriptionInner, ()> {
+        match v {
+            AlertDescription::CloseNotify => Ok(0u8),
+            AlertDescription::UnexpectedMessage => Ok(10u8),
+            AlertDescription::BadRecordMac => Ok(20u8),
+            AlertDescription::RecordOverflow => Ok(22u8),
+            AlertDescription::HandshakeFailure => Ok(40u8),
+            AlertDescription::BadCertificate => Ok(42u8),
+            AlertDescription::UnsupportedCertificate => Ok(43u8),
+            AlertDescription::CertificateRevoked => Ok(44u8),
+            AlertDescription::CertificateExpired => Ok(45u8),
+            AlertDescription::CertificateUnknown => Ok(46u8),
+            AlertDescription::IllegalParameter => Ok(47u8),
+            AlertDescription::UnknownCA => Ok(48u8),
+            AlertDescription::AccessDenied => Ok(49u8),
+            AlertDescription::DecodeError => Ok(50u8),
+            AlertDescription::DecryptError => Ok(51u8),
+            AlertDescription::ProtocolVersion => Ok(70u8),
+            AlertDescription::InsufficientSecurity => Ok(71u8),
+            AlertDescription::InternalError => Ok(80u8),
+            AlertDescription::InappropriateFallback => Ok(86u8),
+            AlertDescription::UserCanceled => Ok(90u8),
+            AlertDescription::MissingExtension => Ok(109u8),
+            AlertDescription::UnsupportedExtension => Ok(110u8),
+            AlertDescription::UnrecognizedName => Ok(112u8),
+            AlertDescription::BadCertificateStatusResponse => Ok(113u8),
+            AlertDescription::UnknownPSKIdentity => Ok(115u8),
+            AlertDescription::CertificateRequired => Ok(116u8),
+            AlertDescription::NoApplicationProtocol => Ok(120u8),
+        }
+    }
 }
 
-pub struct SpecExtensionCombinator(SpecExtensionCombinatorAlias);
+impl TryFrom<AlertDescriptionInner> for AlertDescription {
+    type Error = ();
 
-impl SpecCombinator for SpecExtensionCombinator {
-    type Type = SpecExtension;
+    fn ex_try_from(v: AlertDescriptionInner) -> Result<AlertDescription, ()> {
+        match v {
+            0u8 => Ok(AlertDescription::CloseNotify),
+            10u8 => Ok(AlertDescription::UnexpectedMessage),
+            20u8 => Ok(AlertDescription::BadRecordMac),
+            22u8 => Ok(AlertDescription::RecordOverflow),
+            40u8 => Ok(AlertDescription::HandshakeFailure),
+            42u8 => Ok(AlertDescription::BadCertificate),
+            43u8 => Ok(AlertDescription::UnsupportedCertificate),
+            44u8 => Ok(AlertDescription::CertificateRevoked),
+            45u8 => Ok(AlertDescription::CertificateExpired),
+            46u8 => Ok(AlertDescription::CertificateUnknown),
+            47u8 => Ok(AlertDescription::IllegalParameter),
+            48u8 => Ok(AlertDescription::UnknownCA),
+            49u8 => Ok(AlertDescription::AccessDenied),
+            50u8 => Ok(AlertDescription::DecodeError),
+            51u8 => Ok(AlertDescription::DecryptError),
+            70u8 => Ok(AlertDescription::ProtocolVersion),
+            71u8 => Ok(AlertDescription::InsufficientSecurity),
+            80u8 => Ok(AlertDescription::InternalError),
+            86u8 => Ok(AlertDescription::InappropriateFallback),
+            90u8 => Ok(AlertDescription::UserCanceled),
+            109u8 => Ok(AlertDescription::MissingExtension),
+            110u8 => Ok(AlertDescription::UnsupportedExtension),
+            112u8 => Ok(AlertDescription::UnrecognizedName),
+            113u8 => Ok(AlertDescription::BadCertificateStatusResponse),
+            115u8 => Ok(AlertDescription::UnknownPSKIdentity),
+            116u8 => Ok(AlertDescription::CertificateRequired),
+            120u8 => Ok(AlertDescription::NoApplicationProtocol),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<AlertDescription> for AlertDescriptionInner {
+    type Error = ();
+
+    fn ex_try_from(v: AlertDescription) -> Result<AlertDescriptionInner, ()> {
+        match v {
+            AlertDescription::CloseNotify => Ok(0u8),
+            AlertDescription::UnexpectedMessage => Ok(10u8),
+            AlertDescription::BadRecordMac => Ok(20u8),
+            AlertDescription::RecordOverflow => Ok(22u8),
+            AlertDescription::HandshakeFailure => Ok(40u8),
+            AlertDescription::BadCertificate => Ok(42u8),
+            AlertDescription::UnsupportedCertificate => Ok(43u8),
+            AlertDescription::CertificateRevoked => Ok(44u8),
+            AlertDescription::CertificateExpired => Ok(45u8),
+            AlertDescription::CertificateUnknown => Ok(46u8),
+            AlertDescription::IllegalParameter => Ok(47u8),
+            AlertDescription::UnknownCA => Ok(48u8),
+            AlertDescription::AccessDenied => Ok(49u8),
+            AlertDescription::DecodeError => Ok(50u8),
+            AlertDescription::DecryptError => Ok(51u8),
+            AlertDescription::ProtocolVersion => Ok(70u8),
+            AlertDescription::InsufficientSecurity => Ok(71u8),
+            AlertDescription::InternalError => Ok(80u8),
+            AlertDescription::InappropriateFallback => Ok(86u8),
+            AlertDescription::UserCanceled => Ok(90u8),
+            AlertDescription::MissingExtension => Ok(109u8),
+            AlertDescription::UnsupportedExtension => Ok(110u8),
+            AlertDescription::UnrecognizedName => Ok(112u8),
+            AlertDescription::BadCertificateStatusResponse => Ok(113u8),
+            AlertDescription::UnknownPSKIdentity => Ok(115u8),
+            AlertDescription::CertificateRequired => Ok(116u8),
+            AlertDescription::NoApplicationProtocol => Ok(120u8),
+        }
+    }
+}
+
+pub struct AlertDescriptionMapper;
+
+impl View for AlertDescriptionMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecPartialIso for AlertDescriptionMapper {
+    type Src = AlertDescriptionInner;
+    type Dst = AlertDescription;
+}
+
+impl SpecPartialIsoProof for AlertDescriptionMapper {
+    proof fn spec_iso(s: Self::Src) { 
+        assert(
+            Self::spec_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_rev_apply(v) is Ok
+            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) { 
+        assert(
+            Self::spec_rev_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_apply(v) is Ok
+            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+}
+
+impl PartialIso for AlertDescriptionMapper {
+    type Src = AlertDescriptionInner;
+    type Dst = AlertDescription;
+}
+
+
+pub struct SpecAlertDescriptionCombinator(SpecAlertDescriptionCombinatorAlias);
+
+impl SpecCombinator for SpecAlertDescriptionCombinator {
+    type Type = SpecAlertDescription;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecExtensionCombinator {
+impl SecureSpecCombinator for SpecAlertDescriptionCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecExtensionCombinatorAlias::is_prefix_secure() }
+    { SpecAlertDescriptionCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -17085,16 +16209,16 @@ impl SecureSpecCombinator for SpecExtensionCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecExtensionCombinatorAlias = Mapped<(SpecExtensionTypeCombinator, SpecOpaque0FfffCombinator), ExtensionMapper<'static>>;
+pub type SpecAlertDescriptionCombinatorAlias = TryMap<U8, AlertDescriptionMapper>;
 
-pub struct ExtensionCombinator<'a>(ExtensionCombinatorAlias<'a>);
+pub struct AlertDescriptionCombinator(AlertDescriptionCombinatorAlias);
 
-impl<'a> View for ExtensionCombinator<'a> {
-    type V = SpecExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecExtensionCombinator(self.0@) }
+impl View for AlertDescriptionCombinator {
+    type V = SpecAlertDescriptionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecAlertDescriptionCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for ExtensionCombinator<'a> {
-    type Type = Extension<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for AlertDescriptionCombinator {
+    type Type = AlertDescription;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -17108,95 +16232,89 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for ExtensionCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type ExtensionCombinatorAlias<'a> = Mapped<(ExtensionTypeCombinator, Opaque0FfffCombinator<'a>), ExtensionMapper<'a>>;
+pub type AlertDescriptionCombinatorAlias = TryMap<U8, AlertDescriptionMapper>;
 
 
-pub closed spec fn spec_extension() -> SpecExtensionCombinator {
-    SpecExtensionCombinator(
-    Mapped {
-        inner: (spec_extension_type(), spec_opaque_0_ffff()),
-        mapper: ExtensionMapper::spec_new(),
-    })
+pub closed spec fn spec_alert_description() -> SpecAlertDescriptionCombinator {
+    SpecAlertDescriptionCombinator(TryMap { inner: U8, mapper: AlertDescriptionMapper })
 }
 
                 
-pub fn extension<'a>() -> (o: ExtensionCombinator<'a>)
-    ensures o@ == spec_extension(),
+pub fn alert_description() -> (o: AlertDescriptionCombinator)
+    ensures o@ == spec_alert_description(),
 {
-    ExtensionCombinator(
-    Mapped {
-        inner: (extension_type(), opaque_0_ffff()),
-        mapper: ExtensionMapper::new(),
-    })
+    AlertDescriptionCombinator(TryMap { inner: U8, mapper: AlertDescriptionMapper })
 }
 
                 
 
-pub struct SpecOpaque2Ffff {
-    pub l: u16,
+pub struct SpecOpaque0Ffffff {
+    pub l: u24,
     pub data: Seq<u8>,
 }
 
-pub type SpecOpaque2FfffInner = (u16, Seq<u8>);
-impl SpecFrom<SpecOpaque2Ffff> for SpecOpaque2FfffInner {
-    open spec fn spec_from(m: SpecOpaque2Ffff) -> SpecOpaque2FfffInner {
+pub type SpecOpaque0FfffffInner = (u24, Seq<u8>);
+impl SpecFrom<SpecOpaque0Ffffff> for SpecOpaque0FfffffInner {
+    open spec fn spec_from(m: SpecOpaque0Ffffff) -> SpecOpaque0FfffffInner {
         (m.l, m.data)
     }
 }
-impl SpecFrom<SpecOpaque2FfffInner> for SpecOpaque2Ffff {
-    open spec fn spec_from(m: SpecOpaque2FfffInner) -> SpecOpaque2Ffff {
+impl SpecFrom<SpecOpaque0FfffffInner> for SpecOpaque0Ffffff {
+    open spec fn spec_from(m: SpecOpaque0FfffffInner) -> SpecOpaque0Ffffff {
         let (l, data) = m;
-        SpecOpaque2Ffff { l, data }
+        SpecOpaque0Ffffff { l, data }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 
-pub struct Opaque2Ffff<'a> {
-    pub l: u16,
+pub struct Opaque0Ffffff<'a> {
+    pub l: u24,
     pub data: &'a [u8],
 }
 
-impl View for Opaque2Ffff<'_> {
-    type V = SpecOpaque2Ffff;
+impl View for Opaque0Ffffff<'_> {
+    type V = SpecOpaque0Ffffff;
 
     open spec fn view(&self) -> Self::V {
-        SpecOpaque2Ffff {
+        SpecOpaque0Ffffff {
             l: self.l@,
             data: self.data@,
         }
     }
 }
-pub type Opaque2FfffInner<'a> = (u16, &'a [u8]);
-impl<'a> From<Opaque2Ffff<'a>> for Opaque2FfffInner<'a> {
-    fn ex_from(m: Opaque2Ffff) -> Opaque2FfffInner {
+pub type Opaque0FfffffInner<'a> = (u24, &'a [u8]);
+impl<'a> From<Opaque0Ffffff<'a>> for Opaque0FfffffInner<'a> {
+    fn ex_from(m: Opaque0Ffffff) -> Opaque0FfffffInner {
         (m.l, m.data)
     }
 }
-impl<'a> From<Opaque2FfffInner<'a>> for Opaque2Ffff<'a> {
-    fn ex_from(m: Opaque2FfffInner) -> Opaque2Ffff {
+impl<'a> From<Opaque0FfffffInner<'a>> for Opaque0Ffffff<'a> {
+    fn ex_from(m: Opaque0FfffffInner) -> Opaque0Ffffff {
         let (l, data) = m;
-        Opaque2Ffff { l, data }
+        Opaque0Ffffff { l, data }
     }
 }
 
-pub struct Opaque2FfffMapper<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque2FfffMapper<'a> {
+pub struct Opaque0FfffffMapper<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque0FfffffMapper<'a> {
     pub closed spec fn spec_new() -> Self {
-        Opaque2FfffMapper(PhantomData)
+        Opaque0FfffffMapper(PhantomData)
     }
     pub fn new() -> Self {
-        Opaque2FfffMapper(PhantomData)
+        Opaque0FfffffMapper(PhantomData)
     }
 }
-impl View for Opaque2FfffMapper<'_> {
+impl View for Opaque0FfffffMapper<'_> {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for Opaque2FfffMapper<'_> {
-    type Src = SpecOpaque2FfffInner;
-    type Dst = SpecOpaque2Ffff;
+impl SpecIso for Opaque0FfffffMapper<'_> {
+    type Src = SpecOpaque0FfffffInner;
+    type Dst = SpecOpaque0Ffffff;
+}
+impl SpecIsoProof for Opaque0FfffffMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -17204,23 +16322,23 @@ impl SpecIso for Opaque2FfffMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for Opaque2FfffMapper<'a> {
-    type Src = Opaque2FfffInner<'a>;
-    type Dst = Opaque2Ffff<'a>;
+impl<'a> Iso for Opaque0FfffffMapper<'a> {
+    type Src = Opaque0FfffffInner<'a>;
+    type Dst = Opaque0Ffffff<'a>;
 }
 
-pub struct SpecOpaque2FfffCombinator(SpecOpaque2FfffCombinatorAlias);
+pub struct SpecOpaque0FfffffCombinator(SpecOpaque0FfffffCombinatorAlias);
 
-impl SpecCombinator for SpecOpaque2FfffCombinator {
-    type Type = SpecOpaque2Ffff;
+impl SpecCombinator for SpecOpaque0FfffffCombinator {
+    type Type = SpecOpaque0Ffffff;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecOpaque2FfffCombinator {
+impl SecureSpecCombinator for SpecOpaque0FfffffCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecOpaque2FfffCombinatorAlias::is_prefix_secure() }
+    { SpecOpaque0FfffffCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -17234,40 +16352,16 @@ impl SecureSpecCombinator for SpecOpaque2FfffCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecOpaque2FfffCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate3016150102856496288>, Bytes>, Opaque2FfffMapper<'static>>;
-pub struct Predicate3016150102856496288;
-impl View for Predicate3016150102856496288 {
-    type V = Self;
+pub type SpecOpaque0FfffffCombinatorAlias = Mapped<SpecDepend<U24Be, Bytes>, Opaque0FfffffMapper<'static>>;
 
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
+pub struct Opaque0FfffffCombinator<'a>(Opaque0FfffffCombinatorAlias<'a>);
+
+impl<'a> View for Opaque0FfffffCombinator<'a> {
+    type V = SpecOpaque0FfffffCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOpaque0FfffffCombinator(self.0@) }
 }
-impl Pred for Predicate3016150102856496288 {
-    type Input = u16;
-
-    fn apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 2 && i <= 65535)
-    }
-}
-impl SpecPred for Predicate3016150102856496288 {
-    type Input = u16;
-
-    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
-        let i = (*i);
-        (i >= 2 && i <= 65535)
-    }
-}
-
-pub struct Opaque2FfffCombinator<'a>(Opaque2FfffCombinatorAlias<'a>);
-
-impl<'a> View for Opaque2FfffCombinator<'a> {
-    type V = SpecOpaque2FfffCombinator;
-    closed spec fn view(&self) -> Self::V { SpecOpaque2FfffCombinator(self.0@) }
-}
-impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque2FfffCombinator<'a> {
-    type Type = Opaque2Ffff<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque0FfffffCombinator<'a> {
+    type Type = Opaque0Ffffff<'a>;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -17281,48 +16375,48 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque2FfffCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type Opaque2FfffCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate3016150102856496288>, Bytes, Opaque2FfffCont0<'a>>, Opaque2FfffMapper<'a>>;
+pub type Opaque0FfffffCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, U24Be, Bytes, Opaque0FfffffCont0<'a>>, Opaque0FfffffMapper<'a>>;
 
 
-pub closed spec fn spec_opaque_2_ffff() -> SpecOpaque2FfffCombinator {
-    SpecOpaque2FfffCombinator(
+pub closed spec fn spec_opaque_0_ffffff() -> SpecOpaque0FfffffCombinator {
+    SpecOpaque0FfffffCombinator(
     Mapped {
-        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate3016150102856496288 }, snd: |deps| spec_opaque2_ffff_cont0(deps) },
-        mapper: Opaque2FfffMapper::spec_new(),
+        inner: SpecDepend { fst: U24Be, snd: |deps| spec_opaque0_ffffff_cont0(deps) },
+        mapper: Opaque0FfffffMapper::spec_new(),
     })
 }
 
-pub open spec fn spec_opaque2_ffff_cont0(deps: u16) -> Bytes {
+pub open spec fn spec_opaque0_ffffff_cont0(deps: u24) -> Bytes {
     let l = deps;
     Bytes(l.spec_into())
 }
                 
-pub fn opaque_2_ffff<'a>() -> (o: Opaque2FfffCombinator<'a>)
-    ensures o@ == spec_opaque_2_ffff(),
+pub fn opaque_0_ffffff<'a>() -> (o: Opaque0FfffffCombinator<'a>)
+    ensures o@ == spec_opaque_0_ffffff(),
 {
-    Opaque2FfffCombinator(
+    Opaque0FfffffCombinator(
     Mapped {
-        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate3016150102856496288 }, snd: Opaque2FfffCont0::new(), spec_snd: Ghost(|deps| spec_opaque2_ffff_cont0(deps)) },
-        mapper: Opaque2FfffMapper::new(),
+        inner: Depend { fst: U24Be, snd: Opaque0FfffffCont0::new(), spec_snd: Ghost(|deps| spec_opaque0_ffffff_cont0(deps)) },
+        mapper: Opaque0FfffffMapper::new(),
     })
 }
 
-pub struct Opaque2FfffCont0<'a>(PhantomData<&'a ()>);
-impl<'a> Opaque2FfffCont0<'a> {
+pub struct Opaque0FfffffCont0<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque0FfffffCont0<'a> {
     pub fn new() -> Self {
-        Opaque2FfffCont0(PhantomData)
+        Opaque0FfffffCont0(PhantomData)
     }
 }
-impl<'a> Continuation<&u16> for Opaque2FfffCont0<'a> {
+impl<'a> Continuation<&u24> for Opaque0FfffffCont0<'a> {
     type Output = Bytes;
 
-    open spec fn requires(&self, deps: &u16) -> bool { true }
+    open spec fn requires(&self, deps: &u24) -> bool { true }
 
-    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
-        o@ == spec_opaque2_ffff_cont0(deps@)
+    open spec fn ensures(&self, deps: &u24, o: Self::Output) -> bool {
+        o@ == spec_opaque0_ffffff_cont0(deps@)
     }
 
-    fn apply(&self, deps: &u16) -> Self::Output {
+    fn apply(&self, deps: &u24) -> Self::Output {
         let l = *deps;
         Bytes(l.ex_into())
     }
@@ -17417,10 +16511,12 @@ impl View for ContentTypeMapper {
     }
 }
 
-impl SpecTryFromInto for ContentTypeMapper {
+impl SpecPartialIso for ContentTypeMapper {
     type Src = ContentTypeInner;
     type Dst = ContentType;
+}
 
+impl SpecPartialIsoProof for ContentTypeMapper {
     proof fn spec_iso(s: Self::Src) { 
         assert(
             Self::spec_apply(s) matches Ok(v) ==> {
@@ -17438,7 +16534,7 @@ impl SpecTryFromInto for ContentTypeMapper {
     }
 }
 
-impl TryFromInto for ContentTypeMapper {
+impl PartialIso for ContentTypeMapper {
     type Src = ContentTypeInner;
     type Dst = ContentType;
 }
@@ -17641,6 +16737,8 @@ impl View for TlsCiphertextMapper<'_> {
 impl SpecIso for TlsCiphertextMapper<'_> {
     type Src = SpecTlsCiphertextInner;
     type Dst = SpecTlsCiphertext;
+}
+impl SpecIsoProof for TlsCiphertextMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -17724,22 +16822,161 @@ pub fn tls_ciphertext<'a>() -> (o: TlsCiphertextCombinator<'a>)
 }
 
                 
-pub type SpecUnknownExtension = SpecOpaque0Ffff;
-pub type UnknownExtension<'a> = Opaque0Ffff<'a>;
+
+#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HandshakeType {
+    ClientHello = 1,
+ServerHello = 2,
+NewSessionTicket = 4,
+EndOfEarlyData = 5,
+EncryptedExtensions = 8,
+Certificate = 11,
+CertificateRequest = 13,
+CertificateVerify = 15,
+Finished = 20,
+KeyUpdate = 24
+}
+pub type SpecHandshakeType = HandshakeType;
+
+pub type HandshakeTypeInner = u8;
+
+impl View for HandshakeType {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecTryFrom<HandshakeTypeInner> for HandshakeType {
+    type Error = ();
+
+    open spec fn spec_try_from(v: HandshakeTypeInner) -> Result<HandshakeType, ()> {
+        match v {
+            1u8 => Ok(HandshakeType::ClientHello),
+            2u8 => Ok(HandshakeType::ServerHello),
+            4u8 => Ok(HandshakeType::NewSessionTicket),
+            5u8 => Ok(HandshakeType::EndOfEarlyData),
+            8u8 => Ok(HandshakeType::EncryptedExtensions),
+            11u8 => Ok(HandshakeType::Certificate),
+            13u8 => Ok(HandshakeType::CertificateRequest),
+            15u8 => Ok(HandshakeType::CertificateVerify),
+            20u8 => Ok(HandshakeType::Finished),
+            24u8 => Ok(HandshakeType::KeyUpdate),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SpecTryFrom<HandshakeType> for HandshakeTypeInner {
+    type Error = ();
+
+    open spec fn spec_try_from(v: HandshakeType) -> Result<HandshakeTypeInner, ()> {
+        match v {
+            HandshakeType::ClientHello => Ok(1u8),
+            HandshakeType::ServerHello => Ok(2u8),
+            HandshakeType::NewSessionTicket => Ok(4u8),
+            HandshakeType::EndOfEarlyData => Ok(5u8),
+            HandshakeType::EncryptedExtensions => Ok(8u8),
+            HandshakeType::Certificate => Ok(11u8),
+            HandshakeType::CertificateRequest => Ok(13u8),
+            HandshakeType::CertificateVerify => Ok(15u8),
+            HandshakeType::Finished => Ok(20u8),
+            HandshakeType::KeyUpdate => Ok(24u8),
+        }
+    }
+}
+
+impl TryFrom<HandshakeTypeInner> for HandshakeType {
+    type Error = ();
+
+    fn ex_try_from(v: HandshakeTypeInner) -> Result<HandshakeType, ()> {
+        match v {
+            1u8 => Ok(HandshakeType::ClientHello),
+            2u8 => Ok(HandshakeType::ServerHello),
+            4u8 => Ok(HandshakeType::NewSessionTicket),
+            5u8 => Ok(HandshakeType::EndOfEarlyData),
+            8u8 => Ok(HandshakeType::EncryptedExtensions),
+            11u8 => Ok(HandshakeType::Certificate),
+            13u8 => Ok(HandshakeType::CertificateRequest),
+            15u8 => Ok(HandshakeType::CertificateVerify),
+            20u8 => Ok(HandshakeType::Finished),
+            24u8 => Ok(HandshakeType::KeyUpdate),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<HandshakeType> for HandshakeTypeInner {
+    type Error = ();
+
+    fn ex_try_from(v: HandshakeType) -> Result<HandshakeTypeInner, ()> {
+        match v {
+            HandshakeType::ClientHello => Ok(1u8),
+            HandshakeType::ServerHello => Ok(2u8),
+            HandshakeType::NewSessionTicket => Ok(4u8),
+            HandshakeType::EndOfEarlyData => Ok(5u8),
+            HandshakeType::EncryptedExtensions => Ok(8u8),
+            HandshakeType::Certificate => Ok(11u8),
+            HandshakeType::CertificateRequest => Ok(13u8),
+            HandshakeType::CertificateVerify => Ok(15u8),
+            HandshakeType::Finished => Ok(20u8),
+            HandshakeType::KeyUpdate => Ok(24u8),
+        }
+    }
+}
+
+pub struct HandshakeTypeMapper;
+
+impl View for HandshakeTypeMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecPartialIso for HandshakeTypeMapper {
+    type Src = HandshakeTypeInner;
+    type Dst = HandshakeType;
+}
+
+impl SpecPartialIsoProof for HandshakeTypeMapper {
+    proof fn spec_iso(s: Self::Src) { 
+        assert(
+            Self::spec_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_rev_apply(v) is Ok
+            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) { 
+        assert(
+            Self::spec_rev_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_apply(v) is Ok
+            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+}
+
+impl PartialIso for HandshakeTypeMapper {
+    type Src = HandshakeTypeInner;
+    type Dst = HandshakeType;
+}
 
 
-pub struct SpecUnknownExtensionCombinator(SpecUnknownExtensionCombinatorAlias);
+pub struct SpecHandshakeTypeCombinator(SpecHandshakeTypeCombinatorAlias);
 
-impl SpecCombinator for SpecUnknownExtensionCombinator {
-    type Type = SpecUnknownExtension;
+impl SpecCombinator for SpecHandshakeTypeCombinator {
+    type Type = SpecHandshakeType;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecUnknownExtensionCombinator {
+impl SecureSpecCombinator for SpecHandshakeTypeCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecUnknownExtensionCombinatorAlias::is_prefix_secure() }
+    { SpecHandshakeTypeCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -17753,16 +16990,16 @@ impl SecureSpecCombinator for SpecUnknownExtensionCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecUnknownExtensionCombinatorAlias = SpecOpaque0FfffCombinator;
+pub type SpecHandshakeTypeCombinatorAlias = TryMap<U8, HandshakeTypeMapper>;
 
-pub struct UnknownExtensionCombinator<'a>(UnknownExtensionCombinatorAlias<'a>);
+pub struct HandshakeTypeCombinator(HandshakeTypeCombinatorAlias);
 
-impl<'a> View for UnknownExtensionCombinator<'a> {
-    type V = SpecUnknownExtensionCombinator;
-    closed spec fn view(&self) -> Self::V { SpecUnknownExtensionCombinator(self.0@) }
+impl View for HandshakeTypeCombinator {
+    type V = SpecHandshakeTypeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHandshakeTypeCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for UnknownExtensionCombinator<'a> {
-    type Type = UnknownExtension<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HandshakeTypeCombinator {
+    type Type = HandshakeType;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -17776,87 +17013,89 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for UnknownExtensionCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type UnknownExtensionCombinatorAlias<'a> = Opaque0FfffCombinator<'a>;
+pub type HandshakeTypeCombinatorAlias = TryMap<U8, HandshakeTypeMapper>;
 
 
-pub closed spec fn spec_unknown_extension() -> SpecUnknownExtensionCombinator {
-    SpecUnknownExtensionCombinator(spec_opaque_0_ffff())
+pub closed spec fn spec_handshake_type() -> SpecHandshakeTypeCombinator {
+    SpecHandshakeTypeCombinator(TryMap { inner: U8, mapper: HandshakeTypeMapper })
 }
 
                 
-pub fn unknown_extension<'a>() -> (o: UnknownExtensionCombinator<'a>)
-    ensures o@ == spec_unknown_extension(),
+pub fn handshake_type() -> (o: HandshakeTypeCombinator)
+    ensures o@ == spec_handshake_type(),
 {
-    UnknownExtensionCombinator(opaque_0_ffff())
+    HandshakeTypeCombinator(TryMap { inner: U8, mapper: HandshakeTypeMapper })
 }
 
                 
 
-pub struct SpecCertificateEntry {
-    pub data: SpecCertificateEntryData,
-    pub extensions: SpecCertificateExtensions,
+pub struct SpecAlert {
+    pub level: SpecAlertLevel,
+    pub description: SpecAlertDescription,
 }
 
-pub type SpecCertificateEntryInner = (SpecCertificateEntryData, SpecCertificateExtensions);
-impl SpecFrom<SpecCertificateEntry> for SpecCertificateEntryInner {
-    open spec fn spec_from(m: SpecCertificateEntry) -> SpecCertificateEntryInner {
-        (m.data, m.extensions)
+pub type SpecAlertInner = (SpecAlertLevel, SpecAlertDescription);
+impl SpecFrom<SpecAlert> for SpecAlertInner {
+    open spec fn spec_from(m: SpecAlert) -> SpecAlertInner {
+        (m.level, m.description)
     }
 }
-impl SpecFrom<SpecCertificateEntryInner> for SpecCertificateEntry {
-    open spec fn spec_from(m: SpecCertificateEntryInner) -> SpecCertificateEntry {
-        let (data, extensions) = m;
-        SpecCertificateEntry { data, extensions }
+impl SpecFrom<SpecAlertInner> for SpecAlert {
+    open spec fn spec_from(m: SpecAlertInner) -> SpecAlert {
+        let (level, description) = m;
+        SpecAlert { level, description }
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 
-pub struct CertificateEntry<'a> {
-    pub data: CertificateEntryData<'a>,
-    pub extensions: CertificateExtensions<'a>,
+pub struct Alert {
+    pub level: AlertLevel,
+    pub description: AlertDescription,
 }
 
-impl View for CertificateEntry<'_> {
-    type V = SpecCertificateEntry;
+impl View for Alert {
+    type V = SpecAlert;
 
     open spec fn view(&self) -> Self::V {
-        SpecCertificateEntry {
-            data: self.data@,
-            extensions: self.extensions@,
+        SpecAlert {
+            level: self.level@,
+            description: self.description@,
         }
     }
 }
-pub type CertificateEntryInner<'a> = (CertificateEntryData<'a>, CertificateExtensions<'a>);
-impl<'a> From<CertificateEntry<'a>> for CertificateEntryInner<'a> {
-    fn ex_from(m: CertificateEntry) -> CertificateEntryInner {
-        (m.data, m.extensions)
+pub type AlertInner = (AlertLevel, AlertDescription);
+impl From<Alert> for AlertInner {
+    fn ex_from(m: Alert) -> AlertInner {
+        (m.level, m.description)
     }
 }
-impl<'a> From<CertificateEntryInner<'a>> for CertificateEntry<'a> {
-    fn ex_from(m: CertificateEntryInner) -> CertificateEntry {
-        let (data, extensions) = m;
-        CertificateEntry { data, extensions }
+impl From<AlertInner> for Alert {
+    fn ex_from(m: AlertInner) -> Alert {
+        let (level, description) = m;
+        Alert { level, description }
     }
 }
 
-pub struct CertificateEntryMapper<'a>(PhantomData<&'a ()>);
-impl<'a> CertificateEntryMapper<'a> {
+pub struct AlertMapper;
+impl AlertMapper {
     pub closed spec fn spec_new() -> Self {
-        CertificateEntryMapper(PhantomData)
+        AlertMapper
     }
     pub fn new() -> Self {
-        CertificateEntryMapper(PhantomData)
+        AlertMapper
     }
 }
-impl View for CertificateEntryMapper<'_> {
+impl View for AlertMapper {
     type V = Self;
     open spec fn view(&self) -> Self::V {
         *self
     }
 }
-impl SpecIso for CertificateEntryMapper<'_> {
-    type Src = SpecCertificateEntryInner;
-    type Dst = SpecCertificateEntry;
+impl SpecIso for AlertMapper {
+    type Src = SpecAlertInner;
+    type Dst = SpecAlert;
+}
+impl SpecIsoProof for AlertMapper {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -17864,23 +17103,23 @@ impl SpecIso for CertificateEntryMapper<'_> {
         assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
     }
 }
-impl<'a> Iso for CertificateEntryMapper<'a> {
-    type Src = CertificateEntryInner<'a>;
-    type Dst = CertificateEntry<'a>;
+impl Iso for AlertMapper {
+    type Src = AlertInner;
+    type Dst = Alert;
 }
 
-pub struct SpecCertificateEntryCombinator(SpecCertificateEntryCombinatorAlias);
+pub struct SpecAlertCombinator(SpecAlertCombinatorAlias);
 
-impl SpecCombinator for SpecCertificateEntryCombinator {
-    type Type = SpecCertificateEntry;
+impl SpecCombinator for SpecAlertCombinator {
+    type Type = SpecAlert;
     closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
     { self.0.spec_parse(s) }
     closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
     { self.0.spec_serialize(v) }
 }
-impl SecureSpecCombinator for SpecCertificateEntryCombinator {
+impl SecureSpecCombinator for SpecAlertCombinator {
     open spec fn is_prefix_secure() -> bool 
-    { SpecCertificateEntryCombinatorAlias::is_prefix_secure() }
+    { SpecAlertCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
     proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
@@ -17894,16 +17133,16 @@ impl SecureSpecCombinator for SpecCertificateEntryCombinator {
     proof fn lemma_parse_productive(&self, s: Seq<u8>) 
     { self.0.lemma_parse_productive(s) }
 }
-pub type SpecCertificateEntryCombinatorAlias = Mapped<(SpecCertificateEntryDataCombinator, SpecCertificateExtensionsCombinator), CertificateEntryMapper<'static>>;
+pub type SpecAlertCombinatorAlias = Mapped<(SpecAlertLevelCombinator, SpecAlertDescriptionCombinator), AlertMapper>;
 
-pub struct CertificateEntryCombinator<'a>(CertificateEntryCombinatorAlias<'a>);
+pub struct AlertCombinator(AlertCombinatorAlias);
 
-impl<'a> View for CertificateEntryCombinator<'a> {
-    type V = SpecCertificateEntryCombinator;
-    closed spec fn view(&self) -> Self::V { SpecCertificateEntryCombinator(self.0@) }
+impl View for AlertCombinator {
+    type V = SpecAlertCombinator;
+    closed spec fn view(&self) -> Self::V { SpecAlertCombinator(self.0@) }
 }
-impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateEntryCombinator<'a> {
-    type Type = CertificateEntry<'a>;
+impl<'a> Combinator<&'a [u8], Vec<u8>> for AlertCombinator {
+    type Type = Alert;
     closed spec fn spec_length(&self) -> Option<usize> 
     { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
     fn length(&self) -> Option<usize> 
@@ -17917,27 +17156,621 @@ impl<'a> Combinator<&'a [u8], Vec<u8>> for CertificateEntryCombinator<'a> {
     fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
     { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
 } 
-pub type CertificateEntryCombinatorAlias<'a> = Mapped<(CertificateEntryDataCombinator<'a>, CertificateExtensionsCombinator<'a>), CertificateEntryMapper<'a>>;
+pub type AlertCombinatorAlias = Mapped<(AlertLevelCombinator, AlertDescriptionCombinator), AlertMapper>;
 
 
-pub closed spec fn spec_certificate_entry(cert_type: SpecCertificateType) -> SpecCertificateEntryCombinator {
-    SpecCertificateEntryCombinator(
+pub closed spec fn spec_alert() -> SpecAlertCombinator {
+    SpecAlertCombinator(
     Mapped {
-        inner: (spec_certificate_entry_data(cert_type), spec_certificate_extensions()),
-        mapper: CertificateEntryMapper::spec_new(),
+        inner: (spec_alert_level(), spec_alert_description()),
+        mapper: AlertMapper::spec_new(),
     })
 }
 
-pub fn certificate_entry<'a>(cert_type: CertificateType) -> (o: CertificateEntryCombinator<'a>)
-    ensures o@ == spec_certificate_entry(cert_type@),
+                
+pub fn alert() -> (o: AlertCombinator)
+    ensures o@ == spec_alert(),
 {
-    CertificateEntryCombinator(
+    AlertCombinator(
     Mapped {
-        inner: (certificate_entry_data(cert_type), certificate_extensions()),
-        mapper: CertificateEntryMapper::new(),
+        inner: (alert_level(), alert_description()),
+        mapper: AlertMapper::new(),
     })
 }
 
+                
+pub type SpecSrtpProtectionProfile = Seq<u8>;
+pub type SrtpProtectionProfile<'a> = &'a [u8];
+
+
+pub struct SpecSrtpProtectionProfileCombinator(SpecSrtpProtectionProfileCombinatorAlias);
+
+impl SpecCombinator for SpecSrtpProtectionProfileCombinator {
+    type Type = SpecSrtpProtectionProfile;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSrtpProtectionProfileCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSrtpProtectionProfileCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSrtpProtectionProfileCombinatorAlias = BytesN<2>;
+
+pub struct SrtpProtectionProfileCombinator(SrtpProtectionProfileCombinatorAlias);
+
+impl View for SrtpProtectionProfileCombinator {
+    type V = SpecSrtpProtectionProfileCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSrtpProtectionProfileCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SrtpProtectionProfileCombinator {
+    type Type = SrtpProtectionProfile<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SrtpProtectionProfileCombinatorAlias = BytesN<2>;
+
+
+pub closed spec fn spec_srtp_protection_profile() -> SpecSrtpProtectionProfileCombinator {
+    SpecSrtpProtectionProfileCombinator(BytesN::<2>)
+}
+
+                
+pub fn srtp_protection_profile() -> (o: SrtpProtectionProfileCombinator)
+    ensures o@ == spec_srtp_protection_profile(),
+{
+    SrtpProtectionProfileCombinator(BytesN::<2>)
+}
+
+                
+
+pub struct SpecSrtpProtectionProfiles {
+    pub l: u16,
+    pub list: Seq<SpecSrtpProtectionProfile>,
+}
+
+pub type SpecSrtpProtectionProfilesInner = (u16, Seq<SpecSrtpProtectionProfile>);
+impl SpecFrom<SpecSrtpProtectionProfiles> for SpecSrtpProtectionProfilesInner {
+    open spec fn spec_from(m: SpecSrtpProtectionProfiles) -> SpecSrtpProtectionProfilesInner {
+        (m.l, m.list)
+    }
+}
+impl SpecFrom<SpecSrtpProtectionProfilesInner> for SpecSrtpProtectionProfiles {
+    open spec fn spec_from(m: SpecSrtpProtectionProfilesInner) -> SpecSrtpProtectionProfiles {
+        let (l, list) = m;
+        SpecSrtpProtectionProfiles { l, list }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct SrtpProtectionProfiles<'a> {
+    pub l: u16,
+    pub list: RepeatResult<SrtpProtectionProfile<'a>>,
+}
+
+impl View for SrtpProtectionProfiles<'_> {
+    type V = SpecSrtpProtectionProfiles;
+
+    open spec fn view(&self) -> Self::V {
+        SpecSrtpProtectionProfiles {
+            l: self.l@,
+            list: self.list@,
+        }
+    }
+}
+pub type SrtpProtectionProfilesInner<'a> = (u16, RepeatResult<SrtpProtectionProfile<'a>>);
+impl<'a> From<SrtpProtectionProfiles<'a>> for SrtpProtectionProfilesInner<'a> {
+    fn ex_from(m: SrtpProtectionProfiles) -> SrtpProtectionProfilesInner {
+        (m.l, m.list)
+    }
+}
+impl<'a> From<SrtpProtectionProfilesInner<'a>> for SrtpProtectionProfiles<'a> {
+    fn ex_from(m: SrtpProtectionProfilesInner) -> SrtpProtectionProfiles {
+        let (l, list) = m;
+        SrtpProtectionProfiles { l, list }
+    }
+}
+
+pub struct SrtpProtectionProfilesMapper<'a>(PhantomData<&'a ()>);
+impl<'a> SrtpProtectionProfilesMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        SrtpProtectionProfilesMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        SrtpProtectionProfilesMapper(PhantomData)
+    }
+}
+impl View for SrtpProtectionProfilesMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for SrtpProtectionProfilesMapper<'_> {
+    type Src = SpecSrtpProtectionProfilesInner;
+    type Dst = SpecSrtpProtectionProfiles;
+}
+impl SpecIsoProof for SrtpProtectionProfilesMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for SrtpProtectionProfilesMapper<'a> {
+    type Src = SrtpProtectionProfilesInner<'a>;
+    type Dst = SrtpProtectionProfiles<'a>;
+}
+
+pub struct SpecSrtpProtectionProfilesCombinator(SpecSrtpProtectionProfilesCombinatorAlias);
+
+impl SpecCombinator for SpecSrtpProtectionProfilesCombinator {
+    type Type = SpecSrtpProtectionProfiles;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecSrtpProtectionProfilesCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecSrtpProtectionProfilesCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecSrtpProtectionProfilesCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<SpecSrtpProtectionProfileCombinator>>>, SrtpProtectionProfilesMapper<'static>>;
+
+pub struct SrtpProtectionProfilesCombinator<'a>(SrtpProtectionProfilesCombinatorAlias<'a>);
+
+impl<'a> View for SrtpProtectionProfilesCombinator<'a> {
+    type V = SpecSrtpProtectionProfilesCombinator;
+    closed spec fn view(&self) -> Self::V { SpecSrtpProtectionProfilesCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for SrtpProtectionProfilesCombinator<'a> {
+    type Type = SrtpProtectionProfiles<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type SrtpProtectionProfilesCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate8195707947578446211>, AndThen<Bytes, Repeat<SrtpProtectionProfileCombinator>>, SrtpProtectionProfilesCont0<'a>>, SrtpProtectionProfilesMapper<'a>>;
+
+
+pub closed spec fn spec_srtp_protection_profiles() -> SpecSrtpProtectionProfilesCombinator {
+    SpecSrtpProtectionProfilesCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: |deps| spec_srtp_protection_profiles_cont0(deps) },
+        mapper: SrtpProtectionProfilesMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_srtp_protection_profiles_cont0(deps: u16) -> AndThen<Bytes, Repeat<SpecSrtpProtectionProfileCombinator>> {
+    let l = deps;
+    AndThen(Bytes(l.spec_into()), Repeat(spec_srtp_protection_profile()))
+}
+                
+pub fn srtp_protection_profiles<'a>() -> (o: SrtpProtectionProfilesCombinator<'a>)
+    ensures o@ == spec_srtp_protection_profiles(),
+{
+    SrtpProtectionProfilesCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate8195707947578446211 }, snd: SrtpProtectionProfilesCont0::new(), spec_snd: Ghost(|deps| spec_srtp_protection_profiles_cont0(deps)) },
+        mapper: SrtpProtectionProfilesMapper::new(),
+    })
+}
+
+pub struct SrtpProtectionProfilesCont0<'a>(PhantomData<&'a ()>);
+impl<'a> SrtpProtectionProfilesCont0<'a> {
+    pub fn new() -> Self {
+        SrtpProtectionProfilesCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for SrtpProtectionProfilesCont0<'a> {
+    type Output = AndThen<Bytes, Repeat<SrtpProtectionProfileCombinator>>;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_srtp_protection_profiles_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        AndThen(Bytes(l.ex_into()), Repeat::new(srtp_protection_profile()))
+    }
+}
+                
+
+pub struct SpecUseSrtpData {
+    pub profiles: SpecSrtpProtectionProfiles,
+    pub srtp_mki: SpecOpaque0Ff,
+}
+
+pub type SpecUseSrtpDataInner = (SpecSrtpProtectionProfiles, SpecOpaque0Ff);
+impl SpecFrom<SpecUseSrtpData> for SpecUseSrtpDataInner {
+    open spec fn spec_from(m: SpecUseSrtpData) -> SpecUseSrtpDataInner {
+        (m.profiles, m.srtp_mki)
+    }
+}
+impl SpecFrom<SpecUseSrtpDataInner> for SpecUseSrtpData {
+    open spec fn spec_from(m: SpecUseSrtpDataInner) -> SpecUseSrtpData {
+        let (profiles, srtp_mki) = m;
+        SpecUseSrtpData { profiles, srtp_mki }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct UseSrtpData<'a> {
+    pub profiles: SrtpProtectionProfiles<'a>,
+    pub srtp_mki: Opaque0Ff<'a>,
+}
+
+impl View for UseSrtpData<'_> {
+    type V = SpecUseSrtpData;
+
+    open spec fn view(&self) -> Self::V {
+        SpecUseSrtpData {
+            profiles: self.profiles@,
+            srtp_mki: self.srtp_mki@,
+        }
+    }
+}
+pub type UseSrtpDataInner<'a> = (SrtpProtectionProfiles<'a>, Opaque0Ff<'a>);
+impl<'a> From<UseSrtpData<'a>> for UseSrtpDataInner<'a> {
+    fn ex_from(m: UseSrtpData) -> UseSrtpDataInner {
+        (m.profiles, m.srtp_mki)
+    }
+}
+impl<'a> From<UseSrtpDataInner<'a>> for UseSrtpData<'a> {
+    fn ex_from(m: UseSrtpDataInner) -> UseSrtpData {
+        let (profiles, srtp_mki) = m;
+        UseSrtpData { profiles, srtp_mki }
+    }
+}
+
+pub struct UseSrtpDataMapper<'a>(PhantomData<&'a ()>);
+impl<'a> UseSrtpDataMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        UseSrtpDataMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        UseSrtpDataMapper(PhantomData)
+    }
+}
+impl View for UseSrtpDataMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for UseSrtpDataMapper<'_> {
+    type Src = SpecUseSrtpDataInner;
+    type Dst = SpecUseSrtpData;
+}
+impl SpecIsoProof for UseSrtpDataMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for UseSrtpDataMapper<'a> {
+    type Src = UseSrtpDataInner<'a>;
+    type Dst = UseSrtpData<'a>;
+}
+
+pub struct SpecUseSrtpDataCombinator(SpecUseSrtpDataCombinatorAlias);
+
+impl SpecCombinator for SpecUseSrtpDataCombinator {
+    type Type = SpecUseSrtpData;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecUseSrtpDataCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecUseSrtpDataCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecUseSrtpDataCombinatorAlias = Mapped<(SpecSrtpProtectionProfilesCombinator, SpecOpaque0FfCombinator), UseSrtpDataMapper<'static>>;
+
+pub struct UseSrtpDataCombinator<'a>(UseSrtpDataCombinatorAlias<'a>);
+
+impl<'a> View for UseSrtpDataCombinator<'a> {
+    type V = SpecUseSrtpDataCombinator;
+    closed spec fn view(&self) -> Self::V { SpecUseSrtpDataCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for UseSrtpDataCombinator<'a> {
+    type Type = UseSrtpData<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type UseSrtpDataCombinatorAlias<'a> = Mapped<(SrtpProtectionProfilesCombinator<'a>, Opaque0FfCombinator<'a>), UseSrtpDataMapper<'a>>;
+
+
+pub closed spec fn spec_use_srtp_data() -> SpecUseSrtpDataCombinator {
+    SpecUseSrtpDataCombinator(
+    Mapped {
+        inner: (spec_srtp_protection_profiles(), spec_opaque_0_ff()),
+        mapper: UseSrtpDataMapper::spec_new(),
+    })
+}
+
+                
+pub fn use_srtp_data<'a>() -> (o: UseSrtpDataCombinator<'a>)
+    ensures o@ == spec_use_srtp_data(),
+{
+    UseSrtpDataCombinator(
+    Mapped {
+        inner: (srtp_protection_profiles(), opaque_0_ff()),
+        mapper: UseSrtpDataMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecOpaque2Ffff {
+    pub l: u16,
+    pub data: Seq<u8>,
+}
+
+pub type SpecOpaque2FfffInner = (u16, Seq<u8>);
+impl SpecFrom<SpecOpaque2Ffff> for SpecOpaque2FfffInner {
+    open spec fn spec_from(m: SpecOpaque2Ffff) -> SpecOpaque2FfffInner {
+        (m.l, m.data)
+    }
+}
+impl SpecFrom<SpecOpaque2FfffInner> for SpecOpaque2Ffff {
+    open spec fn spec_from(m: SpecOpaque2FfffInner) -> SpecOpaque2Ffff {
+        let (l, data) = m;
+        SpecOpaque2Ffff { l, data }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct Opaque2Ffff<'a> {
+    pub l: u16,
+    pub data: &'a [u8],
+}
+
+impl View for Opaque2Ffff<'_> {
+    type V = SpecOpaque2Ffff;
+
+    open spec fn view(&self) -> Self::V {
+        SpecOpaque2Ffff {
+            l: self.l@,
+            data: self.data@,
+        }
+    }
+}
+pub type Opaque2FfffInner<'a> = (u16, &'a [u8]);
+impl<'a> From<Opaque2Ffff<'a>> for Opaque2FfffInner<'a> {
+    fn ex_from(m: Opaque2Ffff) -> Opaque2FfffInner {
+        (m.l, m.data)
+    }
+}
+impl<'a> From<Opaque2FfffInner<'a>> for Opaque2Ffff<'a> {
+    fn ex_from(m: Opaque2FfffInner) -> Opaque2Ffff {
+        let (l, data) = m;
+        Opaque2Ffff { l, data }
+    }
+}
+
+pub struct Opaque2FfffMapper<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque2FfffMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        Opaque2FfffMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        Opaque2FfffMapper(PhantomData)
+    }
+}
+impl View for Opaque2FfffMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for Opaque2FfffMapper<'_> {
+    type Src = SpecOpaque2FfffInner;
+    type Dst = SpecOpaque2Ffff;
+}
+impl SpecIsoProof for Opaque2FfffMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for Opaque2FfffMapper<'a> {
+    type Src = Opaque2FfffInner<'a>;
+    type Dst = Opaque2Ffff<'a>;
+}
+
+pub struct SpecOpaque2FfffCombinator(SpecOpaque2FfffCombinatorAlias);
+
+impl SpecCombinator for SpecOpaque2FfffCombinator {
+    type Type = SpecOpaque2Ffff;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecOpaque2FfffCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecOpaque2FfffCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecOpaque2FfffCombinatorAlias = Mapped<SpecDepend<Refined<U16Be, Predicate3016150102856496288>, Bytes>, Opaque2FfffMapper<'static>>;
+pub struct Predicate3016150102856496288;
+impl View for Predicate3016150102856496288 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred for Predicate3016150102856496288 {
+    type Input = u16;
+
+    fn apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 2 && i <= 65535)
+    }
+}
+impl SpecPred for Predicate3016150102856496288 {
+    type Input = u16;
+
+    open spec fn spec_apply(&self, i: &Self::Input) -> bool {
+        let i = (*i);
+        (i >= 2 && i <= 65535)
+    }
+}
+
+pub struct Opaque2FfffCombinator<'a>(Opaque2FfffCombinatorAlias<'a>);
+
+impl<'a> View for Opaque2FfffCombinator<'a> {
+    type V = SpecOpaque2FfffCombinator;
+    closed spec fn view(&self) -> Self::V { SpecOpaque2FfffCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for Opaque2FfffCombinator<'a> {
+    type Type = Opaque2Ffff<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type Opaque2FfffCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Refined<U16Be, Predicate3016150102856496288>, Bytes, Opaque2FfffCont0<'a>>, Opaque2FfffMapper<'a>>;
+
+
+pub closed spec fn spec_opaque_2_ffff() -> SpecOpaque2FfffCombinator {
+    SpecOpaque2FfffCombinator(
+    Mapped {
+        inner: SpecDepend { fst: Refined { inner: U16Be, predicate: Predicate3016150102856496288 }, snd: |deps| spec_opaque2_ffff_cont0(deps) },
+        mapper: Opaque2FfffMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_opaque2_ffff_cont0(deps: u16) -> Bytes {
+    let l = deps;
+    Bytes(l.spec_into())
+}
+                
+pub fn opaque_2_ffff<'a>() -> (o: Opaque2FfffCombinator<'a>)
+    ensures o@ == spec_opaque_2_ffff(),
+{
+    Opaque2FfffCombinator(
+    Mapped {
+        inner: Depend { fst: Refined { inner: U16Be, predicate: Predicate3016150102856496288 }, snd: Opaque2FfffCont0::new(), spec_snd: Ghost(|deps| spec_opaque2_ffff_cont0(deps)) },
+        mapper: Opaque2FfffMapper::new(),
+    })
+}
+
+pub struct Opaque2FfffCont0<'a>(PhantomData<&'a ()>);
+impl<'a> Opaque2FfffCont0<'a> {
+    pub fn new() -> Self {
+        Opaque2FfffCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&u16> for Opaque2FfffCont0<'a> {
+    type Output = Bytes;
+
+    open spec fn requires(&self, deps: &u16) -> bool { true }
+
+    open spec fn ensures(&self, deps: &u16, o: Self::Output) -> bool {
+        o@ == spec_opaque2_ffff_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &u16) -> Self::Output {
+        let l = *deps;
+        Bytes(l.ex_into())
+    }
+}
+                
 
 pub struct SpecTlsPlaintext {
     pub content_type: SpecContentType,
@@ -18007,6 +17840,8 @@ impl View for TlsPlaintextMapper<'_> {
 impl SpecIso for TlsPlaintextMapper<'_> {
     type Src = SpecTlsPlaintextInner;
     type Dst = SpecTlsPlaintext;
+}
+impl SpecIsoProof for TlsPlaintextMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
         assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
     }
@@ -18089,6 +17924,356 @@ pub fn tls_plaintext<'a>() -> (o: TlsPlaintextCombinator<'a>)
     })
 }
 
+                
+
+pub struct SpecServerCertTypeServerExtension {
+    pub server_certificate_type: SpecCertificateType,
+}
+
+pub type SpecServerCertTypeServerExtensionInner = SpecCertificateType;
+impl SpecFrom<SpecServerCertTypeServerExtension> for SpecServerCertTypeServerExtensionInner {
+    open spec fn spec_from(m: SpecServerCertTypeServerExtension) -> SpecServerCertTypeServerExtensionInner {
+        m.server_certificate_type
+    }
+}
+impl SpecFrom<SpecServerCertTypeServerExtensionInner> for SpecServerCertTypeServerExtension {
+    open spec fn spec_from(m: SpecServerCertTypeServerExtensionInner) -> SpecServerCertTypeServerExtension {
+        let server_certificate_type = m;
+        SpecServerCertTypeServerExtension { server_certificate_type }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct ServerCertTypeServerExtension {
+    pub server_certificate_type: CertificateType,
+}
+
+impl View for ServerCertTypeServerExtension {
+    type V = SpecServerCertTypeServerExtension;
+
+    open spec fn view(&self) -> Self::V {
+        SpecServerCertTypeServerExtension {
+            server_certificate_type: self.server_certificate_type@,
+        }
+    }
+}
+pub type ServerCertTypeServerExtensionInner = CertificateType;
+impl From<ServerCertTypeServerExtension> for ServerCertTypeServerExtensionInner {
+    fn ex_from(m: ServerCertTypeServerExtension) -> ServerCertTypeServerExtensionInner {
+        m.server_certificate_type
+    }
+}
+impl From<ServerCertTypeServerExtensionInner> for ServerCertTypeServerExtension {
+    fn ex_from(m: ServerCertTypeServerExtensionInner) -> ServerCertTypeServerExtension {
+        let server_certificate_type = m;
+        ServerCertTypeServerExtension { server_certificate_type }
+    }
+}
+
+pub struct ServerCertTypeServerExtensionMapper;
+impl ServerCertTypeServerExtensionMapper {
+    pub closed spec fn spec_new() -> Self {
+        ServerCertTypeServerExtensionMapper
+    }
+    pub fn new() -> Self {
+        ServerCertTypeServerExtensionMapper
+    }
+}
+impl View for ServerCertTypeServerExtensionMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for ServerCertTypeServerExtensionMapper {
+    type Src = SpecServerCertTypeServerExtensionInner;
+    type Dst = SpecServerCertTypeServerExtension;
+}
+impl SpecIsoProof for ServerCertTypeServerExtensionMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl Iso for ServerCertTypeServerExtensionMapper {
+    type Src = ServerCertTypeServerExtensionInner;
+    type Dst = ServerCertTypeServerExtension;
+}
+
+pub struct SpecServerCertTypeServerExtensionCombinator(SpecServerCertTypeServerExtensionCombinatorAlias);
+
+impl SpecCombinator for SpecServerCertTypeServerExtensionCombinator {
+    type Type = SpecServerCertTypeServerExtension;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecServerCertTypeServerExtensionCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecServerCertTypeServerExtensionCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecServerCertTypeServerExtensionCombinatorAlias = Mapped<SpecCertificateTypeCombinator, ServerCertTypeServerExtensionMapper>;
+
+pub struct ServerCertTypeServerExtensionCombinator(ServerCertTypeServerExtensionCombinatorAlias);
+
+impl View for ServerCertTypeServerExtensionCombinator {
+    type V = SpecServerCertTypeServerExtensionCombinator;
+    closed spec fn view(&self) -> Self::V { SpecServerCertTypeServerExtensionCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for ServerCertTypeServerExtensionCombinator {
+    type Type = ServerCertTypeServerExtension;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type ServerCertTypeServerExtensionCombinatorAlias = Mapped<CertificateTypeCombinator, ServerCertTypeServerExtensionMapper>;
+
+
+pub closed spec fn spec_server_cert_type_server_extension() -> SpecServerCertTypeServerExtensionCombinator {
+    SpecServerCertTypeServerExtensionCombinator(
+    Mapped {
+        inner: spec_certificate_type(),
+        mapper: ServerCertTypeServerExtensionMapper::spec_new(),
+    })
+}
+
+                
+pub fn server_cert_type_server_extension() -> (o: ServerCertTypeServerExtensionCombinator)
+    ensures o@ == spec_server_cert_type_server_extension(),
+{
+    ServerCertTypeServerExtensionCombinator(
+    Mapped {
+        inner: certificate_type(),
+        mapper: ServerCertTypeServerExtensionMapper::new(),
+    })
+}
+
+                
+
+pub struct SpecHandshake {
+    pub msg_type: SpecHandshakeType,
+    pub length: u24,
+    pub msg: SpecHandshakeMsg,
+}
+
+pub type SpecHandshakeInner = ((SpecHandshakeType, u24), SpecHandshakeMsg);
+impl SpecFrom<SpecHandshake> for SpecHandshakeInner {
+    open spec fn spec_from(m: SpecHandshake) -> SpecHandshakeInner {
+        ((m.msg_type, m.length), m.msg)
+    }
+}
+impl SpecFrom<SpecHandshakeInner> for SpecHandshake {
+    open spec fn spec_from(m: SpecHandshakeInner) -> SpecHandshake {
+        let ((msg_type, length), msg) = m;
+        SpecHandshake { msg_type, length, msg }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct Handshake<'a> {
+    pub msg_type: HandshakeType,
+    pub length: u24,
+    pub msg: HandshakeMsg<'a>,
+}
+
+impl View for Handshake<'_> {
+    type V = SpecHandshake;
+
+    open spec fn view(&self) -> Self::V {
+        SpecHandshake {
+            msg_type: self.msg_type@,
+            length: self.length@,
+            msg: self.msg@,
+        }
+    }
+}
+pub type HandshakeInner<'a> = ((HandshakeType, u24), HandshakeMsg<'a>);
+impl<'a> From<Handshake<'a>> for HandshakeInner<'a> {
+    fn ex_from(m: Handshake) -> HandshakeInner {
+        ((m.msg_type, m.length), m.msg)
+    }
+}
+impl<'a> From<HandshakeInner<'a>> for Handshake<'a> {
+    fn ex_from(m: HandshakeInner) -> Handshake {
+        let ((msg_type, length), msg) = m;
+        Handshake { msg_type, length, msg }
+    }
+}
+
+pub struct HandshakeMapper<'a>(PhantomData<&'a ()>);
+impl<'a> HandshakeMapper<'a> {
+    pub closed spec fn spec_new() -> Self {
+        HandshakeMapper(PhantomData)
+    }
+    pub fn new() -> Self {
+        HandshakeMapper(PhantomData)
+    }
+}
+impl View for HandshakeMapper<'_> {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for HandshakeMapper<'_> {
+    type Src = SpecHandshakeInner;
+    type Dst = SpecHandshake;
+}
+impl SpecIsoProof for HandshakeMapper<'_> {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso for HandshakeMapper<'a> {
+    type Src = HandshakeInner<'a>;
+    type Dst = Handshake<'a>;
+}
+
+pub struct SpecHandshakeCombinator(SpecHandshakeCombinatorAlias);
+
+impl SpecCombinator for SpecHandshakeCombinator {
+    type Type = SpecHandshake;
+    closed spec fn spec_parse(&self, s: Seq<u8>) -> Result<(usize, Self::Type), ()> 
+    { self.0.spec_parse(s) }
+    closed spec fn spec_serialize(&self, v: Self::Type) -> Result<Seq<u8>, ()> 
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecHandshakeCombinator {
+    open spec fn is_prefix_secure() -> bool 
+    { SpecHandshakeCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_length(s) }
+    closed spec fn is_productive(&self) -> bool 
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecHandshakeCombinatorAlias = Mapped<SpecDepend<SpecDepend<SpecHandshakeTypeCombinator, U24Be>, SpecHandshakeMsgCombinator>, HandshakeMapper<'static>>;
+
+pub struct HandshakeCombinator<'a>(HandshakeCombinatorAlias<'a>);
+
+impl<'a> View for HandshakeCombinator<'a> {
+    type V = SpecHandshakeCombinator;
+    closed spec fn view(&self) -> Self::V { SpecHandshakeCombinator(self.0@) }
+}
+impl<'a> Combinator<&'a [u8], Vec<u8>> for HandshakeCombinator<'a> {
+    type Type = Handshake<'a>;
+    closed spec fn spec_length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::spec_length(&self.0) }
+    fn length(&self) -> Option<usize> 
+    { <_ as Combinator<&[u8], Vec<u8>>>::length(&self.0) }
+    closed spec fn parse_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::parse_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    { <_ as Combinator<&[u8],Vec<u8>>>::parse(&self.0, s) }
+    closed spec fn serialize_requires(&self) -> bool 
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize_requires(&self.0) }
+    fn serialize(&self, v: Self::Type, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<&[u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+} 
+pub type HandshakeCombinatorAlias<'a> = Mapped<Depend<&'a [u8], Vec<u8>, Depend<&'a [u8], Vec<u8>, HandshakeTypeCombinator, U24Be, HandshakeCont1<'a>>, HandshakeMsgCombinator<'a>, HandshakeCont0<'a>>, HandshakeMapper<'a>>;
+
+
+pub closed spec fn spec_handshake() -> SpecHandshakeCombinator {
+    SpecHandshakeCombinator(
+    Mapped {
+        inner: SpecDepend { fst: SpecDepend { fst: spec_handshake_type(), snd: |deps| spec_handshake_cont1(deps) }, snd: |deps| spec_handshake_cont0(deps) },
+        mapper: HandshakeMapper::spec_new(),
+    })
+}
+
+pub open spec fn spec_handshake_cont1(deps: SpecHandshakeType) -> U24Be {
+    let msg_type = deps;
+    U24Be
+}
+pub open spec fn spec_handshake_cont0(deps: (SpecHandshakeType, u24)) -> SpecHandshakeMsgCombinator {
+    let (msg_type, length) = deps;
+    spec_handshake_msg(length, msg_type)
+}
+                
+pub fn handshake<'a>() -> (o: HandshakeCombinator<'a>)
+    ensures o@ == spec_handshake(),
+{
+    HandshakeCombinator(
+    Mapped {
+        inner: Depend { fst: Depend { fst: handshake_type(), snd: HandshakeCont1::new(), spec_snd: Ghost(|deps| spec_handshake_cont1(deps)) }, snd: HandshakeCont0::new(), spec_snd: Ghost(|deps| spec_handshake_cont0(deps)) },
+        mapper: HandshakeMapper::new(),
+    })
+}
+
+pub struct HandshakeCont1<'a>(PhantomData<&'a ()>);
+impl<'a> HandshakeCont1<'a> {
+    pub fn new() -> Self {
+        HandshakeCont1(PhantomData)
+    }
+}
+impl<'a> Continuation<&HandshakeType> for HandshakeCont1<'a> {
+    type Output = U24Be;
+
+    open spec fn requires(&self, deps: &HandshakeType) -> bool { true }
+
+    open spec fn ensures(&self, deps: &HandshakeType, o: Self::Output) -> bool {
+        o@ == spec_handshake_cont1(deps@)
+    }
+
+    fn apply(&self, deps: &HandshakeType) -> Self::Output {
+        let msg_type = *deps;
+        U24Be
+    }
+}
+pub struct HandshakeCont0<'a>(PhantomData<&'a ()>);
+impl<'a> HandshakeCont0<'a> {
+    pub fn new() -> Self {
+        HandshakeCont0(PhantomData)
+    }
+}
+impl<'a> Continuation<&(HandshakeType, u24)> for HandshakeCont0<'a> {
+    type Output = HandshakeMsgCombinator<'a>;
+
+    open spec fn requires(&self, deps: &(HandshakeType, u24)) -> bool { true }
+
+    open spec fn ensures(&self, deps: &(HandshakeType, u24), o: Self::Output) -> bool {
+        o@ == spec_handshake_cont0(deps@)
+    }
+
+    fn apply(&self, deps: &(HandshakeType, u24)) -> Self::Output {
+        let (msg_type, length) = *deps;
+        handshake_msg(length, msg_type)
+    }
+}
                 
 
 }

--- a/vest-examples/src/map.rs
+++ b/vest-examples/src/map.rs
@@ -96,7 +96,9 @@ impl SpecIso for Msg1Mapper<'_> {
     type Src = SpecMsg1Inner;
 
     type Dst = SpecMsg1;
+}
 
+impl SpecIsoProof for Msg1Mapper<'_> {
     proof fn spec_iso(s: SpecMsg1Inner) {
     }
 
@@ -207,7 +209,9 @@ impl SpecIso for Msg2Mapper<'_> {
     type Src = Msg2Inner;
 
     type Dst = Msg2;
+}
 
+impl SpecIsoProof for Msg2Mapper<'_> {
     proof fn spec_iso(s: Msg2Inner) {
     }
 
@@ -318,7 +322,9 @@ impl SpecIso for Msg3Mapper<'_> {
     type Src = SpecMsg3Inner;
 
     type Dst = SpecMsg3;
+}
 
+impl SpecIsoProof for Msg3Mapper<'_> {
     proof fn spec_iso(s: SpecMsg3Inner) {
     }
 
@@ -455,7 +461,9 @@ impl SpecIso for Msg4Mapper<'_> {
     type Src = SpecMsg4Inner;
 
     type Dst = SpecMsg4;
+}
 
+impl SpecIsoProof for Msg4Mapper<'_> {
     proof fn spec_iso(s: SpecMsg4Inner) {
     }
 
@@ -560,7 +568,7 @@ fn serialize_parse4() -> Result<(), Error> {
         msg@.theorem_serialize_parse_roundtrip(val@);
         assert(n == len);
         assert(val@ == val_@);
-        assert(val_@ == SpecMsg4::M3(SpecMsg3 { a: bytes1@ }));
+        // assert(val_@ == SpecMsg4::M3(SpecMsg3 { a: bytes1@ }));
     }
     Ok(())
 }

--- a/vest-examples/src/repeat.rs
+++ b/vest-examples/src/repeat.rs
@@ -107,7 +107,9 @@ impl SpecIso for OpaqueU16Mapper<'_> {
     type Src = SpecOpaqueU16Inner;
 
     type Dst = SpecOpaqueU16;
+}
 
+impl SpecIsoProof for OpaqueU16Mapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 
@@ -597,7 +599,9 @@ impl SpecIso for ResponderIdListMapper<'_> {
     type Src = SpecResponderIdListInner;
 
     type Dst = SpecResponderIdList;
+}
 
+impl SpecIsoProof for ResponderIdListMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 

--- a/vest-examples/src/tlv.rs
+++ b/vest-examples/src/tlv.rs
@@ -89,7 +89,9 @@ impl SpecIso for MsgDMapper<'_> {
     type Src = SpecMsgDInner;
 
     type Dst = SpecMsgD;
+}
 
+impl SpecIsoProof for MsgDMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 
@@ -173,7 +175,9 @@ impl SpecIso for MsgBMapper<'_> {
     type Src = SpecMsgBInner;
 
     type Dst = SpecMsgB;
+}
 
+impl SpecIsoProof for MsgBMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 
@@ -294,7 +298,9 @@ impl SpecIso for MsgCF4Mapper<'_> {
     type Src = SpecMsgCF4Inner;
 
     type Dst = SpecMsgCF4;
+}
 
+impl SpecIsoProof for MsgCF4Mapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 
@@ -382,7 +388,9 @@ impl SpecIso for MsgCMapper<'_> {
     type Src = SpecMsgCInner;
 
     type Dst = SpecMsgC;
+}
 
+impl SpecIsoProof for MsgCMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 
@@ -468,7 +476,9 @@ impl SpecIso for MsgAMapper<'_> {
     type Src = SpecMsgAInner;
 
     type Dst = SpecMsgA;
+}
 
+impl SpecIsoProof for MsgAMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 

--- a/vest/src/bitcoin/varint.rs
+++ b/vest/src/bitcoin/varint.rs
@@ -5,7 +5,7 @@ use crate::{
         choice::*,
         cond::Cond,
         depend::{Continuation, Depend, SpecDepend},
-        map::{SpecTryFromInto, TryFromInto, TryMap},
+        map::{SpecPartialIso, SpecPartialIsoProof, PartialIso, TryMap},
         refined::{Pred, Refined, SpecPred},
         uints::*,
     },
@@ -344,11 +344,13 @@ impl View for VarIntMapper<'_> {
     }
 }
 
-impl SpecTryFromInto for VarIntMapper<'_> {
+impl SpecPartialIso for VarIntMapper<'_> {
     type Src = (u8, Either<Seq<u8>, Either<u16, Either<u32, u64>>>);
 
     type Dst = VarInt;
+}
 
+impl SpecPartialIsoProof for VarIntMapper<'_> {
     proof fn spec_iso(s: Self::Src) {
     }
 
@@ -356,7 +358,7 @@ impl SpecTryFromInto for VarIntMapper<'_> {
     }
 }
 
-impl<'a> TryFromInto for VarIntMapper<'a> {
+impl<'a> PartialIso for VarIntMapper<'a> {
     type Src = (u8, Either<&'a [u8], Either<u16, Either<u32, u64>>>);
 
     type Dst = VarInt;

--- a/vest/src/regular/disjoint.rs
+++ b/vest/src/regular/disjoint.rs
@@ -4,7 +4,7 @@ use super::choice::OrdChoice;
 use super::cond::Cond;
 use super::depend::SpecDepend;
 use super::fail::Fail;
-use super::map::{Mapped, SpecIso, SpecTryFromInto, TryMap};
+use super::map::{Mapped, SpecIso, SpecPartialIso, SpecPartialIsoFn, TryMap};
 use super::preceded::Preceded;
 use super::refined::{Refined, SpecPred};
 use super::tag::{Tag, TagPred};
@@ -135,8 +135,8 @@ impl<U1, U2, M1, M2> DisjointFrom<Mapped<U2, M2>> for Mapped<U1, M1> where
 // `TryMap<U, M2>`
 impl<U, M1, M2> DisjointFrom<TryMap<U, M2>> for TryMap<U, M1> where
     U: SpecCombinator,
-    M1: SpecTryFromInto<Src = U::Type>,
-    M2: SpecTryFromInto<Src = U::Type>,
+    M1: SpecPartialIsoFn<Src = U::Type>,
+    M2: SpecPartialIsoFn<Src = U::Type>,
     U::Type: SpecTryFrom<M1::Dst>,
     U::Type: SpecTryFrom<M2::Dst>,
     M1::Dst: SpecTryFrom<U::Type>,
@@ -145,8 +145,8 @@ impl<U, M1, M2> DisjointFrom<TryMap<U, M2>> for TryMap<U, M1> where
     open spec fn disjoint_from(&self, other: &TryMap<U, M2>) -> bool {
         self.inner == other.inner && forall|t|
             {
-                <M1 as SpecTryFromInto>::spec_apply(t) is Ok
-                    ==> <M2 as SpecTryFromInto>::spec_apply(t) is Err
+                <M1 as SpecPartialIsoFn>::spec_apply(t) is Ok
+                    ==> <M2 as SpecPartialIsoFn>::spec_apply(t) is Err
             }
     }
 

--- a/vest/src/regular/map.rs
+++ b/vest/src/regular/map.rs
@@ -236,7 +236,7 @@ impl<I, O, Inner, M> Combinator<I, O> for Mapped<Inner, M> where
     }
 }
 
-/// Spec version of [`TryFromInto`].
+/// Spec version of [`PartialIso`].
 pub trait SpecPartialIso {
     /// The source type
     type Src: SpecTryFrom<Self::Dst>;
@@ -245,6 +245,7 @@ pub trait SpecPartialIso {
     type Dst: SpecTryFrom<Self::Src>;
 }
 
+/// The faillible functions of [`SpecPartialIso`]
 pub trait SpecPartialIsoFn: SpecPartialIso {
     /// Applies the faillible conversion to the source type.
     spec fn spec_apply(s: Self::Src) -> Result<
@@ -259,6 +260,7 @@ pub trait SpecPartialIsoFn: SpecPartialIso {
     >;
 }
 
+// Blanket implementation for all types that implement `SpecPartialIso`
 impl<T: SpecPartialIso> SpecPartialIsoFn for T {
     open spec fn spec_apply(s: Self::Src) -> Result<
         Self::Dst,
@@ -275,6 +277,7 @@ impl<T: SpecPartialIso> SpecPartialIsoFn for T {
     }
 }
 
+/// The proof of [`SpecPartialIsoFn`]
 pub trait SpecPartialIsoProof: SpecPartialIsoFn {
     /// One direction of the isomorphism when the conversion is successful.
     proof fn spec_iso(s: Self::Src)
@@ -308,6 +311,7 @@ pub trait PartialIso: View where
     type Dst: View + TryFrom<Self::Src>;
 }
 
+/// The faillible functions of [`PartialIso`]
 pub trait PartialIsoFn: PartialIso where
     Self::V: SpecPartialIso<Src = <Self::Src as View>::V, Dst = <Self::Dst as View>::V>,
     <Self::Src as View>::V: SpecTryFrom<<Self::Dst as View>::V>,
@@ -334,6 +338,7 @@ pub trait PartialIsoFn: PartialIso where
     ;
 }
 
+// Blanket implementation for all types that implement `PartialIso`
 impl<T: PartialIso> PartialIsoFn for T where
     T::V: SpecPartialIso<Src = <T::Src as View>::V, Dst = <T::Dst as View>::V>,
     <T::Src as View>::V: SpecTryFrom<<T::Dst as View>::V>,


### PR DESCRIPTION
Fix https://github.com/secure-foundations/vest/issues/16.

Specifically, this PR removes the default impls for `SpecIso` and `Iso` (that unsoundly verified the exec-spec equivalence for all), and instead introduces the `SpecIsoFn` and `IsoFn` sub-traits and adds blanket impls for all types that implement `SpecIso` and `Iso`. This way we soundly verifies the exec-spec equivalence.