### PR TITLE
Update VestLib code to verify with the new mutable reference framework

### DIFF
--- a/vest-dsl/Cargo.toml
+++ b/vest-dsl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vest"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 description = "Vest: A DSL for specifying and generating fast, formally verified parsers and serializers"

--- a/vest-dsl/bitcoin/src/vest_bitcoin.rs
+++ b/vest-dsl/bitcoin/src/vest_bitcoin.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -160,7 +160,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ScriptCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ScriptCombinatorAlias = Mapped<Pair<BtcVarint, bytes::Variable, ScriptCont0>, ScriptMapper>;
 
@@ -227,14 +227,14 @@ pub fn serialize_script<'a>(v: <ScriptCombinator as Combinator<'a, &'a [u8], Vec
         spec_script().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_script().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_script().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_script().spec_serialize(v@))
         },
 {
     let combinator = script();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn script_len<'a>(v: <ScriptCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -413,7 +413,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TxoutCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TxoutCombinatorAlias = Mapped<TxoutCombinator1, TxoutMapper>;
 
@@ -465,14 +465,14 @@ pub fn serialize_txout<'a>(v: <TxoutCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_txout().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_txout().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_txout().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_txout().spec_serialize(v@))
         },
 {
     let combinator = txout();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn txout_len<'a>(v: <TxoutCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -620,7 +620,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OutpointCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OutpointCombinatorAlias = Mapped<OutpointCombinator1, OutpointMapper>;
 
@@ -672,14 +672,14 @@ pub fn serialize_outpoint<'a>(v: <OutpointCombinator as Combinator<'a, &'a [u8],
         spec_outpoint().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_outpoint().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_outpoint().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_outpoint().spec_serialize(v@))
         },
 {
     let combinator = outpoint();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn outpoint_len<'a>(v: <OutpointCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -820,7 +820,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ScriptSigCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ScriptSigCombinatorAlias = Mapped<Pair<BtcVarint, bytes::Variable, ScriptSigCont0>, ScriptSigMapper>;
 
@@ -887,14 +887,14 @@ pub fn serialize_script_sig<'a>(v: <ScriptSigCombinator as Combinator<'a, &'a [u
         spec_script_sig().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_script_sig().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_script_sig().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_script_sig().spec_serialize(v@))
         },
 {
     let combinator = script_sig();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn script_sig_len<'a>(v: <ScriptSigCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1085,7 +1085,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TxinCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TxinCombinatorAlias = Mapped<TxinCombinator2, TxinMapper>;
 
@@ -1137,14 +1137,14 @@ pub fn serialize_txin<'a>(v: <TxinCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_txin().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_txin().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_txin().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_txin().spec_serialize(v@))
         },
 {
     let combinator = txin();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn txin_len<'a>(v: <TxinCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1285,7 +1285,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for WitnessComponentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type WitnessComponentCombinatorAlias = Mapped<Pair<BtcVarint, bytes::Variable, WitnessComponentCont0>, WitnessComponentMapper>;
 
@@ -1352,14 +1352,14 @@ pub fn serialize_witness_component<'a>(v: <WitnessComponentCombinator as Combina
         spec_witness_component().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_witness_component().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_witness_component().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_witness_component().spec_serialize(v@))
         },
 {
     let combinator = witness_component();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn witness_component_len<'a>(v: <WitnessComponentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1531,7 +1531,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for WitnessCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type WitnessCombinatorAlias = Mapped<Pair<BtcVarint, RepeatN<WitnessComponentCombinator>, WitnessCont0>, WitnessMapper>;
 
@@ -1598,14 +1598,14 @@ pub fn serialize_witness<'a>(v: <WitnessCombinator as Combinator<'a, &'a [u8], V
         spec_witness().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_witness().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_witness().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_witness().spec_serialize(v@))
         },
 {
     let combinator = witness();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn witness_len<'a>(v: <WitnessCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1845,7 +1845,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LockTimeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LockTimeCombinatorAlias = Mapped<LockTimeCombinator1, LockTimeMapper>;
 
@@ -1889,14 +1889,14 @@ pub fn serialize_lock_time<'a>(v: <LockTimeCombinator as Combinator<'a, &'a [u8]
         spec_lock_time().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_lock_time().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_lock_time().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_lock_time().spec_serialize(v@))
         },
 {
     let combinator = lock_time();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn lock_time_len<'a>(v: <LockTimeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2053,7 +2053,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TxSegwitCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TxSegwitCombinatorAlias = Mapped<Pair<Pair<(Refined<U8, TagPred<u8>>, BtcVarint), (RepeatN<TxinCombinator>, BtcVarint), TxSegwitCont1>, (RepeatN<TxoutCombinator>, (RepeatN<WitnessCombinator>, LockTimeCombinator)), TxSegwitCont0>, TxSegwitMapper>;
 
@@ -2135,14 +2135,14 @@ pub fn serialize_tx_segwit<'a>(v: <TxSegwitCombinator as Combinator<'a, &'a [u8]
         spec_tx_segwit().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tx_segwit().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tx_segwit().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tx_segwit().spec_serialize(v@))
         },
 {
     let combinator = tx_segwit();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tx_segwit_len<'a>(v: <TxSegwitCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2353,7 +2353,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TxNonsegwitCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TxNonsegwitCombinatorAlias = Mapped<Pair<(RepeatN<TxinCombinator>, BtcVarint), (RepeatN<TxoutCombinator>, LockTimeCombinator), TxNonsegwitCont0>, TxNonsegwitMapper>;
 
@@ -2422,14 +2422,14 @@ pub fn serialize_tx_nonsegwit<'a>(v: <TxNonsegwitCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tx_nonsegwit(txin_count@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tx_nonsegwit(txin_count@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tx_nonsegwit(txin_count@).spec_serialize(v@))
         },
 {
     let combinator = tx_nonsegwit( txin_count );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn tx_nonsegwit_len<'a>(v: <TxNonsegwitCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, txin_count: VarInt) -> (serialize_len: usize)
@@ -2634,7 +2634,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TxRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TxRestCombinatorAlias = Mapped<TxRestCombinator1, TxRestMapper>;
 
@@ -2680,14 +2680,14 @@ pub fn serialize_tx_rest<'a>(v: <TxRestCombinator as Combinator<'a, &'a [u8], Ve
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tx_rest(txin_count@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tx_rest(txin_count@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tx_rest(txin_count@).spec_serialize(v@))
         },
 {
     let combinator = tx_rest( txin_count );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn tx_rest_len<'a>(v: <TxRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, txin_count: VarInt) -> (serialize_len: usize)
@@ -2831,7 +2831,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TxCombinatorAlias = Mapped<Pair<(U32Le, BtcVarint), TxRestCombinator, TxCont0>, TxMapper>;
 
@@ -2898,14 +2898,14 @@ pub fn serialize_tx<'a>(v: <TxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::
         spec_tx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tx().spec_serialize(v@))
         },
 {
     let combinator = tx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tx_len<'a>(v: <TxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3095,7 +3095,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BlockCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type BlockCombinatorAlias = Mapped<Pair<(U32Le, (bytes::Fixed<32>, (bytes::Fixed<32>, (U32Le, (U32Le, (U32Le, BtcVarint)))))), RepeatN<TxCombinator>, BlockCont0>, BlockMapper>;
 
@@ -3162,14 +3162,14 @@ pub fn serialize_block<'a>(v: <BlockCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_block().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_block().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_block().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_block().spec_serialize(v@))
         },
 {
     let combinator = block();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn block_len<'a>(v: <BlockCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/mavlink/src/vest_mavlink.rs
+++ b/vest-dsl/mavlink/src/vest_mavlink.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -261,7 +261,7 @@ impl SpecPartialIso for MavFrameMapper {
 }
 
 impl SpecPartialIsoProof for MavFrameMapper {
-    proof fn spec_iso(s: Self::Src) { 
+    proof fn spec_iso(s: Self::Src) {
         assert(
             Self::spec_apply(s) matches Ok(v) ==> {
             &&& Self::spec_rev_apply(v) is Ok
@@ -269,7 +269,7 @@ impl SpecPartialIsoProof for MavFrameMapper {
         });
     }
 
-    proof fn spec_iso_rev(s: Self::Dst) { 
+    proof fn spec_iso_rev(s: Self::Dst) {
         assert(
             Self::spec_rev_apply(s) matches Ok(v) ==> {
             &&& Self::spec_apply(v) is Ok
@@ -293,13 +293,13 @@ impl SpecCombinator for SpecMavFrameCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavFrameCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavFrameCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -307,11 +307,11 @@ impl SecureSpecCombinator for SpecMavFrameCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavFrameCombinatorAlias = TryMap<U8, MavFrameMapper>;
@@ -327,13 +327,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavFrameCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavFrameCombinatorAlias = TryMap<U8, MavFrameMapper>;
 
 
@@ -348,11 +348,11 @@ pub fn mav_frame<'a>() -> (o: MavFrameCombinator)
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = MavFrameCombinator(TryMap { inner: U8, mapper: MavFrameMapper });
-    assert({
-        &&& combinator@ == spec_mav_frame()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_mav_frame()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -376,14 +376,14 @@ pub fn serialize_mav_frame<'a>(v: <MavFrameCombinator as Combinator<'a, &'a [u8]
         spec_mav_frame().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mav_frame().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mav_frame().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mav_frame().spec_serialize(v@))
         },
 {
     let combinator = mav_frame();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mav_frame_len<'a>(v: <MavFrameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -413,13 +413,13 @@ impl SpecCombinator for SpecMavCmdCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavCmdCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavCmdCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -427,11 +427,11 @@ impl SecureSpecCombinator for SpecMavCmdCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavCmdCombinatorAlias = U16Le;
@@ -447,13 +447,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavCmdCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavCmdCombinatorAlias = U16Le;
 
 
@@ -468,11 +468,11 @@ pub fn mav_cmd<'a>() -> (o: MavCmdCombinator)
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = MavCmdCombinator(U16Le);
-    assert({
-        &&& combinator@ == spec_mav_cmd()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_mav_cmd()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -496,14 +496,14 @@ pub fn serialize_mav_cmd<'a>(v: <MavCmdCombinator as Combinator<'a, &'a [u8], Ve
         spec_mav_cmd().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mav_cmd().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mav_cmd().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mav_cmd().spec_serialize(v@))
         },
 {
     let combinator = mav_cmd();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mav_cmd_len<'a>(v: <MavCmdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -649,13 +649,13 @@ impl SpecCombinator for SpecCommandIntCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecCommandIntCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecCommandIntCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -663,11 +663,11 @@ impl SecureSpecCombinator for SpecCommandIntCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecCommandIntCombinatorAlias = Mapped<SpecCommandIntCombinatorAlias12, CommandIntMapper>;
@@ -798,13 +798,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CommandIntCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type CommandIntCombinatorAlias = Mapped<CommandIntCombinator12, CommandIntMapper>;
 
 
@@ -827,11 +827,11 @@ pub fn command_int<'a>() -> (o: CommandIntCombinator)
         inner: CommandIntCombinator12((U8, CommandIntCombinator11((U8, CommandIntCombinator10((mav_frame(), CommandIntCombinator9((mav_cmd(), CommandIntCombinator8((U8, CommandIntCombinator7((Refined { inner: U8, predicate: Predicate2576612288366319398 }, CommandIntCombinator6((U32Le, CommandIntCombinator5((U32Le, CommandIntCombinator4((U32Le, CommandIntCombinator3((U32Le, CommandIntCombinator2((U32Le, CommandIntCombinator1((U32Le, U32Le)))))))))))))))))))))))),
         mapper: CommandIntMapper,
     });
-    assert({
-        &&& combinator@ == spec_command_int()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_command_int()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -855,14 +855,14 @@ pub fn serialize_command_int<'a>(v: <CommandIntCombinator as Combinator<'a, &'a 
         spec_command_int().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_command_int().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_command_int().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_command_int().spec_serialize(v@))
         },
 {
     let combinator = command_int();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn command_int_len<'a>(v: <CommandIntCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -873,1303 +873,6 @@ pub fn command_int_len<'a>(v: <CommandIntCombinator as Combinator<'a, &'a [u8], 
         serialize_len == spec_command_int().spec_serialize(v@).len(),
 {
     let combinator = command_int();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-                
-
-pub struct SpecTerrainRequest {
-    pub lat: u32,
-    pub lon: u32,
-    pub grid_spacing: u16,
-    pub mask: u64,
-}
-
-pub type SpecTerrainRequestInner = (u32, (u32, (u16, u64)));
-
-
-impl SpecFrom<SpecTerrainRequest> for SpecTerrainRequestInner {
-    open spec fn spec_from(m: SpecTerrainRequest) -> SpecTerrainRequestInner {
-        (m.lat, (m.lon, (m.grid_spacing, m.mask)))
-    }
-}
-
-impl SpecFrom<SpecTerrainRequestInner> for SpecTerrainRequest {
-    open spec fn spec_from(m: SpecTerrainRequestInner) -> SpecTerrainRequest {
-        let (lat, (lon, (grid_spacing, mask))) = m;
-        SpecTerrainRequest { lat, lon, grid_spacing, mask }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct TerrainRequest {
-    pub lat: u32,
-    pub lon: u32,
-    pub grid_spacing: u16,
-    pub mask: u64,
-}
-
-impl View for TerrainRequest {
-    type V = SpecTerrainRequest;
-
-    open spec fn view(&self) -> Self::V {
-        SpecTerrainRequest {
-            lat: self.lat@,
-            lon: self.lon@,
-            grid_spacing: self.grid_spacing@,
-            mask: self.mask@,
-        }
-    }
-}
-pub type TerrainRequestInner = (u32, (u32, (u16, u64)));
-
-pub type TerrainRequestInnerRef<'a> = (&'a u32, (&'a u32, (&'a u16, &'a u64)));
-impl<'a> From<&'a TerrainRequest> for TerrainRequestInnerRef<'a> {
-    fn ex_from(m: &'a TerrainRequest) -> TerrainRequestInnerRef<'a> {
-        (&m.lat, (&m.lon, (&m.grid_spacing, &m.mask)))
-    }
-}
-
-impl From<TerrainRequestInner> for TerrainRequest {
-    fn ex_from(m: TerrainRequestInner) -> TerrainRequest {
-        let (lat, (lon, (grid_spacing, mask))) = m;
-        TerrainRequest { lat, lon, grid_spacing, mask }
-    }
-}
-
-pub struct TerrainRequestMapper;
-impl View for TerrainRequestMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for TerrainRequestMapper {
-    type Src = SpecTerrainRequestInner;
-    type Dst = SpecTerrainRequest;
-}
-impl SpecIsoProof for TerrainRequestMapper {
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso<'a> for TerrainRequestMapper {
-    type Src = TerrainRequestInner;
-    type Dst = TerrainRequest;
-    type RefSrc = TerrainRequestInnerRef<'a>;
-}
-type SpecTerrainRequestCombinatorAlias1 = (U16Le, U64Le);
-type SpecTerrainRequestCombinatorAlias2 = (U32Le, SpecTerrainRequestCombinatorAlias1);
-type SpecTerrainRequestCombinatorAlias3 = (U32Le, SpecTerrainRequestCombinatorAlias2);
-pub struct SpecTerrainRequestCombinator(pub SpecTerrainRequestCombinatorAlias);
-
-impl SpecCombinator for SpecTerrainRequestCombinator {
-    type Type = SpecTerrainRequest;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecTerrainRequestCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecTerrainRequestCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecTerrainRequestCombinatorAlias = Mapped<SpecTerrainRequestCombinatorAlias3, TerrainRequestMapper>;
-type TerrainRequestCombinatorAlias1 = (U16Le, U64Le);
-type TerrainRequestCombinatorAlias2 = (U32Le, TerrainRequestCombinator1);
-type TerrainRequestCombinatorAlias3 = (U32Le, TerrainRequestCombinator2);
-pub struct TerrainRequestCombinator1(pub TerrainRequestCombinatorAlias1);
-impl View for TerrainRequestCombinator1 {
-    type V = SpecTerrainRequestCombinatorAlias1;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(TerrainRequestCombinator1, TerrainRequestCombinatorAlias1);
-
-pub struct TerrainRequestCombinator2(pub TerrainRequestCombinatorAlias2);
-impl View for TerrainRequestCombinator2 {
-    type V = SpecTerrainRequestCombinatorAlias2;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(TerrainRequestCombinator2, TerrainRequestCombinatorAlias2);
-
-pub struct TerrainRequestCombinator3(pub TerrainRequestCombinatorAlias3);
-impl View for TerrainRequestCombinator3 {
-    type V = SpecTerrainRequestCombinatorAlias3;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(TerrainRequestCombinator3, TerrainRequestCombinatorAlias3);
-
-pub struct TerrainRequestCombinator(pub TerrainRequestCombinatorAlias);
-
-impl View for TerrainRequestCombinator {
-    type V = SpecTerrainRequestCombinator;
-    open spec fn view(&self) -> Self::V { SpecTerrainRequestCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TerrainRequestCombinator {
-    type Type = TerrainRequest;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type TerrainRequestCombinatorAlias = Mapped<TerrainRequestCombinator3, TerrainRequestMapper>;
-
-
-pub open spec fn spec_terrain_request() -> SpecTerrainRequestCombinator {
-    SpecTerrainRequestCombinator(
-    Mapped {
-        inner: (U32Le, (U32Le, (U16Le, U64Le))),
-        mapper: TerrainRequestMapper,
-    })
-}
-
-                
-pub fn terrain_request<'a>() -> (o: TerrainRequestCombinator)
-    ensures o@ == spec_terrain_request(),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = TerrainRequestCombinator(
-    Mapped {
-        inner: TerrainRequestCombinator3((U32Le, TerrainRequestCombinator2((U32Le, TerrainRequestCombinator1((U16Le, U64Le)))))),
-        mapper: TerrainRequestMapper,
-    });
-    assert({
-        &&& combinator@ == spec_terrain_request()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_terrain_request<'a>(input: &'a [u8]) -> (res: PResult<<TerrainRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_terrain_request().spec_parse(input@) == Some((n as int, v@)),
-        spec_terrain_request().spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_terrain_request().spec_parse(input@) is None,
-        spec_terrain_request().spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = terrain_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_terrain_request<'a>(v: <TerrainRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_terrain_request().wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_terrain_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_terrain_request().spec_serialize(v@))
-        },
-{
-    let combinator = terrain_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
-}
-
-pub fn terrain_request_len<'a>(v: <TerrainRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
-    requires
-        spec_terrain_request().wf(v@),
-        spec_terrain_request().spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_terrain_request().spec_serialize(v@).len(),
-{
-    let combinator = terrain_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-                
-
-pub spec const SPEC_ProtocolMagic_MavLink1: u8 = 254;
-pub spec const SPEC_ProtocolMagic_MavLink2: u8 = 253;
-pub exec static EXEC_ProtocolMagic_MavLink1: u8 ensures EXEC_ProtocolMagic_MavLink1 == SPEC_ProtocolMagic_MavLink1 { 254 }
-pub exec static EXEC_ProtocolMagic_MavLink2: u8 ensures EXEC_ProtocolMagic_MavLink2 == SPEC_ProtocolMagic_MavLink2 { 253 }
-
-#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ProtocolMagic {
-    MavLink1 = 254,
-MavLink2 = 253
-}
-pub type SpecProtocolMagic = ProtocolMagic;
-
-pub type ProtocolMagicInner = u8;
-
-pub type ProtocolMagicInnerRef<'a> = &'a u8;
-
-impl View for ProtocolMagic {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecTryFrom<ProtocolMagicInner> for ProtocolMagic {
-    type Error = ();
-
-    open spec fn spec_try_from(v: ProtocolMagicInner) -> Result<ProtocolMagic, ()> {
-        match v {
-            254u8 => Ok(ProtocolMagic::MavLink1),
-            253u8 => Ok(ProtocolMagic::MavLink2),
-            _ => Err(()),
-        }
-    }
-}
-
-impl SpecTryFrom<ProtocolMagic> for ProtocolMagicInner {
-    type Error = ();
-
-    open spec fn spec_try_from(v: ProtocolMagic) -> Result<ProtocolMagicInner, ()> {
-        match v {
-            ProtocolMagic::MavLink1 => Ok(SPEC_ProtocolMagic_MavLink1),
-            ProtocolMagic::MavLink2 => Ok(SPEC_ProtocolMagic_MavLink2),
-        }
-    }
-}
-
-impl TryFrom<ProtocolMagicInner> for ProtocolMagic {
-    type Error = ();
-
-    fn ex_try_from(v: ProtocolMagicInner) -> Result<ProtocolMagic, ()> {
-        match v {
-            254u8 => Ok(ProtocolMagic::MavLink1),
-            253u8 => Ok(ProtocolMagic::MavLink2),
-            _ => Err(()),
-        }
-    }
-}
-
-impl<'a> TryFrom<&'a ProtocolMagic> for ProtocolMagicInnerRef<'a> {
-    type Error = ();
-
-    fn ex_try_from(v: &'a ProtocolMagic) -> Result<ProtocolMagicInnerRef<'a>, ()> {
-        match v {
-            ProtocolMagic::MavLink1 => Ok(&EXEC_ProtocolMagic_MavLink1),
-            ProtocolMagic::MavLink2 => Ok(&EXEC_ProtocolMagic_MavLink2),
-        }
-    }
-}
-
-pub struct ProtocolMagicMapper;
-
-impl View for ProtocolMagicMapper {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-
-impl SpecPartialIso for ProtocolMagicMapper {
-    type Src = ProtocolMagicInner;
-    type Dst = ProtocolMagic;
-}
-
-impl SpecPartialIsoProof for ProtocolMagicMapper {
-    proof fn spec_iso(s: Self::Src) { 
-        assert(
-            Self::spec_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_rev_apply(v) is Ok
-            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-
-    proof fn spec_iso_rev(s: Self::Dst) { 
-        assert(
-            Self::spec_rev_apply(s) matches Ok(v) ==> {
-            &&& Self::spec_apply(v) is Ok
-            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
-        });
-    }
-}
-
-impl<'a> PartialIso<'a> for ProtocolMagicMapper {
-    type Src = ProtocolMagicInner;
-    type Dst = ProtocolMagic;
-    type RefSrc = ProtocolMagicInnerRef<'a>;
-}
-
-
-pub struct SpecProtocolMagicCombinator(pub SpecProtocolMagicCombinatorAlias);
-
-impl SpecCombinator for SpecProtocolMagicCombinator {
-    type Type = SpecProtocolMagic;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecProtocolMagicCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecProtocolMagicCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecProtocolMagicCombinatorAlias = TryMap<U8, ProtocolMagicMapper>;
-
-pub struct ProtocolMagicCombinator(pub ProtocolMagicCombinatorAlias);
-
-impl View for ProtocolMagicCombinator {
-    type V = SpecProtocolMagicCombinator;
-    open spec fn view(&self) -> Self::V { SpecProtocolMagicCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProtocolMagicCombinator {
-    type Type = ProtocolMagic;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type ProtocolMagicCombinatorAlias = TryMap<U8, ProtocolMagicMapper>;
-
-
-pub open spec fn spec_protocol_magic() -> SpecProtocolMagicCombinator {
-    SpecProtocolMagicCombinator(TryMap { inner: U8, mapper: ProtocolMagicMapper })
-}
-
-                
-pub fn protocol_magic<'a>() -> (o: ProtocolMagicCombinator)
-    ensures o@ == spec_protocol_magic(),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = ProtocolMagicCombinator(TryMap { inner: U8, mapper: ProtocolMagicMapper });
-    assert({
-        &&& combinator@ == spec_protocol_magic()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_protocol_magic<'a>(input: &'a [u8]) -> (res: PResult<<ProtocolMagicCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_protocol_magic().spec_parse(input@) == Some((n as int, v@)),
-        spec_protocol_magic().spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_protocol_magic().spec_parse(input@) is None,
-        spec_protocol_magic().spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = protocol_magic();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_protocol_magic<'a>(v: <ProtocolMagicCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_protocol_magic().wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_protocol_magic().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_protocol_magic().spec_serialize(v@))
-        },
-{
-    let combinator = protocol_magic();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
-}
-
-pub fn protocol_magic_len<'a>(v: <ProtocolMagicCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
-    requires
-        spec_protocol_magic().wf(v@),
-        spec_protocol_magic().spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_protocol_magic().spec_serialize(v@).len(),
-{
-    let combinator = protocol_magic();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-                
-
-pub struct SpecMavlinkV1Msg {
-    pub len: u8,
-    pub seq: u8,
-    pub sysid: u8,
-    pub compid: u8,
-    pub msgid: u8,
-    pub payload: Seq<u8>,
-    pub checksum: u16,
-}
-
-pub type SpecMavlinkV1MsgInner = (u8, (u8, (u8, (u8, (u8, (Seq<u8>, u16))))));
-
-
-impl SpecFrom<SpecMavlinkV1Msg> for SpecMavlinkV1MsgInner {
-    open spec fn spec_from(m: SpecMavlinkV1Msg) -> SpecMavlinkV1MsgInner {
-        (m.len, (m.seq, (m.sysid, (m.compid, (m.msgid, (m.payload, m.checksum))))))
-    }
-}
-
-impl SpecFrom<SpecMavlinkV1MsgInner> for SpecMavlinkV1Msg {
-    open spec fn spec_from(m: SpecMavlinkV1MsgInner) -> SpecMavlinkV1Msg {
-        let (len, (seq, (sysid, (compid, (msgid, (payload, checksum)))))) = m;
-        SpecMavlinkV1Msg { len, seq, sysid, compid, msgid, payload, checksum }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct MavlinkV1Msg<'a> {
-    pub len: u8,
-    pub seq: u8,
-    pub sysid: u8,
-    pub compid: u8,
-    pub msgid: u8,
-    pub payload: &'a [u8],
-    pub checksum: u16,
-}
-
-impl View for MavlinkV1Msg<'_> {
-    type V = SpecMavlinkV1Msg;
-
-    open spec fn view(&self) -> Self::V {
-        SpecMavlinkV1Msg {
-            len: self.len@,
-            seq: self.seq@,
-            sysid: self.sysid@,
-            compid: self.compid@,
-            msgid: self.msgid@,
-            payload: self.payload@,
-            checksum: self.checksum@,
-        }
-    }
-}
-pub type MavlinkV1MsgInner<'a> = (u8, (u8, (u8, (u8, (u8, (&'a [u8], u16))))));
-
-pub type MavlinkV1MsgInnerRef<'a> = (&'a u8, (&'a u8, (&'a u8, (&'a u8, (&'a u8, (&'a &'a [u8], &'a u16))))));
-impl<'a> From<&'a MavlinkV1Msg<'a>> for MavlinkV1MsgInnerRef<'a> {
-    fn ex_from(m: &'a MavlinkV1Msg) -> MavlinkV1MsgInnerRef<'a> {
-        (&m.len, (&m.seq, (&m.sysid, (&m.compid, (&m.msgid, (&m.payload, &m.checksum))))))
-    }
-}
-
-impl<'a> From<MavlinkV1MsgInner<'a>> for MavlinkV1Msg<'a> {
-    fn ex_from(m: MavlinkV1MsgInner) -> MavlinkV1Msg {
-        let (len, (seq, (sysid, (compid, (msgid, (payload, checksum)))))) = m;
-        MavlinkV1Msg { len, seq, sysid, compid, msgid, payload, checksum }
-    }
-}
-
-pub struct MavlinkV1MsgMapper;
-impl View for MavlinkV1MsgMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for MavlinkV1MsgMapper {
-    type Src = SpecMavlinkV1MsgInner;
-    type Dst = SpecMavlinkV1Msg;
-}
-impl SpecIsoProof for MavlinkV1MsgMapper {
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso<'a> for MavlinkV1MsgMapper {
-    type Src = MavlinkV1MsgInner<'a>;
-    type Dst = MavlinkV1Msg<'a>;
-    type RefSrc = MavlinkV1MsgInnerRef<'a>;
-}
-
-pub struct SpecMavlinkV1MsgCombinator(pub SpecMavlinkV1MsgCombinatorAlias);
-
-impl SpecCombinator for SpecMavlinkV1MsgCombinator {
-    type Type = SpecMavlinkV1Msg;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMavlinkV1MsgCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMavlinkV1MsgCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMavlinkV1MsgCombinatorAlias = Mapped<SpecPair<U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le)))))>, MavlinkV1MsgMapper>;
-pub struct Predicate3768926651291043512;
-impl View for Predicate3768926651291043512 {
-    type V = Self;
-
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl Pred<u8> for Predicate3768926651291043512 {
-    fn apply(&self, i: &u8) -> bool {
-        let i = (*i);
-        (i >= 1)
-    }
-}
-impl SpecPred<u8> for Predicate3768926651291043512 {
-    open spec fn spec_apply(&self, i: &u8) -> bool {
-        let i = (*i);
-        (i >= 1)
-    }
-}
-
-pub struct MavlinkV1MsgCombinator(pub MavlinkV1MsgCombinatorAlias);
-
-impl View for MavlinkV1MsgCombinator {
-    type V = SpecMavlinkV1MsgCombinator;
-    open spec fn view(&self) -> Self::V { SpecMavlinkV1MsgCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkV1MsgCombinator {
-    type Type = MavlinkV1Msg<'a>;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type MavlinkV1MsgCombinatorAlias = Mapped<Pair<U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le))))), MavlinkV1MsgCont0>, MavlinkV1MsgMapper>;
-
-
-pub open spec fn spec_mavlink_v1_msg() -> SpecMavlinkV1MsgCombinator {
-    SpecMavlinkV1MsgCombinator(
-    Mapped {
-        inner: Pair::spec_new(U8, |deps| spec_mavlink_v1_msg_cont0(deps)),
-        mapper: MavlinkV1MsgMapper,
-    })
-}
-
-pub open spec fn spec_mavlink_v1_msg_cont0(deps: u8) -> (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le))))) {
-    let len = deps;
-    (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (U8, (bytes::Variable(len.spec_into()), U16Le)))))
-}
-
-impl View for MavlinkV1MsgCont0 {
-    type V = spec_fn(u8) -> (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le)))));
-
-    open spec fn view(&self) -> Self::V {
-        |deps: u8| {
-            spec_mavlink_v1_msg_cont0(deps)
-        }
-    }
-}
-
-                
-pub fn mavlink_v1_msg<'a>() -> (o: MavlinkV1MsgCombinator)
-    ensures o@ == spec_mavlink_v1_msg(),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = MavlinkV1MsgCombinator(
-    Mapped {
-        inner: Pair::new(U8, MavlinkV1MsgCont0),
-        mapper: MavlinkV1MsgMapper,
-    });
-    assert({
-        &&& combinator@ == spec_mavlink_v1_msg()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_mavlink_v1_msg<'a>(input: &'a [u8]) -> (res: PResult<<MavlinkV1MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_mavlink_v1_msg().spec_parse(input@) == Some((n as int, v@)),
-        spec_mavlink_v1_msg().spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_mavlink_v1_msg().spec_parse(input@) is None,
-        spec_mavlink_v1_msg().spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = mavlink_v1_msg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_mavlink_v1_msg<'a>(v: <MavlinkV1MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_mavlink_v1_msg().wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_mavlink_v1_msg().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mavlink_v1_msg().spec_serialize(v@))
-        },
-{
-    let combinator = mavlink_v1_msg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
-}
-
-pub fn mavlink_v1_msg_len<'a>(v: <MavlinkV1MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
-    requires
-        spec_mavlink_v1_msg().wf(v@),
-        spec_mavlink_v1_msg().spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_mavlink_v1_msg().spec_serialize(v@).len(),
-{
-    let combinator = mavlink_v1_msg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-pub struct MavlinkV1MsgCont0;
-type MavlinkV1MsgCont0Type<'a, 'b> = &'b u8;
-type MavlinkV1MsgCont0SType<'a, 'x> = &'x u8;
-type MavlinkV1MsgCont0Input<'a, 'b, 'x> = POrSType<MavlinkV1MsgCont0Type<'a, 'b>, MavlinkV1MsgCont0SType<'a, 'x>>;
-impl<'a, 'b, 'x> Continuation<MavlinkV1MsgCont0Input<'a, 'b, 'x>> for MavlinkV1MsgCont0 {
-    type Output = (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le)))));
-
-    open spec fn requires(&self, deps: MavlinkV1MsgCont0Input<'a, 'b, 'x>) -> bool { true }
-
-    open spec fn ensures(&self, deps: MavlinkV1MsgCont0Input<'a, 'b, 'x>, o: Self::Output) -> bool {
-        o@ == spec_mavlink_v1_msg_cont0(deps@)
-    }
-
-    fn apply(&self, deps: MavlinkV1MsgCont0Input<'a, 'b, 'x>) -> Self::Output {
-        match deps {
-            POrSType::P(deps) => {
-                let len = *deps;
-                (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (U8, (bytes::Variable(len.ex_into()), U16Le)))))
-            }
-            POrSType::S(deps) => {
-                let len = deps;
-                let len = *len;
-                (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (U8, (bytes::Variable(len.ex_into()), U16Le)))))
-            }
-        }
-    }
-}
-                
-pub mod IncompatFlags {
-    use super::*;
-    pub spec const SPEC_Signed: u8 = 1;
-    pub exec const Signed: u8 ensures Signed == SPEC_Signed { 1 }
-}
-
-
-pub struct SpecIncompatFlagsCombinator(pub SpecIncompatFlagsCombinatorAlias);
-
-impl SpecCombinator for SpecIncompatFlagsCombinator {
-    type Type = u8;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecIncompatFlagsCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecIncompatFlagsCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecIncompatFlagsCombinatorAlias = U8;
-
-pub struct IncompatFlagsCombinator(pub IncompatFlagsCombinatorAlias);
-
-impl View for IncompatFlagsCombinator {
-    type V = SpecIncompatFlagsCombinator;
-    open spec fn view(&self) -> Self::V { SpecIncompatFlagsCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IncompatFlagsCombinator {
-    type Type = u8;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type IncompatFlagsCombinatorAlias = U8;
-
-
-pub open spec fn spec_incompat_flags() -> SpecIncompatFlagsCombinator {
-    SpecIncompatFlagsCombinator(U8)
-}
-
-                
-pub fn incompat_flags<'a>() -> (o: IncompatFlagsCombinator)
-    ensures o@ == spec_incompat_flags(),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = IncompatFlagsCombinator(U8);
-    assert({
-        &&& combinator@ == spec_incompat_flags()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_incompat_flags<'a>(input: &'a [u8]) -> (res: PResult<<IncompatFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_incompat_flags().spec_parse(input@) == Some((n as int, v@)),
-        spec_incompat_flags().spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_incompat_flags().spec_parse(input@) is None,
-        spec_incompat_flags().spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = incompat_flags();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_incompat_flags<'a>(v: <IncompatFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_incompat_flags().wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_incompat_flags().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_incompat_flags().spec_serialize(v@))
-        },
-{
-    let combinator = incompat_flags();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
-}
-
-pub fn incompat_flags_len<'a>(v: <IncompatFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
-    requires
-        spec_incompat_flags().wf(v@),
-        spec_incompat_flags().spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_incompat_flags().spec_serialize(v@).len(),
-{
-    let combinator = incompat_flags();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-                
-pub mod MessageIds {
-    use super::*;
-    pub spec const SPEC_CommandInt: u32 = 75;
-    pub spec const SPEC_CommandLong: u32 = 76;
-    pub spec const SPEC_CommandAck: u32 = 77;
-    pub spec const SPEC_CommandCancel: u32 = 80;
-    pub spec const SPEC_TerrainRequest: u32 = 134;
-    pub spec const SPEC_Reserved: u32 = 8388608;
-    pub exec const CommandInt: u32 ensures CommandInt == SPEC_CommandInt { 75 }
-    pub exec const CommandLong: u32 ensures CommandLong == SPEC_CommandLong { 76 }
-    pub exec const CommandAck: u32 ensures CommandAck == SPEC_CommandAck { 77 }
-    pub exec const CommandCancel: u32 ensures CommandCancel == SPEC_CommandCancel { 80 }
-    pub exec const TerrainRequest: u32 ensures TerrainRequest == SPEC_TerrainRequest { 134 }
-    pub exec const Reserved: u32 ensures Reserved == SPEC_Reserved { 8388608 }
-}
-
-
-pub struct SpecMessageIdsCombinator(pub SpecMessageIdsCombinatorAlias);
-
-impl SpecCombinator for SpecMessageIdsCombinator {
-    type Type = u24;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMessageIdsCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMessageIdsCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMessageIdsCombinatorAlias = U24Le;
-
-pub struct MessageIdsCombinator(pub MessageIdsCombinatorAlias);
-
-impl View for MessageIdsCombinator {
-    type V = SpecMessageIdsCombinator;
-    open spec fn view(&self) -> Self::V { SpecMessageIdsCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MessageIdsCombinator {
-    type Type = u24;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type MessageIdsCombinatorAlias = U24Le;
-
-
-pub open spec fn spec_message_ids() -> SpecMessageIdsCombinator {
-    SpecMessageIdsCombinator(U24Le)
-}
-
-                
-pub fn message_ids<'a>() -> (o: MessageIdsCombinator)
-    ensures o@ == spec_message_ids(),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = MessageIdsCombinator(U24Le);
-    assert({
-        &&& combinator@ == spec_message_ids()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_message_ids<'a>(input: &'a [u8]) -> (res: PResult<<MessageIdsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_message_ids().spec_parse(input@) == Some((n as int, v@)),
-        spec_message_ids().spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_message_ids().spec_parse(input@) is None,
-        spec_message_ids().spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = message_ids();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_message_ids<'a>(v: <MessageIdsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_message_ids().wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_message_ids().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_message_ids().spec_serialize(v@))
-        },
-{
-    let combinator = message_ids();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
-}
-
-pub fn message_ids_len<'a>(v: <MessageIdsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
-    requires
-        spec_message_ids().wf(v@),
-        spec_message_ids().spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_message_ids().spec_serialize(v@).len(),
-{
-    let combinator = message_ids();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-                
-
-pub struct SpecCommandLong {
-    pub target_system: u8,
-    pub target_component: u8,
-    pub command: u16,
-    pub confirmation: u8,
-    pub param1: u32,
-    pub param2: u32,
-    pub param3: u32,
-    pub param4: u32,
-    pub param5: u32,
-    pub param6: u32,
-    pub param7: u32,
-}
-
-pub type SpecCommandLongInner = (u8, (u8, (u16, (u8, (u32, (u32, (u32, (u32, (u32, (u32, u32))))))))));
-
-
-impl SpecFrom<SpecCommandLong> for SpecCommandLongInner {
-    open spec fn spec_from(m: SpecCommandLong) -> SpecCommandLongInner {
-        (m.target_system, (m.target_component, (m.command, (m.confirmation, (m.param1, (m.param2, (m.param3, (m.param4, (m.param5, (m.param6, m.param7))))))))))
-    }
-}
-
-impl SpecFrom<SpecCommandLongInner> for SpecCommandLong {
-    open spec fn spec_from(m: SpecCommandLongInner) -> SpecCommandLong {
-        let (target_system, (target_component, (command, (confirmation, (param1, (param2, (param3, (param4, (param5, (param6, param7)))))))))) = m;
-        SpecCommandLong { target_system, target_component, command, confirmation, param1, param2, param3, param4, param5, param6, param7 }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq)]
-
-pub struct CommandLong {
-    pub target_system: u8,
-    pub target_component: u8,
-    pub command: u16,
-    pub confirmation: u8,
-    pub param1: u32,
-    pub param2: u32,
-    pub param3: u32,
-    pub param4: u32,
-    pub param5: u32,
-    pub param6: u32,
-    pub param7: u32,
-}
-
-impl View for CommandLong {
-    type V = SpecCommandLong;
-
-    open spec fn view(&self) -> Self::V {
-        SpecCommandLong {
-            target_system: self.target_system@,
-            target_component: self.target_component@,
-            command: self.command@,
-            confirmation: self.confirmation@,
-            param1: self.param1@,
-            param2: self.param2@,
-            param3: self.param3@,
-            param4: self.param4@,
-            param5: self.param5@,
-            param6: self.param6@,
-            param7: self.param7@,
-        }
-    }
-}
-pub type CommandLongInner = (u8, (u8, (u16, (u8, (u32, (u32, (u32, (u32, (u32, (u32, u32))))))))));
-
-pub type CommandLongInnerRef<'a> = (&'a u8, (&'a u8, (&'a u16, (&'a u8, (&'a u32, (&'a u32, (&'a u32, (&'a u32, (&'a u32, (&'a u32, &'a u32))))))))));
-impl<'a> From<&'a CommandLong> for CommandLongInnerRef<'a> {
-    fn ex_from(m: &'a CommandLong) -> CommandLongInnerRef<'a> {
-        (&m.target_system, (&m.target_component, (&m.command, (&m.confirmation, (&m.param1, (&m.param2, (&m.param3, (&m.param4, (&m.param5, (&m.param6, &m.param7))))))))))
-    }
-}
-
-impl From<CommandLongInner> for CommandLong {
-    fn ex_from(m: CommandLongInner) -> CommandLong {
-        let (target_system, (target_component, (command, (confirmation, (param1, (param2, (param3, (param4, (param5, (param6, param7)))))))))) = m;
-        CommandLong { target_system, target_component, command, confirmation, param1, param2, param3, param4, param5, param6, param7 }
-    }
-}
-
-pub struct CommandLongMapper;
-impl View for CommandLongMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for CommandLongMapper {
-    type Src = SpecCommandLongInner;
-    type Dst = SpecCommandLong;
-}
-impl SpecIsoProof for CommandLongMapper {
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso<'a> for CommandLongMapper {
-    type Src = CommandLongInner;
-    type Dst = CommandLong;
-    type RefSrc = CommandLongInnerRef<'a>;
-}
-type SpecCommandLongCombinatorAlias1 = (U32Le, U32Le);
-type SpecCommandLongCombinatorAlias2 = (U32Le, SpecCommandLongCombinatorAlias1);
-type SpecCommandLongCombinatorAlias3 = (U32Le, SpecCommandLongCombinatorAlias2);
-type SpecCommandLongCombinatorAlias4 = (U32Le, SpecCommandLongCombinatorAlias3);
-type SpecCommandLongCombinatorAlias5 = (U32Le, SpecCommandLongCombinatorAlias4);
-type SpecCommandLongCombinatorAlias6 = (U32Le, SpecCommandLongCombinatorAlias5);
-type SpecCommandLongCombinatorAlias7 = (U8, SpecCommandLongCombinatorAlias6);
-type SpecCommandLongCombinatorAlias8 = (SpecMavCmdCombinator, SpecCommandLongCombinatorAlias7);
-type SpecCommandLongCombinatorAlias9 = (U8, SpecCommandLongCombinatorAlias8);
-type SpecCommandLongCombinatorAlias10 = (U8, SpecCommandLongCombinatorAlias9);
-pub struct SpecCommandLongCombinator(pub SpecCommandLongCombinatorAlias);
-
-impl SpecCombinator for SpecCommandLongCombinator {
-    type Type = SpecCommandLong;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecCommandLongCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecCommandLongCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecCommandLongCombinatorAlias = Mapped<SpecCommandLongCombinatorAlias10, CommandLongMapper>;
-type CommandLongCombinatorAlias1 = (U32Le, U32Le);
-type CommandLongCombinatorAlias2 = (U32Le, CommandLongCombinator1);
-type CommandLongCombinatorAlias3 = (U32Le, CommandLongCombinator2);
-type CommandLongCombinatorAlias4 = (U32Le, CommandLongCombinator3);
-type CommandLongCombinatorAlias5 = (U32Le, CommandLongCombinator4);
-type CommandLongCombinatorAlias6 = (U32Le, CommandLongCombinator5);
-type CommandLongCombinatorAlias7 = (U8, CommandLongCombinator6);
-type CommandLongCombinatorAlias8 = (MavCmdCombinator, CommandLongCombinator7);
-type CommandLongCombinatorAlias9 = (U8, CommandLongCombinator8);
-type CommandLongCombinatorAlias10 = (U8, CommandLongCombinator9);
-pub struct CommandLongCombinator1(pub CommandLongCombinatorAlias1);
-impl View for CommandLongCombinator1 {
-    type V = SpecCommandLongCombinatorAlias1;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator1, CommandLongCombinatorAlias1);
-
-pub struct CommandLongCombinator2(pub CommandLongCombinatorAlias2);
-impl View for CommandLongCombinator2 {
-    type V = SpecCommandLongCombinatorAlias2;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator2, CommandLongCombinatorAlias2);
-
-pub struct CommandLongCombinator3(pub CommandLongCombinatorAlias3);
-impl View for CommandLongCombinator3 {
-    type V = SpecCommandLongCombinatorAlias3;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator3, CommandLongCombinatorAlias3);
-
-pub struct CommandLongCombinator4(pub CommandLongCombinatorAlias4);
-impl View for CommandLongCombinator4 {
-    type V = SpecCommandLongCombinatorAlias4;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator4, CommandLongCombinatorAlias4);
-
-pub struct CommandLongCombinator5(pub CommandLongCombinatorAlias5);
-impl View for CommandLongCombinator5 {
-    type V = SpecCommandLongCombinatorAlias5;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator5, CommandLongCombinatorAlias5);
-
-pub struct CommandLongCombinator6(pub CommandLongCombinatorAlias6);
-impl View for CommandLongCombinator6 {
-    type V = SpecCommandLongCombinatorAlias6;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator6, CommandLongCombinatorAlias6);
-
-pub struct CommandLongCombinator7(pub CommandLongCombinatorAlias7);
-impl View for CommandLongCombinator7 {
-    type V = SpecCommandLongCombinatorAlias7;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator7, CommandLongCombinatorAlias7);
-
-pub struct CommandLongCombinator8(pub CommandLongCombinatorAlias8);
-impl View for CommandLongCombinator8 {
-    type V = SpecCommandLongCombinatorAlias8;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator8, CommandLongCombinatorAlias8);
-
-pub struct CommandLongCombinator9(pub CommandLongCombinatorAlias9);
-impl View for CommandLongCombinator9 {
-    type V = SpecCommandLongCombinatorAlias9;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator9, CommandLongCombinatorAlias9);
-
-pub struct CommandLongCombinator10(pub CommandLongCombinatorAlias10);
-impl View for CommandLongCombinator10 {
-    type V = SpecCommandLongCombinatorAlias10;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(CommandLongCombinator10, CommandLongCombinatorAlias10);
-
-pub struct CommandLongCombinator(pub CommandLongCombinatorAlias);
-
-impl View for CommandLongCombinator {
-    type V = SpecCommandLongCombinator;
-    open spec fn view(&self) -> Self::V { SpecCommandLongCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CommandLongCombinator {
-    type Type = CommandLong;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type CommandLongCombinatorAlias = Mapped<CommandLongCombinator10, CommandLongMapper>;
-
-
-pub open spec fn spec_command_long() -> SpecCommandLongCombinator {
-    SpecCommandLongCombinator(
-    Mapped {
-        inner: (U8, (U8, (spec_mav_cmd(), (U8, (U32Le, (U32Le, (U32Le, (U32Le, (U32Le, (U32Le, U32Le)))))))))),
-        mapper: CommandLongMapper,
-    })
-}
-
-                
-pub fn command_long<'a>() -> (o: CommandLongCombinator)
-    ensures o@ == spec_command_long(),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = CommandLongCombinator(
-    Mapped {
-        inner: CommandLongCombinator10((U8, CommandLongCombinator9((U8, CommandLongCombinator8((mav_cmd(), CommandLongCombinator7((U8, CommandLongCombinator6((U32Le, CommandLongCombinator5((U32Le, CommandLongCombinator4((U32Le, CommandLongCombinator3((U32Le, CommandLongCombinator2((U32Le, CommandLongCombinator1((U32Le, U32Le)))))))))))))))))))),
-        mapper: CommandLongMapper,
-    });
-    assert({
-        &&& combinator@ == spec_command_long()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_command_long<'a>(input: &'a [u8]) -> (res: PResult<<CommandLongCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_command_long().spec_parse(input@) == Some((n as int, v@)),
-        spec_command_long().spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_command_long().spec_parse(input@) is None,
-        spec_command_long().spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = command_long();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_command_long<'a>(v: <CommandLongCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_command_long().wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_command_long().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_command_long().spec_serialize(v@))
-        },
-{
-    let combinator = command_long();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
-}
-
-pub fn command_long_len<'a>(v: <CommandLongCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
-    requires
-        spec_command_long().wf(v@),
-        spec_command_long().spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_command_long().spec_serialize(v@).len(),
-{
-    let combinator = command_long();
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -2324,7 +1027,7 @@ impl SpecPartialIso for MavResultMapper {
 }
 
 impl SpecPartialIsoProof for MavResultMapper {
-    proof fn spec_iso(s: Self::Src) { 
+    proof fn spec_iso(s: Self::Src) {
         assert(
             Self::spec_apply(s) matches Ok(v) ==> {
             &&& Self::spec_rev_apply(v) is Ok
@@ -2332,7 +1035,7 @@ impl SpecPartialIsoProof for MavResultMapper {
         });
     }
 
-    proof fn spec_iso_rev(s: Self::Dst) { 
+    proof fn spec_iso_rev(s: Self::Dst) {
         assert(
             Self::spec_rev_apply(s) matches Ok(v) ==> {
             &&& Self::spec_apply(v) is Ok
@@ -2356,13 +1059,13 @@ impl SpecCombinator for SpecMavResultCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavResultCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavResultCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -2370,11 +1073,11 @@ impl SecureSpecCombinator for SpecMavResultCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavResultCombinatorAlias = TryMap<U8, MavResultMapper>;
@@ -2390,13 +1093,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavResultCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavResultCombinatorAlias = TryMap<U8, MavResultMapper>;
 
 
@@ -2411,11 +1114,11 @@ pub fn mav_result<'a>() -> (o: MavResultCombinator)
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = MavResultCombinator(TryMap { inner: U8, mapper: MavResultMapper });
-    assert({
-        &&& combinator@ == spec_mav_result()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_mav_result()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -2439,14 +1142,14 @@ pub fn serialize_mav_result<'a>(v: <MavResultCombinator as Combinator<'a, &'a [u
         spec_mav_result().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mav_result().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mav_result().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mav_result().spec_serialize(v@))
         },
 {
     let combinator = mav_result();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mav_result_len<'a>(v: <MavResultCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2457,6 +1160,1303 @@ pub fn mav_result_len<'a>(v: <MavResultCombinator as Combinator<'a, &'a [u8], Ve
         serialize_len == spec_mav_result().spec_serialize(v@).len(),
 {
     let combinator = mav_result();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+                
+
+pub enum SpecMavlinkV2MsgSignature {
+    Variant0(Seq<u8>),
+    Variant1(Seq<u8>),
+}
+
+pub type SpecMavlinkV2MsgSignatureInner = Either<Seq<u8>, Seq<u8>>;
+
+impl SpecFrom<SpecMavlinkV2MsgSignature> for SpecMavlinkV2MsgSignatureInner {
+    open spec fn spec_from(m: SpecMavlinkV2MsgSignature) -> SpecMavlinkV2MsgSignatureInner {
+        match m {
+            SpecMavlinkV2MsgSignature::Variant0(m) => Either::Left(m),
+            SpecMavlinkV2MsgSignature::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+                
+impl SpecFrom<SpecMavlinkV2MsgSignatureInner> for SpecMavlinkV2MsgSignature {
+    open spec fn spec_from(m: SpecMavlinkV2MsgSignatureInner) -> SpecMavlinkV2MsgSignature {
+        match m {
+            Either::Left(m) => SpecMavlinkV2MsgSignature::Variant0(m),
+            Either::Right(m) => SpecMavlinkV2MsgSignature::Variant1(m),
+        }
+    }
+
+}
+
+
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MavlinkV2MsgSignature<'a> {
+    Variant0(&'a [u8]),
+    Variant1(&'a [u8]),
+}
+
+pub type MavlinkV2MsgSignatureInner<'a> = Either<&'a [u8], &'a [u8]>;
+
+pub type MavlinkV2MsgSignatureInnerRef<'a> = Either<&'a &'a [u8], &'a &'a [u8]>;
+
+
+impl<'a> View for MavlinkV2MsgSignature<'a> {
+    type V = SpecMavlinkV2MsgSignature;
+    open spec fn view(&self) -> Self::V {
+        match self {
+            MavlinkV2MsgSignature::Variant0(m) => SpecMavlinkV2MsgSignature::Variant0(m@),
+            MavlinkV2MsgSignature::Variant1(m) => SpecMavlinkV2MsgSignature::Variant1(m@),
+        }
+    }
+}
+
+
+impl<'a> From<&'a MavlinkV2MsgSignature<'a>> for MavlinkV2MsgSignatureInnerRef<'a> {
+    fn ex_from(m: &'a MavlinkV2MsgSignature<'a>) -> MavlinkV2MsgSignatureInnerRef<'a> {
+        match m {
+            MavlinkV2MsgSignature::Variant0(m) => Either::Left(m),
+            MavlinkV2MsgSignature::Variant1(m) => Either::Right(m),
+        }
+    }
+
+}
+
+impl<'a> From<MavlinkV2MsgSignatureInner<'a>> for MavlinkV2MsgSignature<'a> {
+    fn ex_from(m: MavlinkV2MsgSignatureInner<'a>) -> MavlinkV2MsgSignature<'a> {
+        match m {
+            Either::Left(m) => MavlinkV2MsgSignature::Variant0(m),
+            Either::Right(m) => MavlinkV2MsgSignature::Variant1(m),
+        }
+    }
+    
+}
+
+
+pub struct MavlinkV2MsgSignatureMapper;
+impl View for MavlinkV2MsgSignatureMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for MavlinkV2MsgSignatureMapper {
+    type Src = SpecMavlinkV2MsgSignatureInner;
+    type Dst = SpecMavlinkV2MsgSignature;
+}
+impl SpecIsoProof for MavlinkV2MsgSignatureMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso<'a> for MavlinkV2MsgSignatureMapper {
+    type Src = MavlinkV2MsgSignatureInner<'a>;
+    type Dst = MavlinkV2MsgSignature<'a>;
+    type RefSrc = MavlinkV2MsgSignatureInnerRef<'a>;
+}
+
+type SpecMavlinkV2MsgSignatureCombinatorAlias1 = Choice<Cond<bytes::Fixed<13>>, Cond<bytes::Fixed<0>>>;
+pub struct SpecMavlinkV2MsgSignatureCombinator(pub SpecMavlinkV2MsgSignatureCombinatorAlias);
+
+impl SpecCombinator for SpecMavlinkV2MsgSignatureCombinator {
+    type Type = SpecMavlinkV2MsgSignature;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMavlinkV2MsgSignatureCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecMavlinkV2MsgSignatureCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMavlinkV2MsgSignatureCombinatorAlias = Mapped<SpecMavlinkV2MsgSignatureCombinatorAlias1, MavlinkV2MsgSignatureMapper>;
+type MavlinkV2MsgSignatureCombinatorAlias1 = Choice<Cond<bytes::Fixed<13>>, Cond<bytes::Fixed<0>>>;
+pub struct MavlinkV2MsgSignatureCombinator1(pub MavlinkV2MsgSignatureCombinatorAlias1);
+impl View for MavlinkV2MsgSignatureCombinator1 {
+    type V = SpecMavlinkV2MsgSignatureCombinatorAlias1;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(MavlinkV2MsgSignatureCombinator1, MavlinkV2MsgSignatureCombinatorAlias1);
+
+pub struct MavlinkV2MsgSignatureCombinator(pub MavlinkV2MsgSignatureCombinatorAlias);
+
+impl View for MavlinkV2MsgSignatureCombinator {
+    type V = SpecMavlinkV2MsgSignatureCombinator;
+    open spec fn view(&self) -> Self::V { SpecMavlinkV2MsgSignatureCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkV2MsgSignatureCombinator {
+    type Type = MavlinkV2MsgSignature<'a>;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type MavlinkV2MsgSignatureCombinatorAlias = Mapped<MavlinkV2MsgSignatureCombinator1, MavlinkV2MsgSignatureMapper>;
+
+
+pub open spec fn spec_mavlink_v2_msg_signature(incompat_flags: u8) -> SpecMavlinkV2MsgSignatureCombinator {
+    SpecMavlinkV2MsgSignatureCombinator(Mapped { inner: Choice(Cond { cond: incompat_flags == 1, inner: bytes::Fixed::<13> }, Cond { cond: !(incompat_flags == 1), inner: bytes::Fixed::<0> }), mapper: MavlinkV2MsgSignatureMapper })
+}
+
+pub fn mavlink_v2_msg_signature<'a>(incompat_flags: u8) -> (o: MavlinkV2MsgSignatureCombinator)
+    requires
+        spec_incompat_flags().wf(incompat_flags@),
+
+    ensures o@ == spec_mavlink_v2_msg_signature(incompat_flags@),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = MavlinkV2MsgSignatureCombinator(Mapped { inner: MavlinkV2MsgSignatureCombinator1(Choice::new(Cond { cond: incompat_flags == 1, inner: bytes::Fixed::<13> }, Cond { cond: !(incompat_flags == 1), inner: bytes::Fixed::<0> })), mapper: MavlinkV2MsgSignatureMapper });
+    // assert({
+    //     &&& combinator@ == spec_mavlink_v2_msg_signature(incompat_flags@)
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_mavlink_v2_msg_signature<'a>(input: &'a [u8], incompat_flags: u8) -> (res: PResult<<MavlinkV2MsgSignatureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+        spec_incompat_flags().wf(incompat_flags@),
+
+    ensures
+        res matches Ok((n, v)) ==> spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) == Some((n as int, v@)),
+        spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) is None,
+        spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = mavlink_v2_msg_signature( incompat_flags );
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_mavlink_v2_msg_signature<'a>(v: <MavlinkV2MsgSignatureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, incompat_flags: u8) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_mavlink_v2_msg_signature(incompat_flags@).wf(v@),
+        spec_incompat_flags().wf(incompat_flags@),
+
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@))
+        },
+{
+    let combinator = mavlink_v2_msg_signature( incompat_flags );
+    combinator.serialize(v, &mut *data, pos)
+}
+
+pub fn mavlink_v2_msg_signature_len<'a>(v: <MavlinkV2MsgSignatureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, incompat_flags: u8) -> (serialize_len: usize)
+    requires
+        spec_mavlink_v2_msg_signature(incompat_flags@).wf(v@),
+        spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@).len() <= usize::MAX,
+        spec_incompat_flags().wf(incompat_flags@),
+
+    ensures
+        serialize_len == spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@).len(),
+{
+    let combinator = mavlink_v2_msg_signature( incompat_flags );
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+pub mod MessageIds {
+    use super::*;
+    pub spec const SPEC_CommandInt: u32 = 75;
+    pub spec const SPEC_CommandLong: u32 = 76;
+    pub spec const SPEC_CommandAck: u32 = 77;
+    pub spec const SPEC_CommandCancel: u32 = 80;
+    pub spec const SPEC_TerrainRequest: u32 = 134;
+    pub spec const SPEC_Reserved: u32 = 8388608;
+    pub exec const CommandInt: u32 ensures CommandInt == SPEC_CommandInt { 75 }
+    pub exec const CommandLong: u32 ensures CommandLong == SPEC_CommandLong { 76 }
+    pub exec const CommandAck: u32 ensures CommandAck == SPEC_CommandAck { 77 }
+    pub exec const CommandCancel: u32 ensures CommandCancel == SPEC_CommandCancel { 80 }
+    pub exec const TerrainRequest: u32 ensures TerrainRequest == SPEC_TerrainRequest { 134 }
+    pub exec const Reserved: u32 ensures Reserved == SPEC_Reserved { 8388608 }
+}
+
+
+pub struct SpecMessageIdsCombinator(pub SpecMessageIdsCombinatorAlias);
+
+impl SpecCombinator for SpecMessageIdsCombinator {
+    type Type = u24;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMessageIdsCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecMessageIdsCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMessageIdsCombinatorAlias = U24Le;
+
+pub struct MessageIdsCombinator(pub MessageIdsCombinatorAlias);
+
+impl View for MessageIdsCombinator {
+    type V = SpecMessageIdsCombinator;
+    open spec fn view(&self) -> Self::V { SpecMessageIdsCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MessageIdsCombinator {
+    type Type = u24;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type MessageIdsCombinatorAlias = U24Le;
+
+
+pub open spec fn spec_message_ids() -> SpecMessageIdsCombinator {
+    SpecMessageIdsCombinator(U24Le)
+}
+
+                
+pub fn message_ids<'a>() -> (o: MessageIdsCombinator)
+    ensures o@ == spec_message_ids(),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = MessageIdsCombinator(U24Le);
+    // assert({
+    //     &&& combinator@ == spec_message_ids()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_message_ids<'a>(input: &'a [u8]) -> (res: PResult<<MessageIdsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+    ensures
+        res matches Ok((n, v)) ==> spec_message_ids().spec_parse(input@) == Some((n as int, v@)),
+        spec_message_ids().spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_message_ids().spec_parse(input@) is None,
+        spec_message_ids().spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = message_ids();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_message_ids<'a>(v: <MessageIdsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_message_ids().wf(v@),
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_message_ids().spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_message_ids().spec_serialize(v@))
+        },
+{
+    let combinator = message_ids();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
+}
+
+pub fn message_ids_len<'a>(v: <MessageIdsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
+    requires
+        spec_message_ids().wf(v@),
+        spec_message_ids().spec_serialize(v@).len() <= usize::MAX,
+    ensures
+        serialize_len == spec_message_ids().spec_serialize(v@).len(),
+{
+    let combinator = message_ids();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+                
+
+pub struct SpecCommandLong {
+    pub target_system: u8,
+    pub target_component: u8,
+    pub command: u16,
+    pub confirmation: u8,
+    pub param1: u32,
+    pub param2: u32,
+    pub param3: u32,
+    pub param4: u32,
+    pub param5: u32,
+    pub param6: u32,
+    pub param7: u32,
+}
+
+pub type SpecCommandLongInner = (u8, (u8, (u16, (u8, (u32, (u32, (u32, (u32, (u32, (u32, u32))))))))));
+
+
+impl SpecFrom<SpecCommandLong> for SpecCommandLongInner {
+    open spec fn spec_from(m: SpecCommandLong) -> SpecCommandLongInner {
+        (m.target_system, (m.target_component, (m.command, (m.confirmation, (m.param1, (m.param2, (m.param3, (m.param4, (m.param5, (m.param6, m.param7))))))))))
+    }
+}
+
+impl SpecFrom<SpecCommandLongInner> for SpecCommandLong {
+    open spec fn spec_from(m: SpecCommandLongInner) -> SpecCommandLong {
+        let (target_system, (target_component, (command, (confirmation, (param1, (param2, (param3, (param4, (param5, (param6, param7)))))))))) = m;
+        SpecCommandLong { target_system, target_component, command, confirmation, param1, param2, param3, param4, param5, param6, param7 }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct CommandLong {
+    pub target_system: u8,
+    pub target_component: u8,
+    pub command: u16,
+    pub confirmation: u8,
+    pub param1: u32,
+    pub param2: u32,
+    pub param3: u32,
+    pub param4: u32,
+    pub param5: u32,
+    pub param6: u32,
+    pub param7: u32,
+}
+
+impl View for CommandLong {
+    type V = SpecCommandLong;
+
+    open spec fn view(&self) -> Self::V {
+        SpecCommandLong {
+            target_system: self.target_system@,
+            target_component: self.target_component@,
+            command: self.command@,
+            confirmation: self.confirmation@,
+            param1: self.param1@,
+            param2: self.param2@,
+            param3: self.param3@,
+            param4: self.param4@,
+            param5: self.param5@,
+            param6: self.param6@,
+            param7: self.param7@,
+        }
+    }
+}
+pub type CommandLongInner = (u8, (u8, (u16, (u8, (u32, (u32, (u32, (u32, (u32, (u32, u32))))))))));
+
+pub type CommandLongInnerRef<'a> = (&'a u8, (&'a u8, (&'a u16, (&'a u8, (&'a u32, (&'a u32, (&'a u32, (&'a u32, (&'a u32, (&'a u32, &'a u32))))))))));
+impl<'a> From<&'a CommandLong> for CommandLongInnerRef<'a> {
+    fn ex_from(m: &'a CommandLong) -> CommandLongInnerRef<'a> {
+        (&m.target_system, (&m.target_component, (&m.command, (&m.confirmation, (&m.param1, (&m.param2, (&m.param3, (&m.param4, (&m.param5, (&m.param6, &m.param7))))))))))
+    }
+}
+
+impl From<CommandLongInner> for CommandLong {
+    fn ex_from(m: CommandLongInner) -> CommandLong {
+        let (target_system, (target_component, (command, (confirmation, (param1, (param2, (param3, (param4, (param5, (param6, param7)))))))))) = m;
+        CommandLong { target_system, target_component, command, confirmation, param1, param2, param3, param4, param5, param6, param7 }
+    }
+}
+
+pub struct CommandLongMapper;
+impl View for CommandLongMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for CommandLongMapper {
+    type Src = SpecCommandLongInner;
+    type Dst = SpecCommandLong;
+}
+impl SpecIsoProof for CommandLongMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso<'a> for CommandLongMapper {
+    type Src = CommandLongInner;
+    type Dst = CommandLong;
+    type RefSrc = CommandLongInnerRef<'a>;
+}
+type SpecCommandLongCombinatorAlias1 = (U32Le, U32Le);
+type SpecCommandLongCombinatorAlias2 = (U32Le, SpecCommandLongCombinatorAlias1);
+type SpecCommandLongCombinatorAlias3 = (U32Le, SpecCommandLongCombinatorAlias2);
+type SpecCommandLongCombinatorAlias4 = (U32Le, SpecCommandLongCombinatorAlias3);
+type SpecCommandLongCombinatorAlias5 = (U32Le, SpecCommandLongCombinatorAlias4);
+type SpecCommandLongCombinatorAlias6 = (U32Le, SpecCommandLongCombinatorAlias5);
+type SpecCommandLongCombinatorAlias7 = (U8, SpecCommandLongCombinatorAlias6);
+type SpecCommandLongCombinatorAlias8 = (SpecMavCmdCombinator, SpecCommandLongCombinatorAlias7);
+type SpecCommandLongCombinatorAlias9 = (U8, SpecCommandLongCombinatorAlias8);
+type SpecCommandLongCombinatorAlias10 = (U8, SpecCommandLongCombinatorAlias9);
+pub struct SpecCommandLongCombinator(pub SpecCommandLongCombinatorAlias);
+
+impl SpecCombinator for SpecCommandLongCombinator {
+    type Type = SpecCommandLong;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecCommandLongCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecCommandLongCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecCommandLongCombinatorAlias = Mapped<SpecCommandLongCombinatorAlias10, CommandLongMapper>;
+type CommandLongCombinatorAlias1 = (U32Le, U32Le);
+type CommandLongCombinatorAlias2 = (U32Le, CommandLongCombinator1);
+type CommandLongCombinatorAlias3 = (U32Le, CommandLongCombinator2);
+type CommandLongCombinatorAlias4 = (U32Le, CommandLongCombinator3);
+type CommandLongCombinatorAlias5 = (U32Le, CommandLongCombinator4);
+type CommandLongCombinatorAlias6 = (U32Le, CommandLongCombinator5);
+type CommandLongCombinatorAlias7 = (U8, CommandLongCombinator6);
+type CommandLongCombinatorAlias8 = (MavCmdCombinator, CommandLongCombinator7);
+type CommandLongCombinatorAlias9 = (U8, CommandLongCombinator8);
+type CommandLongCombinatorAlias10 = (U8, CommandLongCombinator9);
+pub struct CommandLongCombinator1(pub CommandLongCombinatorAlias1);
+impl View for CommandLongCombinator1 {
+    type V = SpecCommandLongCombinatorAlias1;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator1, CommandLongCombinatorAlias1);
+
+pub struct CommandLongCombinator2(pub CommandLongCombinatorAlias2);
+impl View for CommandLongCombinator2 {
+    type V = SpecCommandLongCombinatorAlias2;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator2, CommandLongCombinatorAlias2);
+
+pub struct CommandLongCombinator3(pub CommandLongCombinatorAlias3);
+impl View for CommandLongCombinator3 {
+    type V = SpecCommandLongCombinatorAlias3;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator3, CommandLongCombinatorAlias3);
+
+pub struct CommandLongCombinator4(pub CommandLongCombinatorAlias4);
+impl View for CommandLongCombinator4 {
+    type V = SpecCommandLongCombinatorAlias4;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator4, CommandLongCombinatorAlias4);
+
+pub struct CommandLongCombinator5(pub CommandLongCombinatorAlias5);
+impl View for CommandLongCombinator5 {
+    type V = SpecCommandLongCombinatorAlias5;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator5, CommandLongCombinatorAlias5);
+
+pub struct CommandLongCombinator6(pub CommandLongCombinatorAlias6);
+impl View for CommandLongCombinator6 {
+    type V = SpecCommandLongCombinatorAlias6;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator6, CommandLongCombinatorAlias6);
+
+pub struct CommandLongCombinator7(pub CommandLongCombinatorAlias7);
+impl View for CommandLongCombinator7 {
+    type V = SpecCommandLongCombinatorAlias7;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator7, CommandLongCombinatorAlias7);
+
+pub struct CommandLongCombinator8(pub CommandLongCombinatorAlias8);
+impl View for CommandLongCombinator8 {
+    type V = SpecCommandLongCombinatorAlias8;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator8, CommandLongCombinatorAlias8);
+
+pub struct CommandLongCombinator9(pub CommandLongCombinatorAlias9);
+impl View for CommandLongCombinator9 {
+    type V = SpecCommandLongCombinatorAlias9;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator9, CommandLongCombinatorAlias9);
+
+pub struct CommandLongCombinator10(pub CommandLongCombinatorAlias10);
+impl View for CommandLongCombinator10 {
+    type V = SpecCommandLongCombinatorAlias10;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(CommandLongCombinator10, CommandLongCombinatorAlias10);
+
+pub struct CommandLongCombinator(pub CommandLongCombinatorAlias);
+
+impl View for CommandLongCombinator {
+    type V = SpecCommandLongCombinator;
+    open spec fn view(&self) -> Self::V { SpecCommandLongCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CommandLongCombinator {
+    type Type = CommandLong;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type CommandLongCombinatorAlias = Mapped<CommandLongCombinator10, CommandLongMapper>;
+
+
+pub open spec fn spec_command_long() -> SpecCommandLongCombinator {
+    SpecCommandLongCombinator(
+    Mapped {
+        inner: (U8, (U8, (spec_mav_cmd(), (U8, (U32Le, (U32Le, (U32Le, (U32Le, (U32Le, (U32Le, U32Le)))))))))),
+        mapper: CommandLongMapper,
+    })
+}
+
+                
+pub fn command_long<'a>() -> (o: CommandLongCombinator)
+    ensures o@ == spec_command_long(),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = CommandLongCombinator(
+    Mapped {
+        inner: CommandLongCombinator10((U8, CommandLongCombinator9((U8, CommandLongCombinator8((mav_cmd(), CommandLongCombinator7((U8, CommandLongCombinator6((U32Le, CommandLongCombinator5((U32Le, CommandLongCombinator4((U32Le, CommandLongCombinator3((U32Le, CommandLongCombinator2((U32Le, CommandLongCombinator1((U32Le, U32Le)))))))))))))))))))),
+        mapper: CommandLongMapper,
+    });
+    // assert({
+    //     &&& combinator@ == spec_command_long()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_command_long<'a>(input: &'a [u8]) -> (res: PResult<<CommandLongCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+    ensures
+        res matches Ok((n, v)) ==> spec_command_long().spec_parse(input@) == Some((n as int, v@)),
+        spec_command_long().spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_command_long().spec_parse(input@) is None,
+        spec_command_long().spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = command_long();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_command_long<'a>(v: <CommandLongCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_command_long().wf(v@),
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_command_long().spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_command_long().spec_serialize(v@))
+        },
+{
+    let combinator = command_long();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
+}
+
+pub fn command_long_len<'a>(v: <CommandLongCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
+    requires
+        spec_command_long().wf(v@),
+        spec_command_long().spec_serialize(v@).len() <= usize::MAX,
+    ensures
+        serialize_len == spec_command_long().spec_serialize(v@).len(),
+{
+    let combinator = command_long();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+                
+
+pub spec const SPEC_ProtocolMagic_MavLink1: u8 = 254;
+pub spec const SPEC_ProtocolMagic_MavLink2: u8 = 253;
+pub exec static EXEC_ProtocolMagic_MavLink1: u8 ensures EXEC_ProtocolMagic_MavLink1 == SPEC_ProtocolMagic_MavLink1 { 254 }
+pub exec static EXEC_ProtocolMagic_MavLink2: u8 ensures EXEC_ProtocolMagic_MavLink2 == SPEC_ProtocolMagic_MavLink2 { 253 }
+
+#[derive(Structural, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ProtocolMagic {
+    MavLink1 = 254,
+MavLink2 = 253
+}
+pub type SpecProtocolMagic = ProtocolMagic;
+
+pub type ProtocolMagicInner = u8;
+
+pub type ProtocolMagicInnerRef<'a> = &'a u8;
+
+impl View for ProtocolMagic {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecTryFrom<ProtocolMagicInner> for ProtocolMagic {
+    type Error = ();
+
+    open spec fn spec_try_from(v: ProtocolMagicInner) -> Result<ProtocolMagic, ()> {
+        match v {
+            254u8 => Ok(ProtocolMagic::MavLink1),
+            253u8 => Ok(ProtocolMagic::MavLink2),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SpecTryFrom<ProtocolMagic> for ProtocolMagicInner {
+    type Error = ();
+
+    open spec fn spec_try_from(v: ProtocolMagic) -> Result<ProtocolMagicInner, ()> {
+        match v {
+            ProtocolMagic::MavLink1 => Ok(SPEC_ProtocolMagic_MavLink1),
+            ProtocolMagic::MavLink2 => Ok(SPEC_ProtocolMagic_MavLink2),
+        }
+    }
+}
+
+impl TryFrom<ProtocolMagicInner> for ProtocolMagic {
+    type Error = ();
+
+    fn ex_try_from(v: ProtocolMagicInner) -> Result<ProtocolMagic, ()> {
+        match v {
+            254u8 => Ok(ProtocolMagic::MavLink1),
+            253u8 => Ok(ProtocolMagic::MavLink2),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a ProtocolMagic> for ProtocolMagicInnerRef<'a> {
+    type Error = ();
+
+    fn ex_try_from(v: &'a ProtocolMagic) -> Result<ProtocolMagicInnerRef<'a>, ()> {
+        match v {
+            ProtocolMagic::MavLink1 => Ok(&EXEC_ProtocolMagic_MavLink1),
+            ProtocolMagic::MavLink2 => Ok(&EXEC_ProtocolMagic_MavLink2),
+        }
+    }
+}
+
+pub struct ProtocolMagicMapper;
+
+impl View for ProtocolMagicMapper {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+
+impl SpecPartialIso for ProtocolMagicMapper {
+    type Src = ProtocolMagicInner;
+    type Dst = ProtocolMagic;
+}
+
+impl SpecPartialIsoProof for ProtocolMagicMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(
+            Self::spec_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_rev_apply(v) is Ok
+            &&& Self::spec_rev_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(
+            Self::spec_rev_apply(s) matches Ok(v) ==> {
+            &&& Self::spec_apply(v) is Ok
+            &&& Self::spec_apply(v) matches Ok(s_) && s == s_
+        });
+    }
+}
+
+impl<'a> PartialIso<'a> for ProtocolMagicMapper {
+    type Src = ProtocolMagicInner;
+    type Dst = ProtocolMagic;
+    type RefSrc = ProtocolMagicInnerRef<'a>;
+}
+
+
+pub struct SpecProtocolMagicCombinator(pub SpecProtocolMagicCombinatorAlias);
+
+impl SpecCombinator for SpecProtocolMagicCombinator {
+    type Type = SpecProtocolMagic;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecProtocolMagicCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecProtocolMagicCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecProtocolMagicCombinatorAlias = TryMap<U8, ProtocolMagicMapper>;
+
+pub struct ProtocolMagicCombinator(pub ProtocolMagicCombinatorAlias);
+
+impl View for ProtocolMagicCombinator {
+    type V = SpecProtocolMagicCombinator;
+    open spec fn view(&self) -> Self::V { SpecProtocolMagicCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProtocolMagicCombinator {
+    type Type = ProtocolMagic;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type ProtocolMagicCombinatorAlias = TryMap<U8, ProtocolMagicMapper>;
+
+
+pub open spec fn spec_protocol_magic() -> SpecProtocolMagicCombinator {
+    SpecProtocolMagicCombinator(TryMap { inner: U8, mapper: ProtocolMagicMapper })
+}
+
+                
+pub fn protocol_magic<'a>() -> (o: ProtocolMagicCombinator)
+    ensures o@ == spec_protocol_magic(),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = ProtocolMagicCombinator(TryMap { inner: U8, mapper: ProtocolMagicMapper });
+    // assert({
+    //     &&& combinator@ == spec_protocol_magic()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_protocol_magic<'a>(input: &'a [u8]) -> (res: PResult<<ProtocolMagicCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+    ensures
+        res matches Ok((n, v)) ==> spec_protocol_magic().spec_parse(input@) == Some((n as int, v@)),
+        spec_protocol_magic().spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_protocol_magic().spec_parse(input@) is None,
+        spec_protocol_magic().spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = protocol_magic();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_protocol_magic<'a>(v: <ProtocolMagicCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_protocol_magic().wf(v@),
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_protocol_magic().spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_protocol_magic().spec_serialize(v@))
+        },
+{
+    let combinator = protocol_magic();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
+}
+
+pub fn protocol_magic_len<'a>(v: <ProtocolMagicCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
+    requires
+        spec_protocol_magic().wf(v@),
+        spec_protocol_magic().spec_serialize(v@).len() <= usize::MAX,
+    ensures
+        serialize_len == spec_protocol_magic().spec_serialize(v@).len(),
+{
+    let combinator = protocol_magic();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+                
+
+pub struct SpecMavlinkV1Msg {
+    pub len: u8,
+    pub seq: u8,
+    pub sysid: u8,
+    pub compid: u8,
+    pub msgid: u8,
+    pub payload: Seq<u8>,
+    pub checksum: u16,
+}
+
+pub type SpecMavlinkV1MsgInner = (u8, (u8, (u8, (u8, (u8, (Seq<u8>, u16))))));
+
+
+impl SpecFrom<SpecMavlinkV1Msg> for SpecMavlinkV1MsgInner {
+    open spec fn spec_from(m: SpecMavlinkV1Msg) -> SpecMavlinkV1MsgInner {
+        (m.len, (m.seq, (m.sysid, (m.compid, (m.msgid, (m.payload, m.checksum))))))
+    }
+}
+
+impl SpecFrom<SpecMavlinkV1MsgInner> for SpecMavlinkV1Msg {
+    open spec fn spec_from(m: SpecMavlinkV1MsgInner) -> SpecMavlinkV1Msg {
+        let (len, (seq, (sysid, (compid, (msgid, (payload, checksum)))))) = m;
+        SpecMavlinkV1Msg { len, seq, sysid, compid, msgid, payload, checksum }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct MavlinkV1Msg<'a> {
+    pub len: u8,
+    pub seq: u8,
+    pub sysid: u8,
+    pub compid: u8,
+    pub msgid: u8,
+    pub payload: &'a [u8],
+    pub checksum: u16,
+}
+
+impl View for MavlinkV1Msg<'_> {
+    type V = SpecMavlinkV1Msg;
+
+    open spec fn view(&self) -> Self::V {
+        SpecMavlinkV1Msg {
+            len: self.len@,
+            seq: self.seq@,
+            sysid: self.sysid@,
+            compid: self.compid@,
+            msgid: self.msgid@,
+            payload: self.payload@,
+            checksum: self.checksum@,
+        }
+    }
+}
+pub type MavlinkV1MsgInner<'a> = (u8, (u8, (u8, (u8, (u8, (&'a [u8], u16))))));
+
+pub type MavlinkV1MsgInnerRef<'a> = (&'a u8, (&'a u8, (&'a u8, (&'a u8, (&'a u8, (&'a &'a [u8], &'a u16))))));
+impl<'a> From<&'a MavlinkV1Msg<'a>> for MavlinkV1MsgInnerRef<'a> {
+    fn ex_from(m: &'a MavlinkV1Msg) -> MavlinkV1MsgInnerRef<'a> {
+        (&m.len, (&m.seq, (&m.sysid, (&m.compid, (&m.msgid, (&m.payload, &m.checksum))))))
+    }
+}
+
+impl<'a> From<MavlinkV1MsgInner<'a>> for MavlinkV1Msg<'a> {
+    fn ex_from(m: MavlinkV1MsgInner) -> MavlinkV1Msg {
+        let (len, (seq, (sysid, (compid, (msgid, (payload, checksum)))))) = m;
+        MavlinkV1Msg { len, seq, sysid, compid, msgid, payload, checksum }
+    }
+}
+
+pub struct MavlinkV1MsgMapper;
+impl View for MavlinkV1MsgMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for MavlinkV1MsgMapper {
+    type Src = SpecMavlinkV1MsgInner;
+    type Dst = SpecMavlinkV1Msg;
+}
+impl SpecIsoProof for MavlinkV1MsgMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso<'a> for MavlinkV1MsgMapper {
+    type Src = MavlinkV1MsgInner<'a>;
+    type Dst = MavlinkV1Msg<'a>;
+    type RefSrc = MavlinkV1MsgInnerRef<'a>;
+}
+
+pub struct SpecMavlinkV1MsgCombinator(pub SpecMavlinkV1MsgCombinatorAlias);
+
+impl SpecCombinator for SpecMavlinkV1MsgCombinator {
+    type Type = SpecMavlinkV1Msg;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecMavlinkV1MsgCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecMavlinkV1MsgCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecMavlinkV1MsgCombinatorAlias = Mapped<SpecPair<U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le)))))>, MavlinkV1MsgMapper>;
+pub struct Predicate3768926651291043512;
+impl View for Predicate3768926651291043512 {
+    type V = Self;
+
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl Pred<u8> for Predicate3768926651291043512 {
+    fn apply(&self, i: &u8) -> bool {
+        let i = (*i);
+        (i >= 1)
+    }
+}
+impl SpecPred<u8> for Predicate3768926651291043512 {
+    open spec fn spec_apply(&self, i: &u8) -> bool {
+        let i = (*i);
+        (i >= 1)
+    }
+}
+
+pub struct MavlinkV1MsgCombinator(pub MavlinkV1MsgCombinatorAlias);
+
+impl View for MavlinkV1MsgCombinator {
+    type V = SpecMavlinkV1MsgCombinator;
+    open spec fn view(&self) -> Self::V { SpecMavlinkV1MsgCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkV1MsgCombinator {
+    type Type = MavlinkV1Msg<'a>;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type MavlinkV1MsgCombinatorAlias = Mapped<Pair<U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le))))), MavlinkV1MsgCont0>, MavlinkV1MsgMapper>;
+
+
+pub open spec fn spec_mavlink_v1_msg() -> SpecMavlinkV1MsgCombinator {
+    SpecMavlinkV1MsgCombinator(
+    Mapped {
+        inner: Pair::spec_new(U8, |deps| spec_mavlink_v1_msg_cont0(deps)),
+        mapper: MavlinkV1MsgMapper,
+    })
+}
+
+pub open spec fn spec_mavlink_v1_msg_cont0(deps: u8) -> (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le))))) {
+    let len = deps;
+    (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (U8, (bytes::Variable((usize::spec_from(len)) as usize), U16Le)))))
+}
+
+impl View for MavlinkV1MsgCont0 {
+    type V = spec_fn(u8) -> (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le)))));
+
+    open spec fn view(&self) -> Self::V {
+        |deps: u8| {
+            spec_mavlink_v1_msg_cont0(deps)
+        }
+    }
+}
+
+                
+pub fn mavlink_v1_msg<'a>() -> (o: MavlinkV1MsgCombinator)
+    ensures o@ == spec_mavlink_v1_msg(),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = MavlinkV1MsgCombinator(
+    Mapped {
+        inner: Pair::new(U8, MavlinkV1MsgCont0),
+        mapper: MavlinkV1MsgMapper,
+    });
+    // assert({
+    //     &&& combinator@ == spec_mavlink_v1_msg()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_mavlink_v1_msg<'a>(input: &'a [u8]) -> (res: PResult<<MavlinkV1MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+    ensures
+        res matches Ok((n, v)) ==> spec_mavlink_v1_msg().spec_parse(input@) == Some((n as int, v@)),
+        spec_mavlink_v1_msg().spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_mavlink_v1_msg().spec_parse(input@) is None,
+        spec_mavlink_v1_msg().spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = mavlink_v1_msg();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_mavlink_v1_msg<'a>(v: <MavlinkV1MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_mavlink_v1_msg().wf(v@),
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_mavlink_v1_msg().spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mavlink_v1_msg().spec_serialize(v@))
+        },
+{
+    let combinator = mavlink_v1_msg();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
+}
+
+pub fn mavlink_v1_msg_len<'a>(v: <MavlinkV1MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
+    requires
+        spec_mavlink_v1_msg().wf(v@),
+        spec_mavlink_v1_msg().spec_serialize(v@).len() <= usize::MAX,
+    ensures
+        serialize_len == spec_mavlink_v1_msg().spec_serialize(v@).len(),
+{
+    let combinator = mavlink_v1_msg();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+pub struct MavlinkV1MsgCont0;
+type MavlinkV1MsgCont0Type<'a, 'b> = &'b u8;
+type MavlinkV1MsgCont0SType<'a, 'x> = &'x u8;
+type MavlinkV1MsgCont0Input<'a, 'b, 'x> = POrSType<MavlinkV1MsgCont0Type<'a, 'b>, MavlinkV1MsgCont0SType<'a, 'x>>;
+impl<'a, 'b, 'x> Continuation<MavlinkV1MsgCont0Input<'a, 'b, 'x>> for MavlinkV1MsgCont0 {
+    type Output = (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, (U8, (bytes::Variable, U16Le)))));
+
+    open spec fn requires(&self, deps: MavlinkV1MsgCont0Input<'a, 'b, 'x>) -> bool {
+        &&& (U8).wf(deps@)
+        }
+
+    open spec fn ensures(&self, deps: MavlinkV1MsgCont0Input<'a, 'b, 'x>, o: Self::Output) -> bool {
+        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o)
+        &&& o@ == spec_mavlink_v1_msg_cont0(deps@)
+    }
+
+    fn apply(&self, deps: MavlinkV1MsgCont0Input<'a, 'b, 'x>) -> Self::Output {
+        match deps {
+            POrSType::P(deps) => {
+                let len = deps;
+                let len = *len;
+                (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (U8, (bytes::Variable((usize::ex_from(len)) as usize), U16Le)))))
+            }
+            POrSType::S(deps) => {
+                let len = deps;
+                let len = *len;
+                (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (U8, (bytes::Variable((usize::ex_from(len)) as usize), U16Le)))))
+            }
+        }
+    }
+}
+                
+pub mod IncompatFlags {
+    use super::*;
+    pub spec const SPEC_Signed: u8 = 1;
+    pub exec const Signed: u8 ensures Signed == SPEC_Signed { 1 }
+}
+
+
+pub struct SpecIncompatFlagsCombinator(pub SpecIncompatFlagsCombinatorAlias);
+
+impl SpecCombinator for SpecIncompatFlagsCombinator {
+    type Type = u8;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecIncompatFlagsCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecIncompatFlagsCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecIncompatFlagsCombinatorAlias = U8;
+
+pub struct IncompatFlagsCombinator(pub IncompatFlagsCombinatorAlias);
+
+impl View for IncompatFlagsCombinator {
+    type V = SpecIncompatFlagsCombinator;
+    open spec fn view(&self) -> Self::V { SpecIncompatFlagsCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IncompatFlagsCombinator {
+    type Type = u8;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type IncompatFlagsCombinatorAlias = U8;
+
+
+pub open spec fn spec_incompat_flags() -> SpecIncompatFlagsCombinator {
+    SpecIncompatFlagsCombinator(U8)
+}
+
+                
+pub fn incompat_flags<'a>() -> (o: IncompatFlagsCombinator)
+    ensures o@ == spec_incompat_flags(),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = IncompatFlagsCombinator(U8);
+    // assert({
+    //     &&& combinator@ == spec_incompat_flags()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_incompat_flags<'a>(input: &'a [u8]) -> (res: PResult<<IncompatFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+    ensures
+        res matches Ok((n, v)) ==> spec_incompat_flags().spec_parse(input@) == Some((n as int, v@)),
+        spec_incompat_flags().spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_incompat_flags().spec_parse(input@) is None,
+        spec_incompat_flags().spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = incompat_flags();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_incompat_flags<'a>(v: <IncompatFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_incompat_flags().wf(v@),
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_incompat_flags().spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_incompat_flags().spec_serialize(v@))
+        },
+{
+    let combinator = incompat_flags();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
+}
+
+pub fn incompat_flags_len<'a>(v: <IncompatFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
+    requires
+        spec_incompat_flags().wf(v@),
+        spec_incompat_flags().spec_serialize(v@).len() <= usize::MAX,
+    ensures
+        serialize_len == spec_incompat_flags().spec_serialize(v@).len(),
+{
+    let combinator = incompat_flags();
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -2564,13 +2564,13 @@ impl SpecCombinator for SpecCommandAckCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecCommandAckCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecCommandAckCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -2578,11 +2578,11 @@ impl SecureSpecCombinator for SpecCommandAckCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecCommandAckCombinatorAlias = Mapped<SpecCommandAckCombinatorAlias5, CommandAckMapper>;
@@ -2657,13 +2657,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CommandAckCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type CommandAckCombinatorAlias = Mapped<CommandAckCombinator5, CommandAckMapper>;
 
 
@@ -2686,11 +2686,11 @@ pub fn command_ack<'a>() -> (o: CommandAckCombinator)
         inner: CommandAckCombinator5((mav_cmd(), CommandAckCombinator4((mav_result(), CommandAckCombinator3((Refined { inner: U8, predicate: Predicate5789190955059586907 }, CommandAckCombinator2((U32Le, CommandAckCombinator1((U8, U8)))))))))),
         mapper: CommandAckMapper,
     });
-    assert({
-        &&& combinator@ == spec_command_ack()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_command_ack()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -2714,14 +2714,14 @@ pub fn serialize_command_ack<'a>(v: <CommandAckCombinator as Combinator<'a, &'a 
         spec_command_ack().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_command_ack().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_command_ack().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_command_ack().spec_serialize(v@))
         },
 {
     let combinator = command_ack();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn command_ack_len<'a>(v: <CommandAckCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2732,6 +2732,237 @@ pub fn command_ack_len<'a>(v: <CommandAckCombinator as Combinator<'a, &'a [u8], 
         serialize_len == spec_command_ack().spec_serialize(v@).len(),
 {
     let combinator = command_ack();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
+}
+
+                
+
+pub struct SpecTerrainRequest {
+    pub lat: u32,
+    pub lon: u32,
+    pub grid_spacing: u16,
+    pub mask: u64,
+}
+
+pub type SpecTerrainRequestInner = (u32, (u32, (u16, u64)));
+
+
+impl SpecFrom<SpecTerrainRequest> for SpecTerrainRequestInner {
+    open spec fn spec_from(m: SpecTerrainRequest) -> SpecTerrainRequestInner {
+        (m.lat, (m.lon, (m.grid_spacing, m.mask)))
+    }
+}
+
+impl SpecFrom<SpecTerrainRequestInner> for SpecTerrainRequest {
+    open spec fn spec_from(m: SpecTerrainRequestInner) -> SpecTerrainRequest {
+        let (lat, (lon, (grid_spacing, mask))) = m;
+        SpecTerrainRequest { lat, lon, grid_spacing, mask }
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub struct TerrainRequest {
+    pub lat: u32,
+    pub lon: u32,
+    pub grid_spacing: u16,
+    pub mask: u64,
+}
+
+impl View for TerrainRequest {
+    type V = SpecTerrainRequest;
+
+    open spec fn view(&self) -> Self::V {
+        SpecTerrainRequest {
+            lat: self.lat@,
+            lon: self.lon@,
+            grid_spacing: self.grid_spacing@,
+            mask: self.mask@,
+        }
+    }
+}
+pub type TerrainRequestInner = (u32, (u32, (u16, u64)));
+
+pub type TerrainRequestInnerRef<'a> = (&'a u32, (&'a u32, (&'a u16, &'a u64)));
+impl<'a> From<&'a TerrainRequest> for TerrainRequestInnerRef<'a> {
+    fn ex_from(m: &'a TerrainRequest) -> TerrainRequestInnerRef<'a> {
+        (&m.lat, (&m.lon, (&m.grid_spacing, &m.mask)))
+    }
+}
+
+impl From<TerrainRequestInner> for TerrainRequest {
+    fn ex_from(m: TerrainRequestInner) -> TerrainRequest {
+        let (lat, (lon, (grid_spacing, mask))) = m;
+        TerrainRequest { lat, lon, grid_spacing, mask }
+    }
+}
+
+pub struct TerrainRequestMapper;
+impl View for TerrainRequestMapper {
+    type V = Self;
+    open spec fn view(&self) -> Self::V {
+        *self
+    }
+}
+impl SpecIso for TerrainRequestMapper {
+    type Src = SpecTerrainRequestInner;
+    type Dst = SpecTerrainRequest;
+}
+impl SpecIsoProof for TerrainRequestMapper {
+    proof fn spec_iso(s: Self::Src) {
+        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
+    }
+    proof fn spec_iso_rev(s: Self::Dst) {
+        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
+    }
+}
+impl<'a> Iso<'a> for TerrainRequestMapper {
+    type Src = TerrainRequestInner;
+    type Dst = TerrainRequest;
+    type RefSrc = TerrainRequestInnerRef<'a>;
+}
+type SpecTerrainRequestCombinatorAlias1 = (U16Le, U64Le);
+type SpecTerrainRequestCombinatorAlias2 = (U32Le, SpecTerrainRequestCombinatorAlias1);
+type SpecTerrainRequestCombinatorAlias3 = (U32Le, SpecTerrainRequestCombinatorAlias2);
+pub struct SpecTerrainRequestCombinator(pub SpecTerrainRequestCombinatorAlias);
+
+impl SpecCombinator for SpecTerrainRequestCombinator {
+    type Type = SpecTerrainRequest;
+    open spec fn requires(&self) -> bool
+    { self.0.requires() }
+    open spec fn wf(&self, v: Self::Type) -> bool
+    { self.0.wf(v) }
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
+    { self.0.spec_parse(s) }
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
+    { self.0.spec_serialize(v) }
+}
+impl SecureSpecCombinator for SpecTerrainRequestCombinator {
+    open spec fn is_prefix_secure() -> bool
+    { SpecTerrainRequestCombinatorAlias::is_prefix_secure() }
+    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
+    { self.0.theorem_serialize_parse_roundtrip(v) }
+    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
+    { self.0.theorem_parse_serialize_roundtrip(buf) }
+    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
+    { self.0.lemma_prefix_secure(s1, s2) }
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
+    { self.0.lemma_parse_length(s) }
+    open spec fn is_productive(&self) -> bool
+    { self.0.is_productive() }
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
+    { self.0.lemma_parse_productive(s) }
+}
+pub type SpecTerrainRequestCombinatorAlias = Mapped<SpecTerrainRequestCombinatorAlias3, TerrainRequestMapper>;
+type TerrainRequestCombinatorAlias1 = (U16Le, U64Le);
+type TerrainRequestCombinatorAlias2 = (U32Le, TerrainRequestCombinator1);
+type TerrainRequestCombinatorAlias3 = (U32Le, TerrainRequestCombinator2);
+pub struct TerrainRequestCombinator1(pub TerrainRequestCombinatorAlias1);
+impl View for TerrainRequestCombinator1 {
+    type V = SpecTerrainRequestCombinatorAlias1;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(TerrainRequestCombinator1, TerrainRequestCombinatorAlias1);
+
+pub struct TerrainRequestCombinator2(pub TerrainRequestCombinatorAlias2);
+impl View for TerrainRequestCombinator2 {
+    type V = SpecTerrainRequestCombinatorAlias2;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(TerrainRequestCombinator2, TerrainRequestCombinatorAlias2);
+
+pub struct TerrainRequestCombinator3(pub TerrainRequestCombinatorAlias3);
+impl View for TerrainRequestCombinator3 {
+    type V = SpecTerrainRequestCombinatorAlias3;
+    open spec fn view(&self) -> Self::V { self.0@ }
+}
+impl_wrapper_combinator!(TerrainRequestCombinator3, TerrainRequestCombinatorAlias3);
+
+pub struct TerrainRequestCombinator(pub TerrainRequestCombinatorAlias);
+
+impl View for TerrainRequestCombinator {
+    type V = SpecTerrainRequestCombinator;
+    open spec fn view(&self) -> Self::V { SpecTerrainRequestCombinator(self.0@) }
+}
+impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TerrainRequestCombinator {
+    type Type = TerrainRequest;
+    type SType = &'a Self::Type;
+    fn length(&self, v: Self::SType) -> usize
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
+    open spec fn ex_requires(&self) -> bool
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
+    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
+    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
+pub type TerrainRequestCombinatorAlias = Mapped<TerrainRequestCombinator3, TerrainRequestMapper>;
+
+
+pub open spec fn spec_terrain_request() -> SpecTerrainRequestCombinator {
+    SpecTerrainRequestCombinator(
+    Mapped {
+        inner: (U32Le, (U32Le, (U16Le, U64Le))),
+        mapper: TerrainRequestMapper,
+    })
+}
+
+                
+pub fn terrain_request<'a>() -> (o: TerrainRequestCombinator)
+    ensures o@ == spec_terrain_request(),
+            o@.requires(),
+            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
+{
+    let combinator = TerrainRequestCombinator(
+    Mapped {
+        inner: TerrainRequestCombinator3((U32Le, TerrainRequestCombinator2((U32Le, TerrainRequestCombinator1((U16Le, U64Le)))))),
+        mapper: TerrainRequestMapper,
+    });
+    // assert({
+    //     &&& combinator@ == spec_terrain_request()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
+    combinator
+}
+
+pub fn parse_terrain_request<'a>(input: &'a [u8]) -> (res: PResult<<TerrainRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+    requires
+        input.len() <= usize::MAX,
+    ensures
+        res matches Ok((n, v)) ==> spec_terrain_request().spec_parse(input@) == Some((n as int, v@)),
+        spec_terrain_request().spec_parse(input@) matches Some((n, v))
+            ==> res matches Ok((m, u)) && m == n && v == u@,
+        res is Err ==> spec_terrain_request().spec_parse(input@) is None,
+        spec_terrain_request().spec_parse(input@) is None ==> res is Err,
+{
+    let combinator = terrain_request();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
+}
+
+pub fn serialize_terrain_request<'a>(v: <TerrainRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize) -> (o: SResult<usize, SerializeError>)
+    requires
+        pos <= old(data)@.len() <= usize::MAX,
+        spec_terrain_request().wf(v@),
+    ensures
+        o matches Ok(n) ==> {
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_terrain_request().spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_terrain_request().spec_serialize(v@))
+        },
+{
+    let combinator = terrain_request();
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
+}
+
+pub fn terrain_request_len<'a>(v: <TerrainRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
+    requires
+        spec_terrain_request().wf(v@),
+        spec_terrain_request().spec_serialize(v@).len() <= usize::MAX,
+    ensures
+        serialize_len == spec_terrain_request().spec_serialize(v@).len(),
+{
+    let combinator = terrain_request();
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -2868,13 +3099,13 @@ impl SpecCombinator for SpecMavlinkV2MsgPayloadCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavlinkV2MsgPayloadCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavlinkV2MsgPayloadCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -2882,11 +3113,11 @@ impl SecureSpecCombinator for SpecMavlinkV2MsgPayloadCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavlinkV2MsgPayloadCombinatorAlias = AndThen<bytes::Variable, Mapped<SpecMavlinkV2MsgPayloadCombinatorAlias4, MavlinkV2MsgPayloadMapper>>;
@@ -2933,37 +3164,42 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkV2MsgPayloadCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavlinkV2MsgPayloadCombinatorAlias = AndThen<bytes::Variable, Mapped<MavlinkV2MsgPayloadCombinator4, MavlinkV2MsgPayloadMapper>>;
 
 
 pub open spec fn spec_mavlink_v2_msg_payload(len: u8, msgid: u24) -> SpecMavlinkV2MsgPayloadCombinator {
-    SpecMavlinkV2MsgPayloadCombinator(AndThen(bytes::Variable(len.spec_into()), Mapped { inner: Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_CommandInt, inner: spec_command_int() }, Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_CommandLong, inner: spec_command_long() }, Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_CommandAck, inner: spec_command_ack() }, Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_TerrainRequest, inner: spec_terrain_request() }, Cond { cond: !(msgid.spec_as_u32() == MessageIds::SPEC_CommandInt || msgid.spec_as_u32() == MessageIds::SPEC_CommandLong || msgid.spec_as_u32() == MessageIds::SPEC_CommandAck || msgid.spec_as_u32() == MessageIds::SPEC_TerrainRequest), inner: bytes::Variable(len.spec_into()) })))), mapper: MavlinkV2MsgPayloadMapper }))
+    SpecMavlinkV2MsgPayloadCombinator(AndThen(bytes::Variable((usize::spec_from(len)) as usize), Mapped { inner: Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_CommandInt, inner: spec_command_int() }, Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_CommandLong, inner: spec_command_long() }, Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_CommandAck, inner: spec_command_ack() }, Choice(Cond { cond: msgid.spec_as_u32() == MessageIds::SPEC_TerrainRequest, inner: spec_terrain_request() }, Cond { cond: !(msgid.spec_as_u32() == MessageIds::SPEC_CommandInt || msgid.spec_as_u32() == MessageIds::SPEC_CommandLong || msgid.spec_as_u32() == MessageIds::SPEC_CommandAck || msgid.spec_as_u32() == MessageIds::SPEC_TerrainRequest), inner: bytes::Variable((usize::spec_from(len)) as usize) })))), mapper: MavlinkV2MsgPayloadMapper }))
 }
 
 pub fn mavlink_v2_msg_payload<'a>(len: u8, msgid: u24) -> (o: MavlinkV2MsgPayloadCombinator)
+    requires
+        spec_message_ids().wf(msgid@),
+
     ensures o@ == spec_mavlink_v2_msg_payload(len@, msgid@),
             o@.requires(),
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
-    let combinator = MavlinkV2MsgPayloadCombinator(AndThen(bytes::Variable(len.ex_into()), Mapped { inner: MavlinkV2MsgPayloadCombinator4(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::CommandInt, inner: command_int() }, MavlinkV2MsgPayloadCombinator3(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::CommandLong, inner: command_long() }, MavlinkV2MsgPayloadCombinator2(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::CommandAck, inner: command_ack() }, MavlinkV2MsgPayloadCombinator1(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::TerrainRequest, inner: terrain_request() }, Cond { cond: !(msgid.as_u32() == MessageIds::CommandInt || msgid.as_u32() == MessageIds::CommandLong || msgid.as_u32() == MessageIds::CommandAck || msgid.as_u32() == MessageIds::TerrainRequest), inner: bytes::Variable(len.ex_into()) })))))))), mapper: MavlinkV2MsgPayloadMapper }));
-    assert({
-        &&& combinator@ == spec_mavlink_v2_msg_payload(len@, msgid@)
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    let combinator = MavlinkV2MsgPayloadCombinator(AndThen(bytes::Variable((usize::ex_from(len)) as usize), Mapped { inner: MavlinkV2MsgPayloadCombinator4(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::CommandInt, inner: command_int() }, MavlinkV2MsgPayloadCombinator3(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::CommandLong, inner: command_long() }, MavlinkV2MsgPayloadCombinator2(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::CommandAck, inner: command_ack() }, MavlinkV2MsgPayloadCombinator1(Choice::new(Cond { cond: msgid.as_u32() == MessageIds::TerrainRequest, inner: terrain_request() }, Cond { cond: !(msgid.as_u32() == MessageIds::CommandInt || msgid.as_u32() == MessageIds::CommandLong || msgid.as_u32() == MessageIds::CommandAck || msgid.as_u32() == MessageIds::TerrainRequest), inner: bytes::Variable((usize::ex_from(len)) as usize) })))))))), mapper: MavlinkV2MsgPayloadMapper }));
+    // assert({
+    //     &&& combinator@ == spec_mavlink_v2_msg_payload(len@, msgid@)
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
 pub fn parse_mavlink_v2_msg_payload<'a>(input: &'a [u8], len: u8, msgid: u24) -> (res: PResult<<MavlinkV2MsgPayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
     requires
         input.len() <= usize::MAX,
+        spec_message_ids().wf(msgid@),
+
     ensures
         res matches Ok((n, v)) ==> spec_mavlink_v2_msg_payload(len@, msgid@).spec_parse(input@) == Some((n as int, v@)),
         spec_mavlink_v2_msg_payload(len@, msgid@).spec_parse(input@) matches Some((n, v))
@@ -2979,244 +3215,30 @@ pub fn serialize_mavlink_v2_msg_payload<'a>(v: <MavlinkV2MsgPayloadCombinator as
     requires
         pos <= old(data)@.len() <= usize::MAX,
         spec_mavlink_v2_msg_payload(len@, msgid@).wf(v@),
+        spec_message_ids().wf(msgid@),
+
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mavlink_v2_msg_payload(len@, msgid@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mavlink_v2_msg_payload(len@, msgid@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mavlink_v2_msg_payload(len@, msgid@).spec_serialize(v@))
         },
 {
     let combinator = mavlink_v2_msg_payload( len, msgid );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn mavlink_v2_msg_payload_len<'a>(v: <MavlinkV2MsgPayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, len: u8, msgid: u24) -> (serialize_len: usize)
     requires
         spec_mavlink_v2_msg_payload(len@, msgid@).wf(v@),
         spec_mavlink_v2_msg_payload(len@, msgid@).spec_serialize(v@).len() <= usize::MAX,
+        spec_message_ids().wf(msgid@),
+
     ensures
         serialize_len == spec_mavlink_v2_msg_payload(len@, msgid@).spec_serialize(v@).len(),
 {
     let combinator = mavlink_v2_msg_payload( len, msgid );
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
-}
-
-
-pub enum SpecMavlinkV2MsgSignature {
-    Variant0(Seq<u8>),
-    Variant1(Seq<u8>),
-}
-
-pub type SpecMavlinkV2MsgSignatureInner = Either<Seq<u8>, Seq<u8>>;
-
-impl SpecFrom<SpecMavlinkV2MsgSignature> for SpecMavlinkV2MsgSignatureInner {
-    open spec fn spec_from(m: SpecMavlinkV2MsgSignature) -> SpecMavlinkV2MsgSignatureInner {
-        match m {
-            SpecMavlinkV2MsgSignature::Variant0(m) => Either::Left(m),
-            SpecMavlinkV2MsgSignature::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-                
-impl SpecFrom<SpecMavlinkV2MsgSignatureInner> for SpecMavlinkV2MsgSignature {
-    open spec fn spec_from(m: SpecMavlinkV2MsgSignatureInner) -> SpecMavlinkV2MsgSignature {
-        match m {
-            Either::Left(m) => SpecMavlinkV2MsgSignature::Variant0(m),
-            Either::Right(m) => SpecMavlinkV2MsgSignature::Variant1(m),
-        }
-    }
-
-}
-
-
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MavlinkV2MsgSignature<'a> {
-    Variant0(&'a [u8]),
-    Variant1(&'a [u8]),
-}
-
-pub type MavlinkV2MsgSignatureInner<'a> = Either<&'a [u8], &'a [u8]>;
-
-pub type MavlinkV2MsgSignatureInnerRef<'a> = Either<&'a &'a [u8], &'a &'a [u8]>;
-
-
-impl<'a> View for MavlinkV2MsgSignature<'a> {
-    type V = SpecMavlinkV2MsgSignature;
-    open spec fn view(&self) -> Self::V {
-        match self {
-            MavlinkV2MsgSignature::Variant0(m) => SpecMavlinkV2MsgSignature::Variant0(m@),
-            MavlinkV2MsgSignature::Variant1(m) => SpecMavlinkV2MsgSignature::Variant1(m@),
-        }
-    }
-}
-
-
-impl<'a> From<&'a MavlinkV2MsgSignature<'a>> for MavlinkV2MsgSignatureInnerRef<'a> {
-    fn ex_from(m: &'a MavlinkV2MsgSignature<'a>) -> MavlinkV2MsgSignatureInnerRef<'a> {
-        match m {
-            MavlinkV2MsgSignature::Variant0(m) => Either::Left(m),
-            MavlinkV2MsgSignature::Variant1(m) => Either::Right(m),
-        }
-    }
-
-}
-
-impl<'a> From<MavlinkV2MsgSignatureInner<'a>> for MavlinkV2MsgSignature<'a> {
-    fn ex_from(m: MavlinkV2MsgSignatureInner<'a>) -> MavlinkV2MsgSignature<'a> {
-        match m {
-            Either::Left(m) => MavlinkV2MsgSignature::Variant0(m),
-            Either::Right(m) => MavlinkV2MsgSignature::Variant1(m),
-        }
-    }
-    
-}
-
-
-pub struct MavlinkV2MsgSignatureMapper;
-impl View for MavlinkV2MsgSignatureMapper {
-    type V = Self;
-    open spec fn view(&self) -> Self::V {
-        *self
-    }
-}
-impl SpecIso for MavlinkV2MsgSignatureMapper {
-    type Src = SpecMavlinkV2MsgSignatureInner;
-    type Dst = SpecMavlinkV2MsgSignature;
-}
-impl SpecIsoProof for MavlinkV2MsgSignatureMapper {
-    proof fn spec_iso(s: Self::Src) {
-        assert(Self::Src::spec_from(Self::Dst::spec_from(s)) == s);
-    }
-    proof fn spec_iso_rev(s: Self::Dst) {
-        assert(Self::Dst::spec_from(Self::Src::spec_from(s)) == s);
-    }
-}
-impl<'a> Iso<'a> for MavlinkV2MsgSignatureMapper {
-    type Src = MavlinkV2MsgSignatureInner<'a>;
-    type Dst = MavlinkV2MsgSignature<'a>;
-    type RefSrc = MavlinkV2MsgSignatureInnerRef<'a>;
-}
-
-type SpecMavlinkV2MsgSignatureCombinatorAlias1 = Choice<Cond<bytes::Fixed<13>>, Cond<bytes::Fixed<0>>>;
-pub struct SpecMavlinkV2MsgSignatureCombinator(pub SpecMavlinkV2MsgSignatureCombinatorAlias);
-
-impl SpecCombinator for SpecMavlinkV2MsgSignatureCombinator {
-    type Type = SpecMavlinkV2MsgSignature;
-    open spec fn requires(&self) -> bool
-    { self.0.requires() }
-    open spec fn wf(&self, v: Self::Type) -> bool
-    { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
-    { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
-    { self.0.spec_serialize(v) }
-}
-impl SecureSpecCombinator for SpecMavlinkV2MsgSignatureCombinator {
-    open spec fn is_prefix_secure() -> bool 
-    { SpecMavlinkV2MsgSignatureCombinatorAlias::is_prefix_secure() }
-    proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
-    { self.0.theorem_serialize_parse_roundtrip(v) }
-    proof fn theorem_parse_serialize_roundtrip(&self, buf: Seq<u8>)
-    { self.0.theorem_parse_serialize_roundtrip(buf) }
-    proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
-    { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
-    { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
-    { self.0.lemma_parse_productive(s) }
-}
-pub type SpecMavlinkV2MsgSignatureCombinatorAlias = Mapped<SpecMavlinkV2MsgSignatureCombinatorAlias1, MavlinkV2MsgSignatureMapper>;
-type MavlinkV2MsgSignatureCombinatorAlias1 = Choice<Cond<bytes::Fixed<13>>, Cond<bytes::Fixed<0>>>;
-pub struct MavlinkV2MsgSignatureCombinator1(pub MavlinkV2MsgSignatureCombinatorAlias1);
-impl View for MavlinkV2MsgSignatureCombinator1 {
-    type V = SpecMavlinkV2MsgSignatureCombinatorAlias1;
-    open spec fn view(&self) -> Self::V { self.0@ }
-}
-impl_wrapper_combinator!(MavlinkV2MsgSignatureCombinator1, MavlinkV2MsgSignatureCombinatorAlias1);
-
-pub struct MavlinkV2MsgSignatureCombinator(pub MavlinkV2MsgSignatureCombinatorAlias);
-
-impl View for MavlinkV2MsgSignatureCombinator {
-    type V = SpecMavlinkV2MsgSignatureCombinator;
-    open spec fn view(&self) -> Self::V { SpecMavlinkV2MsgSignatureCombinator(self.0@) }
-}
-impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkV2MsgSignatureCombinator {
-    type Type = MavlinkV2MsgSignature<'a>;
-    type SType = &'a Self::Type;
-    fn length(&self, v: Self::SType) -> usize
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
-    { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
-    fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
-pub type MavlinkV2MsgSignatureCombinatorAlias = Mapped<MavlinkV2MsgSignatureCombinator1, MavlinkV2MsgSignatureMapper>;
-
-
-pub open spec fn spec_mavlink_v2_msg_signature(incompat_flags: u8) -> SpecMavlinkV2MsgSignatureCombinator {
-    SpecMavlinkV2MsgSignatureCombinator(Mapped { inner: Choice(Cond { cond: incompat_flags == 1, inner: bytes::Fixed::<13> }, Cond { cond: !(incompat_flags == 1), inner: bytes::Fixed::<0> }), mapper: MavlinkV2MsgSignatureMapper })
-}
-
-pub fn mavlink_v2_msg_signature<'a>(incompat_flags: u8) -> (o: MavlinkV2MsgSignatureCombinator)
-    ensures o@ == spec_mavlink_v2_msg_signature(incompat_flags@),
-            o@.requires(),
-            <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
-{
-    let combinator = MavlinkV2MsgSignatureCombinator(Mapped { inner: MavlinkV2MsgSignatureCombinator1(Choice::new(Cond { cond: incompat_flags == 1, inner: bytes::Fixed::<13> }, Cond { cond: !(incompat_flags == 1), inner: bytes::Fixed::<0> })), mapper: MavlinkV2MsgSignatureMapper });
-    assert({
-        &&& combinator@ == spec_mavlink_v2_msg_signature(incompat_flags@)
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
-    combinator
-}
-
-pub fn parse_mavlink_v2_msg_signature<'a>(input: &'a [u8], incompat_flags: u8) -> (res: PResult<<MavlinkV2MsgSignatureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
-    requires
-        input.len() <= usize::MAX,
-    ensures
-        res matches Ok((n, v)) ==> spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) == Some((n as int, v@)),
-        spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) matches Some((n, v))
-            ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) is None,
-        spec_mavlink_v2_msg_signature(incompat_flags@).spec_parse(input@) is None ==> res is Err,
-{
-    let combinator = mavlink_v2_msg_signature( incompat_flags );
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
-}
-
-pub fn serialize_mavlink_v2_msg_signature<'a>(v: <MavlinkV2MsgSignatureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, incompat_flags: u8) -> (o: SResult<usize, SerializeError>)
-    requires
-        pos <= old(data)@.len() <= usize::MAX,
-        spec_mavlink_v2_msg_signature(incompat_flags@).wf(v@),
-    ensures
-        o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@))
-        },
-{
-    let combinator = mavlink_v2_msg_signature( incompat_flags );
-    combinator.serialize(v, data, pos)
-}
-
-pub fn mavlink_v2_msg_signature_len<'a>(v: <MavlinkV2MsgSignatureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, incompat_flags: u8) -> (serialize_len: usize)
-    requires
-        spec_mavlink_v2_msg_signature(incompat_flags@).wf(v@),
-        spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@).len() <= usize::MAX,
-    ensures
-        serialize_len == spec_mavlink_v2_msg_signature(incompat_flags@).spec_serialize(v@).len(),
-{
-    let combinator = mavlink_v2_msg_signature( incompat_flags );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -3331,13 +3353,13 @@ impl SpecCombinator for SpecMavlinkV2MsgCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavlinkV2MsgCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavlinkV2MsgCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -3345,11 +3367,11 @@ impl SecureSpecCombinator for SpecMavlinkV2MsgCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavlinkV2MsgCombinatorAlias = Mapped<SpecPair<SpecPair<SpecPair<U8, SpecIncompatFlagsCombinator>, (U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, SpecMessageIdsCombinator))))>, (SpecMavlinkV2MsgPayloadCombinator, (U16Le, SpecMavlinkV2MsgSignatureCombinator))>, MavlinkV2MsgMapper>;
@@ -3365,13 +3387,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkV2MsgCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavlinkV2MsgCombinatorAlias = Mapped<Pair<Pair<Pair<U8, IncompatFlagsCombinator, MavlinkV2MsgCont2>, (U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, MessageIdsCombinator)))), MavlinkV2MsgCont1>, (MavlinkV2MsgPayloadCombinator, (U16Le, MavlinkV2MsgSignatureCombinator)), MavlinkV2MsgCont0>, MavlinkV2MsgMapper>;
 
 
@@ -3439,11 +3461,11 @@ pub fn mavlink_v2_msg<'a>() -> (o: MavlinkV2MsgCombinator)
         inner: Pair::new(Pair::new(Pair::new(U8, MavlinkV2MsgCont2), MavlinkV2MsgCont1), MavlinkV2MsgCont0),
         mapper: MavlinkV2MsgMapper,
     });
-    assert({
-        &&& combinator@ == spec_mavlink_v2_msg()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_mavlink_v2_msg()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -3467,14 +3489,14 @@ pub fn serialize_mavlink_v2_msg<'a>(v: <MavlinkV2MsgCombinator as Combinator<'a,
         spec_mavlink_v2_msg().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mavlink_v2_msg().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mavlink_v2_msg().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mavlink_v2_msg().spec_serialize(v@))
         },
 {
     let combinator = mavlink_v2_msg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mavlink_v2_msg_len<'a>(v: <MavlinkV2MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3495,16 +3517,20 @@ type MavlinkV2MsgCont2Input<'a, 'b, 'x> = POrSType<MavlinkV2MsgCont2Type<'a, 'b>
 impl<'a, 'b, 'x> Continuation<MavlinkV2MsgCont2Input<'a, 'b, 'x>> for MavlinkV2MsgCont2 {
     type Output = IncompatFlagsCombinator;
 
-    open spec fn requires(&self, deps: MavlinkV2MsgCont2Input<'a, 'b, 'x>) -> bool { true }
+    open spec fn requires(&self, deps: MavlinkV2MsgCont2Input<'a, 'b, 'x>) -> bool {
+        &&& (U8).wf(deps@)
+        }
 
     open spec fn ensures(&self, deps: MavlinkV2MsgCont2Input<'a, 'b, 'x>, o: Self::Output) -> bool {
-        o@ == spec_mavlink_v2_msg_cont2(deps@)
+        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o)
+        &&& o@ == spec_mavlink_v2_msg_cont2(deps@)
     }
 
     fn apply(&self, deps: MavlinkV2MsgCont2Input<'a, 'b, 'x>) -> Self::Output {
         match deps {
             POrSType::P(deps) => {
-                let len = *deps;
+                let len = deps;
+                let len = *len;
                 incompat_flags()
             }
             POrSType::S(deps) => {
@@ -3522,21 +3548,27 @@ type MavlinkV2MsgCont1Input<'a, 'b, 'x> = POrSType<MavlinkV2MsgCont1Type<'a, 'b>
 impl<'a, 'b, 'x> Continuation<MavlinkV2MsgCont1Input<'a, 'b, 'x>> for MavlinkV2MsgCont1 {
     type Output = (U8, (U8, (Refined<U8, Predicate3768926651291043512>, (Refined<U8, Predicate3768926651291043512>, MessageIdsCombinator))));
 
-    open spec fn requires(&self, deps: MavlinkV2MsgCont1Input<'a, 'b, 'x>) -> bool { true }
+    open spec fn requires(&self, deps: MavlinkV2MsgCont1Input<'a, 'b, 'x>) -> bool {
+        &&& (Pair::spec_new(U8, |deps| spec_mavlink_v2_msg_cont2(deps))).wf(deps@)
+        }
 
     open spec fn ensures(&self, deps: MavlinkV2MsgCont1Input<'a, 'b, 'x>, o: Self::Output) -> bool {
-        o@ == spec_mavlink_v2_msg_cont1(deps@)
+        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o)
+        &&& o@ == spec_mavlink_v2_msg_cont1(deps@)
     }
 
     fn apply(&self, deps: MavlinkV2MsgCont1Input<'a, 'b, 'x>) -> Self::Output {
         match deps {
             POrSType::P(deps) => {
-                let (len, incompat_flags) = *deps;
+                let (len, incompat_flags) = deps;
+                let len = *len;
+                let incompat_flags = *incompat_flags;
                 (U8, (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, message_ids()))))
             }
             POrSType::S(deps) => {
                 let (len, incompat_flags) = deps;
-                let (len, incompat_flags) = (*len, *incompat_flags);
+                let len = *len;
+                let incompat_flags = *incompat_flags;
                 (U8, (U8, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, (Refined { inner: U8, predicate: Predicate3768926651291043512 }, message_ids()))))
             }
         }
@@ -3549,21 +3581,29 @@ type MavlinkV2MsgCont0Input<'a, 'b, 'x> = POrSType<MavlinkV2MsgCont0Type<'a, 'b>
 impl<'a, 'b, 'x> Continuation<MavlinkV2MsgCont0Input<'a, 'b, 'x>> for MavlinkV2MsgCont0 {
     type Output = (MavlinkV2MsgPayloadCombinator, (U16Le, MavlinkV2MsgSignatureCombinator));
 
-    open spec fn requires(&self, deps: MavlinkV2MsgCont0Input<'a, 'b, 'x>) -> bool { true }
+    open spec fn requires(&self, deps: MavlinkV2MsgCont0Input<'a, 'b, 'x>) -> bool {
+        &&& (Pair::spec_new(Pair::spec_new(U8, |deps| spec_mavlink_v2_msg_cont2(deps)), |deps| spec_mavlink_v2_msg_cont1(deps))).wf(deps@)
+        }
 
     open spec fn ensures(&self, deps: MavlinkV2MsgCont0Input<'a, 'b, 'x>, o: Self::Output) -> bool {
-        o@ == spec_mavlink_v2_msg_cont0(deps@)
+        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o)
+        &&& o@ == spec_mavlink_v2_msg_cont0(deps@)
     }
 
     fn apply(&self, deps: MavlinkV2MsgCont0Input<'a, 'b, 'x>) -> Self::Output {
         match deps {
             POrSType::P(deps) => {
-                let ((len, incompat_flags), (_, (_, (_, (_, msgid))))) = *deps;
+                let ((len, incompat_flags), (_, (_, (_, (_, msgid))))) = deps;
+                let len = *len;
+                let incompat_flags = *incompat_flags;
+                let msgid = *msgid;
                 (mavlink_v2_msg_payload(len, msgid), (U16Le, mavlink_v2_msg_signature(incompat_flags)))
             }
             POrSType::S(deps) => {
                 let ((len, incompat_flags), (_, (_, (_, (_, msgid))))) = deps;
-                let ((len, incompat_flags), msgid) = ((*len, *incompat_flags), *msgid);
+                let len = *len;
+                let incompat_flags = *incompat_flags;
+                let msgid = *msgid;
                 (mavlink_v2_msg_payload(len, msgid), (U16Le, mavlink_v2_msg_signature(incompat_flags)))
             }
         }
@@ -3678,13 +3718,13 @@ impl SpecCombinator for SpecMavlinkMsgMsgCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavlinkMsgMsgCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavlinkMsgMsgCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -3692,11 +3732,11 @@ impl SecureSpecCombinator for SpecMavlinkMsgMsgCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavlinkMsgMsgCombinatorAlias = Mapped<SpecMavlinkMsgMsgCombinatorAlias1, MavlinkMsgMsgMapper>;
@@ -3719,13 +3759,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkMsgMsgCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavlinkMsgMsgCombinatorAlias = Mapped<MavlinkMsgMsgCombinator1, MavlinkMsgMsgMapper>;
 
 
@@ -3734,22 +3774,27 @@ pub open spec fn spec_mavlink_msg_msg(magic: SpecProtocolMagic) -> SpecMavlinkMs
 }
 
 pub fn mavlink_msg_msg<'a>(magic: ProtocolMagic) -> (o: MavlinkMsgMsgCombinator)
+    requires
+        spec_protocol_magic().wf(magic@),
+
     ensures o@ == spec_mavlink_msg_msg(magic@),
             o@.requires(),
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = MavlinkMsgMsgCombinator(Mapped { inner: MavlinkMsgMsgCombinator1(Choice::new(Cond { cond: magic == ProtocolMagic::MavLink1, inner: mavlink_v1_msg() }, Cond { cond: magic == ProtocolMagic::MavLink2, inner: mavlink_v2_msg() })), mapper: MavlinkMsgMsgMapper });
-    assert({
-        &&& combinator@ == spec_mavlink_msg_msg(magic@)
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_mavlink_msg_msg(magic@)
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
 pub fn parse_mavlink_msg_msg<'a>(input: &'a [u8], magic: ProtocolMagic) -> (res: PResult<<MavlinkMsgMsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
     requires
         input.len() <= usize::MAX,
+        spec_protocol_magic().wf(magic@),
+
     ensures
         res matches Ok((n, v)) ==> spec_mavlink_msg_msg(magic@).spec_parse(input@) == Some((n as int, v@)),
         spec_mavlink_msg_msg(magic@).spec_parse(input@) matches Some((n, v))
@@ -3765,22 +3810,26 @@ pub fn serialize_mavlink_msg_msg<'a>(v: <MavlinkMsgMsgCombinator as Combinator<'
     requires
         pos <= old(data)@.len() <= usize::MAX,
         spec_mavlink_msg_msg(magic@).wf(v@),
+        spec_protocol_magic().wf(magic@),
+
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mavlink_msg_msg(magic@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mavlink_msg_msg(magic@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mavlink_msg_msg(magic@).spec_serialize(v@))
         },
 {
     let combinator = mavlink_msg_msg( magic );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn mavlink_msg_msg_len<'a>(v: <MavlinkMsgMsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, magic: ProtocolMagic) -> (serialize_len: usize)
     requires
         spec_mavlink_msg_msg(magic@).wf(v@),
         spec_mavlink_msg_msg(magic@).spec_serialize(v@).len() <= usize::MAX,
+        spec_protocol_magic().wf(magic@),
+
     ensures
         serialize_len == spec_mavlink_msg_msg(magic@).spec_serialize(v@).len(),
 {
@@ -3875,13 +3924,13 @@ impl SpecCombinator for SpecMavlinkMsgCombinator {
     { self.0.requires() }
     open spec fn wf(&self, v: Self::Type) -> bool
     { self.0.wf(v) }
-    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)> 
+    open spec fn spec_parse(&self, s: Seq<u8>) -> Option<(int, Self::Type)>
     { self.0.spec_parse(s) }
-    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8> 
+    open spec fn spec_serialize(&self, v: Self::Type) -> Seq<u8>
     { self.0.spec_serialize(v) }
 }
 impl SecureSpecCombinator for SpecMavlinkMsgCombinator {
-    open spec fn is_prefix_secure() -> bool 
+    open spec fn is_prefix_secure() -> bool
     { SpecMavlinkMsgCombinatorAlias::is_prefix_secure() }
     proof fn theorem_serialize_parse_roundtrip(&self, v: Self::Type)
     { self.0.theorem_serialize_parse_roundtrip(v) }
@@ -3889,11 +3938,11 @@ impl SecureSpecCombinator for SpecMavlinkMsgCombinator {
     { self.0.theorem_parse_serialize_roundtrip(buf) }
     proof fn lemma_prefix_secure(&self, s1: Seq<u8>, s2: Seq<u8>)
     { self.0.lemma_prefix_secure(s1, s2) }
-    proof fn lemma_parse_length(&self, s: Seq<u8>) 
+    proof fn lemma_parse_length(&self, s: Seq<u8>)
     { self.0.lemma_parse_length(s) }
-    open spec fn is_productive(&self) -> bool 
+    open spec fn is_productive(&self) -> bool
     { self.0.is_productive() }
-    proof fn lemma_parse_productive(&self, s: Seq<u8>) 
+    proof fn lemma_parse_productive(&self, s: Seq<u8>)
     { self.0.lemma_parse_productive(s) }
 }
 pub type SpecMavlinkMsgCombinatorAlias = Mapped<SpecPair<SpecProtocolMagicCombinator, SpecMavlinkMsgMsgCombinator>, MavlinkMsgMapper>;
@@ -3909,13 +3958,13 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MavlinkMsgCombinator {
     type SType = &'a Self::Type;
     fn length(&self, v: Self::SType) -> usize
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&self.0, v) }
-    open spec fn ex_requires(&self) -> bool 
+    open spec fn ex_requires(&self) -> bool
     { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&self.0) }
-    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>) 
+    fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
-} 
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
+}
 pub type MavlinkMsgCombinatorAlias = Mapped<Pair<ProtocolMagicCombinator, MavlinkMsgMsgCombinator, MavlinkMsgCont0>, MavlinkMsgMapper>;
 
 
@@ -3953,11 +4002,11 @@ pub fn mavlink_msg<'a>() -> (o: MavlinkMsgCombinator)
         inner: Pair::new(protocol_magic(), MavlinkMsgCont0),
         mapper: MavlinkMsgMapper,
     });
-    assert({
-        &&& combinator@ == spec_mavlink_msg()
-        &&& combinator@.requires()
-        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
-    });
+    // assert({
+    //     &&& combinator@ == spec_mavlink_msg()
+    //     &&& combinator@.requires()
+    //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
+    // });
     combinator
 }
 
@@ -3981,14 +4030,14 @@ pub fn serialize_mavlink_msg<'a>(v: <MavlinkMsgCombinator as Combinator<'a, &'a 
         spec_mavlink_msg().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mavlink_msg().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mavlink_msg().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mavlink_msg().spec_serialize(v@))
         },
 {
     let combinator = mavlink_msg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mavlink_msg_len<'a>(v: <MavlinkMsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4009,16 +4058,20 @@ type MavlinkMsgCont0Input<'a, 'b, 'x> = POrSType<MavlinkMsgCont0Type<'a, 'b>, Ma
 impl<'a, 'b, 'x> Continuation<MavlinkMsgCont0Input<'a, 'b, 'x>> for MavlinkMsgCont0 {
     type Output = MavlinkMsgMsgCombinator;
 
-    open spec fn requires(&self, deps: MavlinkMsgCont0Input<'a, 'b, 'x>) -> bool { true }
+    open spec fn requires(&self, deps: MavlinkMsgCont0Input<'a, 'b, 'x>) -> bool {
+        &&& (spec_protocol_magic()).wf(deps@)
+        }
 
     open spec fn ensures(&self, deps: MavlinkMsgCont0Input<'a, 'b, 'x>, o: Self::Output) -> bool {
-        o@ == spec_mavlink_msg_cont0(deps@)
+        &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o)
+        &&& o@ == spec_mavlink_msg_cont0(deps@)
     }
 
     fn apply(&self, deps: MavlinkMsgCont0Input<'a, 'b, 'x>) -> Self::Output {
         match deps {
             POrSType::P(deps) => {
-                let magic = *deps;
+                let magic = deps;
+                let magic = *magic;
                 mavlink_msg_msg(magic)
             }
             POrSType::S(deps) => {

--- a/vest-dsl/src/codegen.rs
+++ b/vest-dsl/src/codegen.rs
@@ -662,7 +662,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for {name}Combinator {{
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     {{ <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }}
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    {{ <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }}
+    {{ <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }}
 }}
 "#
                     )
@@ -3731,7 +3731,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -3918,14 +3918,14 @@ pub fn serialize_{name}<'a>(v: <{upper_caml_name}Combinator as Combinator<'a, &'
         spec_{name}().wf(v@),
     ensures
         o matches Ok(n) ==> {{
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_{name}().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_{name}().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_{name}().spec_serialize(v@))
         }},
 {{
     let combinator = {name}();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }}
 
 pub fn {name}_len<'a>(v: <{upper_caml_name}Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4067,14 +4067,14 @@ pub fn serialize_{name}<'a>(v: <{upper_caml_name}Combinator as Combinator<'a, &'
 {serialize_requires}
     ensures
         o matches Ok(n) ==> {{
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_{name}({args_view}).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_{name}({args_view}).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_{name}({args_view}).spec_serialize(v@))
         }},
 {{
     let combinator = {name}( {args} );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }}
 
 pub fn {name}_len<'a>(v: <{upper_caml_name}Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, {exec_params}) -> (serialize_len: usize)
@@ -4150,14 +4150,14 @@ pub fn serialize_{name}<'a>(v: <{upper_caml_name}Combinator as Combinator<'a, &'
         spec_{name}().wf(v@),
     ensures
         o matches Ok(n) ==> {{
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_{name}().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_{name}().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_{name}().spec_serialize(v@))
         }},
 {{
     let combinator = {name}();
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }}
 
 pub fn {name}_len<'a>(v: <{upper_caml_name}Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/Cargo.toml
+++ b/vest-dsl/test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vstd = "0.0.0-2026-03-17-2326"
+vstd = "=0.0.0-2026-05-10-0145"
 vest_lib = { path = "../../vest" }
 
 [package.metadata.verus]

--- a/vest-dsl/test/src/anonymous_nested.rs
+++ b/vest-dsl/test/src/anonymous_nested.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -188,7 +188,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureParamAndLocalXAPayloadComb
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureParamAndLocalXAPayloadCombinatorAlias = Mapped<CaptureParamAndLocalXAPayloadCombinator1, CaptureParamAndLocalXAPayloadMapper>;
 
@@ -238,14 +238,14 @@ pub fn serialize_capture_param_and_local_x_a_payload<'a>(v: <CaptureParamAndLoca
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_param_and_local_x_a_payload(choice2@, len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_a_payload(choice2@, len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_a_payload(choice2@, len@).spec_serialize(v@))
         },
 {
     let combinator = capture_param_and_local_x_a_payload( choice2, len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_param_and_local_x_a_payload_len<'a>(v: <CaptureParamAndLocalXAPayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice2: COrD, len: u8) -> (serialize_len: usize)
@@ -387,7 +387,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureParamAndLocalXACombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureParamAndLocalXACombinatorAlias = Mapped<Pair<U8, CaptureParamAndLocalXAPayloadCombinator, CaptureParamAndLocalXACont0>, CaptureParamAndLocalXAMapper>;
 
@@ -460,14 +460,14 @@ pub fn serialize_capture_param_and_local_x_a<'a>(v: <CaptureParamAndLocalXACombi
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_param_and_local_x_a(choice2@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_a(choice2@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_a(choice2@).spec_serialize(v@))
         },
 {
     let combinator = capture_param_and_local_x_a( choice2 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_param_and_local_x_a_len<'a>(v: <CaptureParamAndLocalXACombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice2: COrD) -> (serialize_len: usize)
@@ -674,7 +674,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureParamAndLocalXBYCombinator
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureParamAndLocalXBYCombinatorAlias = Mapped<CaptureParamAndLocalXBYCombinator1, CaptureParamAndLocalXBYMapper>;
 
@@ -720,14 +720,14 @@ pub fn serialize_capture_param_and_local_x_b_y<'a>(v: <CaptureParamAndLocalXBYCo
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_param_and_local_x_b_y(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_b_y(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_b_y(tag@).spec_serialize(v@))
         },
 {
     let combinator = capture_param_and_local_x_b_y( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_param_and_local_x_b_y_len<'a>(v: <CaptureParamAndLocalXBYCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: u8) -> (serialize_len: usize)
@@ -868,7 +868,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureParamAndLocalXBCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureParamAndLocalXBCombinatorAlias = Mapped<Pair<U8, CaptureParamAndLocalXBYCombinator, CaptureParamAndLocalXBCont0>, CaptureParamAndLocalXBMapper>;
 
@@ -935,14 +935,14 @@ pub fn serialize_capture_param_and_local_x_b<'a>(v: <CaptureParamAndLocalXBCombi
         spec_capture_param_and_local_x_b().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_param_and_local_x_b().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_b().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x_b().spec_serialize(v@))
         },
 {
     let combinator = capture_param_and_local_x_b();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn capture_param_and_local_x_b_len<'a>(v: <CaptureParamAndLocalXBCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1142,7 +1142,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureParamAndLocalXCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureParamAndLocalXCombinatorAlias = Mapped<CaptureParamAndLocalXCombinator1, CaptureParamAndLocalXMapper>;
 
@@ -1195,14 +1195,14 @@ pub fn serialize_capture_param_and_local_x<'a>(v: <CaptureParamAndLocalXCombinat
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_param_and_local_x(choice1@, choice2@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x(choice1@, choice2@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_param_and_local_x(choice1@, choice2@).spec_serialize(v@))
         },
 {
     let combinator = capture_param_and_local_x( choice1, choice2 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_param_and_local_x_len<'a>(v: <CaptureParamAndLocalXCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice1: AOrB, choice2: COrD) -> (serialize_len: usize)
@@ -1373,7 +1373,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NestedInnerChoiceXACombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NestedInnerChoiceXACombinatorAlias = Mapped<NestedInnerChoiceXACombinator1, NestedInnerChoiceXAMapper>;
 
@@ -1423,14 +1423,14 @@ pub fn serialize_nested_inner_choice_x_a<'a>(v: <NestedInnerChoiceXACombinator a
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_nested_inner_choice_x_a(choice2@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_nested_inner_choice_x_a(choice2@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_nested_inner_choice_x_a(choice2@).spec_serialize(v@))
         },
 {
     let combinator = nested_inner_choice_x_a( choice2 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn nested_inner_choice_x_a_len<'a>(v: <NestedInnerChoiceXACombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice2: COrD) -> (serialize_len: usize)
@@ -1572,7 +1572,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureOuterAndLocalPayloadAnonIn
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureOuterAndLocalPayloadAnonInnerBodyChoice1CombinatorAlias = Mapped<Pair<U8, bytes::Variable, CaptureOuterAndLocalPayloadAnonInnerBodyChoice1Cont0>, CaptureOuterAndLocalPayloadAnonInnerBodyChoice1Mapper>;
 
@@ -1639,14 +1639,14 @@ pub fn serialize_capture_outer_and_local_payload_anon_inner_body_choice1<'a>(v: 
         spec_capture_outer_and_local_payload_anon_inner_body_choice1().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_outer_and_local_payload_anon_inner_body_choice1().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local_payload_anon_inner_body_choice1().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local_payload_anon_inner_body_choice1().spec_serialize(v@))
         },
 {
     let combinator = capture_outer_and_local_payload_anon_inner_body_choice1();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn capture_outer_and_local_payload_anon_inner_body_choice1_len<'a>(v: <CaptureOuterAndLocalPayloadAnonInnerBodyChoice1Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1846,7 +1846,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureOuterAndLocalPayloadAnonIn
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureOuterAndLocalPayloadAnonInnerBodyCombinatorAlias = Mapped<CaptureOuterAndLocalPayloadAnonInnerBodyCombinator1, CaptureOuterAndLocalPayloadAnonInnerBodyMapper>;
 
@@ -1896,14 +1896,14 @@ pub fn serialize_capture_outer_and_local_payload_anon_inner_body<'a>(v: <Capture
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_outer_and_local_payload_anon_inner_body(frame_len@, tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local_payload_anon_inner_body(frame_len@, tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local_payload_anon_inner_body(frame_len@, tag@).spec_serialize(v@))
         },
 {
     let combinator = capture_outer_and_local_payload_anon_inner_body( frame_len, tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_outer_and_local_payload_anon_inner_body_len<'a>(v: <CaptureOuterAndLocalPayloadAnonInnerBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, frame_len: u8, tag: u8) -> (serialize_len: usize)
@@ -2045,7 +2045,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureOuterAndLocalPayloadCombin
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureOuterAndLocalPayloadCombinatorAlias = AndThen<bytes::Variable, Mapped<Pair<U8, CaptureOuterAndLocalPayloadAnonInnerBodyCombinator, CaptureOuterAndLocalPayloadCont0>, CaptureOuterAndLocalPayloadMapper>>;
 
@@ -2118,14 +2118,14 @@ pub fn serialize_capture_outer_and_local_payload<'a>(v: <CaptureOuterAndLocalPay
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_outer_and_local_payload(frame_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local_payload(frame_len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local_payload(frame_len@).spec_serialize(v@))
         },
 {
     let combinator = capture_outer_and_local_payload( frame_len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_outer_and_local_payload_len<'a>(v: <CaptureOuterAndLocalPayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, frame_len: u8) -> (serialize_len: usize)
@@ -2324,7 +2324,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureOuterAndLocalCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureOuterAndLocalCombinatorAlias = Mapped<Pair<Refined<U8, Predicate2172399096230090262>, CaptureOuterAndLocalPayloadCombinator, CaptureOuterAndLocalCont0>, CaptureOuterAndLocalMapper>;
 
@@ -2391,14 +2391,14 @@ pub fn serialize_capture_outer_and_local<'a>(v: <CaptureOuterAndLocalCombinator 
         spec_capture_outer_and_local().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_outer_and_local().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_outer_and_local().spec_serialize(v@))
         },
 {
     let combinator = capture_outer_and_local();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn capture_outer_and_local_len<'a>(v: <CaptureOuterAndLocalCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2577,7 +2577,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NestedInnerStructAnonInnerCombina
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NestedInnerStructAnonInnerCombinatorAlias = AndThen<bytes::Variable, Mapped<NestedInnerStructAnonInnerCombinator1, NestedInnerStructAnonInnerMapper>>;
 
@@ -2631,14 +2631,14 @@ pub fn serialize_nested_inner_struct_anon_inner<'a>(v: <NestedInnerStructAnonInn
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_nested_inner_struct_anon_inner(len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_nested_inner_struct_anon_inner(len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_nested_inner_struct_anon_inner(len@).spec_serialize(v@))
         },
 {
     let combinator = nested_inner_struct_anon_inner( len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn nested_inner_struct_anon_inner_len<'a>(v: <NestedInnerStructAnonInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, len: u32) -> (serialize_len: usize)
@@ -2779,7 +2779,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureLocalInAnonStructWrapperVa
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureLocalInAnonStructWrapperValueChoice0CombinatorAlias = Mapped<Pair<U8, bytes::Variable, CaptureLocalInAnonStructWrapperValueChoice0Cont0>, CaptureLocalInAnonStructWrapperValueChoice0Mapper>;
 
@@ -2846,14 +2846,14 @@ pub fn serialize_capture_local_in_anon_struct_wrapper_value_choice0<'a>(v: <Capt
         spec_capture_local_in_anon_struct_wrapper_value_choice0().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_local_in_anon_struct_wrapper_value_choice0().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct_wrapper_value_choice0().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct_wrapper_value_choice0().spec_serialize(v@))
         },
 {
     let combinator = capture_local_in_anon_struct_wrapper_value_choice0();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn capture_local_in_anon_struct_wrapper_value_choice0_len<'a>(v: <CaptureLocalInAnonStructWrapperValueChoice0Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3053,7 +3053,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureLocalInAnonStructWrapperVa
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureLocalInAnonStructWrapperValueCombinatorAlias = Mapped<CaptureLocalInAnonStructWrapperValueCombinator1, CaptureLocalInAnonStructWrapperValueMapper>;
 
@@ -3099,14 +3099,14 @@ pub fn serialize_capture_local_in_anon_struct_wrapper_value<'a>(v: <CaptureLocal
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_local_in_anon_struct_wrapper_value(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct_wrapper_value(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct_wrapper_value(tag@).spec_serialize(v@))
         },
 {
     let combinator = capture_local_in_anon_struct_wrapper_value( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_local_in_anon_struct_wrapper_value_len<'a>(v: <CaptureLocalInAnonStructWrapperValueCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: u8) -> (serialize_len: usize)
@@ -3275,7 +3275,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NestedInnerChoiceXCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NestedInnerChoiceXCombinatorAlias = Mapped<NestedInnerChoiceXCombinator1, NestedInnerChoiceXMapper>;
 
@@ -3328,14 +3328,14 @@ pub fn serialize_nested_inner_choice_x<'a>(v: <NestedInnerChoiceXCombinator as C
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_nested_inner_choice_x(choice1@, choice2@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_nested_inner_choice_x(choice1@, choice2@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_nested_inner_choice_x(choice1@, choice2@).spec_serialize(v@))
         },
 {
     let combinator = nested_inner_choice_x( choice1, choice2 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn nested_inner_choice_x_len<'a>(v: <NestedInnerChoiceXCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice1: AOrB, choice2: COrD) -> (serialize_len: usize)
@@ -3475,7 +3475,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NestedInnerChoiceCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NestedInnerChoiceCombinatorAlias = Mapped<NestedInnerChoiceXCombinator, NestedInnerChoiceMapper>;
 
@@ -3536,14 +3536,14 @@ pub fn serialize_nested_inner_choice<'a>(v: <NestedInnerChoiceCombinator as Comb
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_nested_inner_choice(choice1@, choice2@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_nested_inner_choice(choice1@, choice2@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_nested_inner_choice(choice1@, choice2@).spec_serialize(v@))
         },
 {
     let combinator = nested_inner_choice( choice1, choice2 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn nested_inner_choice_len<'a>(v: <NestedInnerChoiceCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice1: AOrB, choice2: COrD) -> (serialize_len: usize)
@@ -3683,7 +3683,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureParamAndLocalCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureParamAndLocalCombinatorAlias = Mapped<CaptureParamAndLocalXCombinator, CaptureParamAndLocalMapper>;
 
@@ -3744,14 +3744,14 @@ pub fn serialize_capture_param_and_local<'a>(v: <CaptureParamAndLocalCombinator 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_param_and_local(choice1@, choice2@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_param_and_local(choice1@, choice2@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_param_and_local(choice1@, choice2@).spec_serialize(v@))
         },
 {
     let combinator = capture_param_and_local( choice1, choice2 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn capture_param_and_local_len<'a>(v: <CaptureParamAndLocalCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, choice1: AOrB, choice2: COrD) -> (serialize_len: usize)
@@ -3894,7 +3894,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NestedInnerStructCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NestedInnerStructCombinatorAlias = Mapped<Pair<U32Le, NestedInnerStructAnonInnerCombinator, NestedInnerStructCont0>, NestedInnerStructMapper>;
 
@@ -3961,14 +3961,14 @@ pub fn serialize_nested_inner_struct<'a>(v: <NestedInnerStructCombinator as Comb
         spec_nested_inner_struct().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_nested_inner_struct().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_nested_inner_struct().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_nested_inner_struct().spec_serialize(v@))
         },
 {
     let combinator = nested_inner_struct();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn nested_inner_struct_len<'a>(v: <NestedInnerStructCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4172,7 +4172,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for COrDCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type COrDCombinatorAlias = TryMap<U8, COrDMapper>;
 
@@ -4216,14 +4216,14 @@ pub fn serialize_c_or_d<'a>(v: <COrDCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_c_or_d().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_c_or_d().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_c_or_d().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_c_or_d().spec_serialize(v@))
         },
 {
     let combinator = c_or_d();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn c_or_d_len<'a>(v: <COrDCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4364,7 +4364,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureLocalInAnonStructWrapperCo
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureLocalInAnonStructWrapperCombinatorAlias = Mapped<Pair<U8, CaptureLocalInAnonStructWrapperValueCombinator, CaptureLocalInAnonStructWrapperCont0>, CaptureLocalInAnonStructWrapperMapper>;
 
@@ -4431,14 +4431,14 @@ pub fn serialize_capture_local_in_anon_struct_wrapper<'a>(v: <CaptureLocalInAnon
         spec_capture_local_in_anon_struct_wrapper().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_local_in_anon_struct_wrapper().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct_wrapper().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct_wrapper().spec_serialize(v@))
         },
 {
     let combinator = capture_local_in_anon_struct_wrapper();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn capture_local_in_anon_struct_wrapper_len<'a>(v: <CaptureLocalInAnonStructWrapperCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4607,7 +4607,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CaptureLocalInAnonStructCombinato
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CaptureLocalInAnonStructCombinatorAlias = Mapped<CaptureLocalInAnonStructWrapperCombinator, CaptureLocalInAnonStructMapper>;
 
@@ -4659,14 +4659,14 @@ pub fn serialize_capture_local_in_anon_struct<'a>(v: <CaptureLocalInAnonStructCo
         spec_capture_local_in_anon_struct().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_capture_local_in_anon_struct().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_capture_local_in_anon_struct().spec_serialize(v@))
         },
 {
     let combinator = capture_local_in_anon_struct();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn capture_local_in_anon_struct_len<'a>(v: <CaptureLocalInAnonStructCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4839,7 +4839,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AOrBCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AOrBCombinatorAlias = TryMap<U8, AOrBMapper>;
 
@@ -4883,14 +4883,14 @@ pub fn serialize_a_or_b<'a>(v: <AOrBCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_a_or_b().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_or_b().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_or_b().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_or_b().spec_serialize(v@))
         },
 {
     let combinator = a_or_b();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_or_b_len<'a>(v: <AOrBCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/codegen.rs
+++ b/vest-dsl/test/src/codegen.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -199,7 +199,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg1Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg1CombinatorAlias = Mapped<Msg1Combinator2, Msg1Mapper>;
 
@@ -251,14 +251,14 @@ pub fn serialize_msg1<'a>(v: <Msg1Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg1().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg1().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg1().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg1().spec_serialize(v@))
         },
 {
     let combinator = msg1();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg1_len<'a>(v: <Msg1Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -418,7 +418,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg2Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg2CombinatorAlias = Mapped<Msg2Combinator2, Msg2Mapper>;
 
@@ -470,14 +470,14 @@ pub fn serialize_msg2<'a>(v: <Msg2Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg2().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg2().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg2().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg2().spec_serialize(v@))
         },
 {
     let combinator = msg2();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg2_len<'a>(v: <Msg2Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -657,7 +657,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ATypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ATypeCombinatorAlias = TryMap<U8, ATypeMapper>;
 
@@ -701,14 +701,14 @@ pub fn serialize_a_type<'a>(v: <ATypeCombinator as Combinator<'a, &'a [u8], Vec<
         spec_a_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_type().spec_serialize(v@))
         },
 {
     let combinator = a_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_type_len<'a>(v: <ATypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -775,7 +775,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg3Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg3CombinatorAlias = bytes::Fixed<6>;
 
@@ -819,14 +819,14 @@ pub fn serialize_msg3<'a>(v: <Msg3Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg3().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg3().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg3().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg3().spec_serialize(v@))
         },
 {
     let combinator = msg3();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg3_len<'a>(v: <Msg3Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1011,7 +1011,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg4VCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg4VCombinatorAlias = Mapped<Msg4VCombinator2, Msg4VMapper>;
 
@@ -1061,14 +1061,14 @@ pub fn serialize_msg4_v<'a>(v: <Msg4VCombinator as Combinator<'a, &'a [u8], Vec<
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg4_v(t@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg4_v(t@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg4_v(t@).spec_serialize(v@))
         },
 {
     let combinator = msg4_v( t );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg4_v_len<'a>(v: <Msg4VCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, t: AType) -> (serialize_len: usize)
@@ -1213,7 +1213,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg4CombinatorAlias = Mapped<Pair<ATypeCombinator, (Msg4VCombinator, bytes::Tail), Msg4Cont0>, Msg4Mapper>;
 
@@ -1280,14 +1280,14 @@ pub fn serialize_msg4<'a>(v: <Msg4Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg4().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg4().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg4().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg4().spec_serialize(v@))
         },
 {
     let combinator = msg4();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg4_len<'a>(v: <Msg4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/elab.rs
+++ b/vest-dsl/test/src/elab.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -86,7 +86,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Content0Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Content0CombinatorAlias = bytes::Variable;
 
@@ -132,14 +132,14 @@ pub fn serialize_content_0<'a>(v: <Content0Combinator as Combinator<'a, &'a [u8]
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_content_0(num@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_content_0(num@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_content_0(num@).spec_serialize(v@))
         },
 {
     let combinator = content_0( num );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn content_0_len<'a>(v: <Content0Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num: u24) -> (serialize_len: usize)
@@ -212,7 +212,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ContentTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ContentTypeCombinatorAlias = U8;
 
@@ -256,14 +256,14 @@ pub fn serialize_content_type<'a>(v: <ContentTypeCombinator as Combinator<'a, &'
         spec_content_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_content_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_content_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_content_type().spec_serialize(v@))
         },
 {
     let combinator = content_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn content_type_len<'a>(v: <ContentTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -464,7 +464,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MsgCF4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MsgCF4CombinatorAlias = AndThen<bytes::Variable, Mapped<MsgCF4Combinator3, MsgCF4Mapper>>;
 
@@ -514,14 +514,14 @@ pub fn serialize_msg_c_f4<'a>(v: <MsgCF4Combinator as Combinator<'a, &'a [u8], V
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg_c_f4(f2@, f3@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg_c_f4(f2@, f3@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg_c_f4(f2@, f3@).spec_serialize(v@))
         },
 {
     let combinator = msg_c_f4( f2, f3 );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg_c_f4_len<'a>(v: <MsgCF4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, f2: u8, f3: u24) -> (serialize_len: usize)
@@ -690,7 +690,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MsgDCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MsgDCombinatorAlias = Mapped<MsgDCombinator2, MsgDMapper>;
 
@@ -742,14 +742,14 @@ pub fn serialize_msg_d<'a>(v: <MsgDCombinator as Combinator<'a, &'a [u8], Vec<u8
         spec_msg_d().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg_d().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg_d().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg_d().spec_serialize(v@))
         },
 {
     let combinator = msg_d();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg_d_len<'a>(v: <MsgDCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -887,7 +887,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MsgBCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MsgBCombinatorAlias = Mapped<MsgDCombinator, MsgBMapper>;
 
@@ -939,14 +939,14 @@ pub fn serialize_msg_b<'a>(v: <MsgBCombinator as Combinator<'a, &'a [u8], Vec<u8
         spec_msg_b().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg_b().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg_b().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg_b().spec_serialize(v@))
         },
 {
     let combinator = msg_b();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg_b_len<'a>(v: <MsgBCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1094,7 +1094,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MsgACombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MsgACombinatorAlias = Mapped<MsgACombinator1, MsgAMapper>;
 
@@ -1146,14 +1146,14 @@ pub fn serialize_msg_a<'a>(v: <MsgACombinator as Combinator<'a, &'a [u8], Vec<u8
         spec_msg_a().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg_a().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg_a().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg_a().spec_serialize(v@))
         },
 {
     let combinator = msg_a();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg_a_len<'a>(v: <MsgACombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1297,7 +1297,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MsgCCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MsgCCombinatorAlias = Mapped<Pair<Pair<ContentTypeCombinator, U24Be, MsgCCont1>, MsgCF4Combinator, MsgCCont0>, MsgCMapper>;
 
@@ -1379,14 +1379,14 @@ pub fn serialize_msg_c<'a>(v: <MsgCCombinator as Combinator<'a, &'a [u8], Vec<u8
         spec_msg_c().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg_c().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg_c().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg_c().spec_serialize(v@))
         },
 {
     let combinator = msg_c();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg_c_len<'a>(v: <MsgCCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1518,14 +1518,14 @@ pub fn serialize_F5<'a>(v: <F5Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::
         spec_F5().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_F5().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_F5().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_F5().spec_serialize(v@))
         },
 {
     let combinator = F5();
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn F5_len<'a>(v: <F5Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/enum_constraints.rs
+++ b/vest-dsl/test/src/enum_constraints.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -199,7 +199,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MyTypedEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MyTypedEnumCombinatorAlias = TryMap<U16Le, MyTypedEnumMapper>;
 
@@ -243,14 +243,14 @@ pub fn serialize_my_typed_enum<'a>(v: <MyTypedEnumCombinator as Combinator<'a, &
         spec_my_typed_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_my_typed_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_my_typed_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_my_typed_enum().spec_serialize(v@))
         },
 {
     let combinator = my_typed_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn my_typed_enum_len<'a>(v: <MyTypedEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -430,7 +430,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MyEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MyEnumCombinatorAlias = TryMap<U8, MyEnumMapper>;
 
@@ -474,14 +474,14 @@ pub fn serialize_my_enum<'a>(v: <MyEnumCombinator as Combinator<'a, &'a [u8], Ve
         spec_my_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_my_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_my_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_my_enum().spec_serialize(v@))
         },
 {
     let combinator = my_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn my_enum_len<'a>(v: <MyEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -708,7 +708,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TypedEnumConstraintsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TypedEnumConstraintsCombinatorAlias = Mapped<TypedEnumConstraintsCombinator3, TypedEnumConstraintsMapper>;
 
@@ -760,14 +760,14 @@ pub fn serialize_typed_enum_constraints<'a>(v: <TypedEnumConstraintsCombinator a
         spec_typed_enum_constraints().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_typed_enum_constraints().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_typed_enum_constraints().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_typed_enum_constraints().spec_serialize(v@))
         },
 {
     let combinator = typed_enum_constraints();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn typed_enum_constraints_len<'a>(v: <TypedEnumConstraintsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -994,7 +994,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EnumConstraintsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EnumConstraintsCombinatorAlias = Mapped<EnumConstraintsCombinator3, EnumConstraintsMapper>;
 
@@ -1046,14 +1046,14 @@ pub fn serialize_enum_constraints<'a>(v: <EnumConstraintsCombinator as Combinato
         spec_enum_constraints().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_enum_constraints().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_enum_constraints().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_enum_constraints().spec_serialize(v@))
         },
 {
     let combinator = enum_constraints();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn enum_constraints_len<'a>(v: <EnumConstraintsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/enums.rs
+++ b/vest-dsl/test/src/enums.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -204,7 +204,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ATypedChooseCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ATypedChooseCombinatorAlias = Mapped<ATypedChooseCombinator2, ATypedChooseMapper>;
 
@@ -254,14 +254,14 @@ pub fn serialize_a_typed_choose<'a>(v: <ATypedChooseCombinator as Combinator<'a,
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_typed_choose(e@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_typed_choose(e@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_typed_choose(e@).spec_serialize(v@))
         },
 {
     let combinator = a_typed_choose( e );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn a_typed_choose_len<'a>(v: <ATypedChooseCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, e: ATypedClosedEnum) -> (serialize_len: usize)
@@ -335,7 +335,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ATypedOpenEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ATypedOpenEnumCombinatorAlias = U32Le;
 
@@ -379,14 +379,14 @@ pub fn serialize_a_typed_open_enum<'a>(v: <ATypedOpenEnumCombinator as Combinato
         spec_a_typed_open_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_typed_open_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_typed_open_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_typed_open_enum().spec_serialize(v@))
         },
 {
     let combinator = a_typed_open_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_typed_open_enum_len<'a>(v: <ATypedOpenEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -631,7 +631,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ANonDependentChooseCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ANonDependentChooseCombinatorAlias = Mapped<ANonDependentChooseCombinator2, ANonDependentChooseMapper>;
 
@@ -675,14 +675,14 @@ pub fn serialize_a_non_dependent_choose<'a>(v: <ANonDependentChooseCombinator as
         spec_a_non_dependent_choose().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_non_dependent_choose().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_non_dependent_choose().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_non_dependent_choose().spec_serialize(v@))
         },
 {
     let combinator = a_non_dependent_choose();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_non_dependent_choose_len<'a>(v: <ANonDependentChooseCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -867,7 +867,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ARegularChooseCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ARegularChooseCombinatorAlias = Mapped<ARegularChooseCombinator2, ARegularChooseMapper>;
 
@@ -917,14 +917,14 @@ pub fn serialize_a_regular_choose<'a>(v: <ARegularChooseCombinator as Combinator
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_regular_choose(e@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_regular_choose(e@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_regular_choose(e@).spec_serialize(v@))
         },
 {
     let combinator = a_regular_choose( e );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn a_regular_choose_len<'a>(v: <ARegularChooseCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, e: AClosedEnum) -> (serialize_len: usize)
@@ -1105,7 +1105,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AMixedTypedEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AMixedTypedEnumCombinatorAlias = TryMap<U8, AMixedTypedEnumMapper>;
 
@@ -1149,14 +1149,14 @@ pub fn serialize_a_mixed_typed_enum<'a>(v: <AMixedTypedEnumCombinator as Combina
         spec_a_mixed_typed_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_mixed_typed_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_mixed_typed_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_mixed_typed_enum().spec_serialize(v@))
         },
 {
     let combinator = a_mixed_typed_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_mixed_typed_enum_len<'a>(v: <AMixedTypedEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1336,7 +1336,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AClosedEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AClosedEnumCombinatorAlias = TryMap<U8, AClosedEnumMapper>;
 
@@ -1380,14 +1380,14 @@ pub fn serialize_a_closed_enum<'a>(v: <AClosedEnumCombinator as Combinator<'a, &
         spec_a_closed_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_closed_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_closed_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_closed_enum().spec_serialize(v@))
         },
 {
     let combinator = a_closed_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_closed_enum_len<'a>(v: <AClosedEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1567,7 +1567,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ATypedClosedEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ATypedClosedEnumCombinatorAlias = TryMap<U16Le, ATypedClosedEnumMapper>;
 
@@ -1611,14 +1611,14 @@ pub fn serialize_a_typed_closed_enum<'a>(v: <ATypedClosedEnumCombinator as Combi
         spec_a_typed_closed_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_typed_closed_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_typed_closed_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_typed_closed_enum().spec_serialize(v@))
         },
 {
     let combinator = a_typed_closed_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_typed_closed_enum_len<'a>(v: <ATypedClosedEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1691,7 +1691,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AnOpenEnumCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AnOpenEnumCombinatorAlias = U8;
 
@@ -1735,14 +1735,14 @@ pub fn serialize_an_open_enum<'a>(v: <AnOpenEnumCombinator as Combinator<'a, &'a
         spec_an_open_enum().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_an_open_enum().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_an_open_enum().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_an_open_enum().spec_serialize(v@))
         },
 {
     let combinator = an_open_enum();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn an_open_enum_len<'a>(v: <AnOpenEnumCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1943,7 +1943,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ATypedChooseWithDefaultCombinator
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ATypedChooseWithDefaultCombinatorAlias = Mapped<ATypedChooseWithDefaultCombinator3, ATypedChooseWithDefaultMapper>;
 
@@ -1993,14 +1993,14 @@ pub fn serialize_a_typed_choose_with_default<'a>(v: <ATypedChooseWithDefaultComb
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_typed_choose_with_default(e@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_typed_choose_with_default(e@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_typed_choose_with_default(e@).spec_serialize(v@))
         },
 {
     let combinator = a_typed_choose_with_default( e );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn a_typed_choose_with_default_len<'a>(v: <ATypedChooseWithDefaultCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, e: u32) -> (serialize_len: usize)
@@ -2202,7 +2202,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AChooseWithDefaultCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AChooseWithDefaultCombinatorAlias = Mapped<AChooseWithDefaultCombinator3, AChooseWithDefaultMapper>;
 
@@ -2252,14 +2252,14 @@ pub fn serialize_a_choose_with_default<'a>(v: <AChooseWithDefaultCombinator as C
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a_choose_with_default(e@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a_choose_with_default(e@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a_choose_with_default(e@).spec_serialize(v@))
         },
 {
     let combinator = a_choose_with_default( e );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn a_choose_with_default_len<'a>(v: <AChooseWithDefaultCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, e: u8) -> (serialize_len: usize)

--- a/vest-dsl/test/src/ikev2.rs
+++ b/vest-dsl/test/src/ikev2.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -92,7 +92,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IkeProtocolIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IkeProtocolIdCombinatorAlias = U8;
 
@@ -136,14 +136,14 @@ pub fn serialize_ike_protocol_id<'a>(v: <IkeProtocolIdCombinator as Combinator<'
         spec_ike_protocol_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ike_protocol_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ike_protocol_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ike_protocol_id().spec_serialize(v@))
         },
 {
     let combinator = ike_protocol_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ike_protocol_id_len<'a>(v: <IkeProtocolIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -230,7 +230,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProposalSpiSizeByteCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProposalSpiSizeByteCombinatorAlias = Refined<U8, Predicate7607843399309189603>;
 
@@ -274,14 +274,14 @@ pub fn serialize_proposal_spi_size_byte<'a>(v: <ProposalSpiSizeByteCombinator as
         spec_proposal_spi_size_byte().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_proposal_spi_size_byte().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_proposal_spi_size_byte().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_proposal_spi_size_byte().spec_serialize(v@))
         },
 {
     let combinator = proposal_spi_size_byte();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn proposal_spi_size_byte_len<'a>(v: <ProposalSpiSizeByteCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -358,7 +358,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformTypeCombinatorAlias = U8;
 
@@ -402,14 +402,14 @@ pub fn serialize_transform_type<'a>(v: <TransformTypeCombinator as Combinator<'a
         spec_transform_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform_type().spec_serialize(v@))
         },
 {
     let combinator = transform_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn transform_type_len<'a>(v: <TransformTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -500,7 +500,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EncrIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EncrIdCombinatorAlias = U16Be;
 
@@ -544,14 +544,14 @@ pub fn serialize_encr_id<'a>(v: <EncrIdCombinator as Combinator<'a, &'a [u8], Ve
         spec_encr_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_encr_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_encr_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_encr_id().spec_serialize(v@))
         },
 {
     let combinator = encr_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn encr_id_len<'a>(v: <EncrIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -624,7 +624,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PrfIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PrfIdCombinatorAlias = U16Be;
 
@@ -668,14 +668,14 @@ pub fn serialize_prf_id<'a>(v: <PrfIdCombinator as Combinator<'a, &'a [u8], Vec<
         spec_prf_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_prf_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_prf_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_prf_id().spec_serialize(v@))
         },
 {
     let combinator = prf_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn prf_id_len<'a>(v: <PrfIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -754,7 +754,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IntegIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IntegIdCombinatorAlias = U16Be;
 
@@ -798,14 +798,14 @@ pub fn serialize_integ_id<'a>(v: <IntegIdCombinator as Combinator<'a, &'a [u8], 
         spec_integ_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_integ_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_integ_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_integ_id().spec_serialize(v@))
         },
 {
     let combinator = integ_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn integ_id_len<'a>(v: <IntegIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -890,7 +890,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DhIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DhIdCombinatorAlias = U16Be;
 
@@ -934,14 +934,14 @@ pub fn serialize_dh_id<'a>(v: <DhIdCombinator as Combinator<'a, &'a [u8], Vec<u8
         spec_dh_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_dh_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_dh_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_dh_id().spec_serialize(v@))
         },
 {
     let combinator = dh_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn dh_id_len<'a>(v: <DhIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1012,7 +1012,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EsnIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EsnIdCombinatorAlias = U16Be;
 
@@ -1056,14 +1056,14 @@ pub fn serialize_esn_id<'a>(v: <EsnIdCombinator as Combinator<'a, &'a [u8], Vec<
         spec_esn_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_esn_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_esn_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_esn_id().spec_serialize(v@))
         },
 {
     let combinator = esn_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn esn_id_len<'a>(v: <EsnIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1296,7 +1296,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformIdValueCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformIdValueCombinatorAlias = Mapped<TransformIdValueCombinator5, TransformIdValueMapper>;
 
@@ -1346,14 +1346,14 @@ pub fn serialize_transform_id_value<'a>(v: <TransformIdValueCombinator as Combin
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform_id_value(kind@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform_id_value(kind@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform_id_value(kind@).spec_serialize(v@))
         },
 {
     let combinator = transform_id_value( kind );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn transform_id_value_len<'a>(v: <TransformIdValueCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, kind: u8) -> (serialize_len: usize)
@@ -1503,7 +1503,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformAttrKeyLengthCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformAttrKeyLengthCombinatorAlias = Mapped<TransformAttrKeyLengthCombinator1, TransformAttrKeyLengthMapper>;
 
@@ -1555,14 +1555,14 @@ pub fn serialize_transform_attr_key_length<'a>(v: <TransformAttrKeyLengthCombina
         spec_transform_attr_key_length().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform_attr_key_length().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform_attr_key_length().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform_attr_key_length().spec_serialize(v@))
         },
 {
     let combinator = transform_attr_key_length();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn transform_attr_key_length_len<'a>(v: <TransformAttrKeyLengthCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1723,7 +1723,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformAttrTvCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformAttrTvCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate11909926070075194211>, U16Be, TransformAttrTvCont0>, TransformAttrTvMapper>;
 
@@ -1790,14 +1790,14 @@ pub fn serialize_transform_attr_tv<'a>(v: <TransformAttrTvCombinator as Combinat
         spec_transform_attr_tv().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform_attr_tv().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform_attr_tv().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform_attr_tv().spec_serialize(v@))
         },
 {
     let combinator = transform_attr_tv();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn transform_attr_tv_len<'a>(v: <TransformAttrTvCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1992,7 +1992,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformAttrTlvCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformAttrTlvCombinatorAlias = Mapped<Pair<Pair<Refined<U16Be, Predicate5630542192344936318>, U16Be, TransformAttrTlvCont1>, bytes::Variable, TransformAttrTlvCont0>, TransformAttrTlvMapper>;
 
@@ -2074,14 +2074,14 @@ pub fn serialize_transform_attr_tlv<'a>(v: <TransformAttrTlvCombinator as Combin
         spec_transform_attr_tlv().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform_attr_tlv().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform_attr_tlv().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform_attr_tlv().spec_serialize(v@))
         },
 {
     let combinator = transform_attr_tlv();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn transform_attr_tlv_len<'a>(v: <TransformAttrTlvCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2350,7 +2350,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformAttrCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformAttrCombinatorAlias = Mapped<TransformAttrCombinator2, TransformAttrMapper>;
 
@@ -2394,14 +2394,14 @@ pub fn serialize_transform_attr<'a>(v: <TransformAttrCombinator as Combinator<'a
         spec_transform_attr().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform_attr().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform_attr().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform_attr().spec_serialize(v@))
         },
 {
     let combinator = transform_attr();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn transform_attr_len<'a>(v: <TransformAttrCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2599,7 +2599,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TransformCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TransformCombinatorAlias = Mapped<Pair<Pair<(Refined<U8, Predicate11363499016643468509>, (Refined<U8, TagPred<u8>>, Refined<U16Be, Predicate18193225726552524852>)), TransformTypeCombinator, TransformCont1>, (Refined<U8, TagPred<u8>>, (TransformIdValueCombinator, AndThen<bytes::Variable, Repeat<TransformAttrCombinator>>)), TransformCont0>, TransformMapper>;
 
@@ -2681,14 +2681,14 @@ pub fn serialize_transform<'a>(v: <TransformCombinator as Combinator<'a, &'a [u8
         spec_transform().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_transform().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_transform().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_transform().spec_serialize(v@))
         },
 {
     let combinator = transform();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn transform_len<'a>(v: <TransformCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2900,7 +2900,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProposalBodySpi0Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProposalBodySpi0CombinatorAlias = Mapped<ProposalBodySpi0Combinator1, ProposalBodySpi0Mapper>;
 
@@ -2958,14 +2958,14 @@ pub fn serialize_proposal_body_spi0<'a>(v: <ProposalBodySpi0Combinator as Combin
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_proposal_body_spi0(num_transforms@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_proposal_body_spi0(num_transforms@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_proposal_body_spi0(num_transforms@).spec_serialize(v@))
         },
 {
     let combinator = proposal_body_spi0( num_transforms );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn proposal_body_spi0_len<'a>(v: <ProposalBodySpi0Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num_transforms: u8) -> (serialize_len: usize)
@@ -3114,7 +3114,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProposalBodySpi4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProposalBodySpi4CombinatorAlias = Mapped<ProposalBodySpi4Combinator1, ProposalBodySpi4Mapper>;
 
@@ -3172,14 +3172,14 @@ pub fn serialize_proposal_body_spi4<'a>(v: <ProposalBodySpi4Combinator as Combin
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_proposal_body_spi4(num_transforms@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_proposal_body_spi4(num_transforms@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_proposal_body_spi4(num_transforms@).spec_serialize(v@))
         },
 {
     let combinator = proposal_body_spi4( num_transforms );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn proposal_body_spi4_len<'a>(v: <ProposalBodySpi4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num_transforms: u8) -> (serialize_len: usize)
@@ -3328,7 +3328,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProposalBodySpi8Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProposalBodySpi8CombinatorAlias = Mapped<ProposalBodySpi8Combinator1, ProposalBodySpi8Mapper>;
 
@@ -3386,14 +3386,14 @@ pub fn serialize_proposal_body_spi8<'a>(v: <ProposalBodySpi8Combinator as Combin
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_proposal_body_spi8(num_transforms@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_proposal_body_spi8(num_transforms@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_proposal_body_spi8(num_transforms@).spec_serialize(v@))
         },
 {
     let combinator = proposal_body_spi8( num_transforms );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn proposal_body_spi8_len<'a>(v: <ProposalBodySpi8Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num_transforms: u8) -> (serialize_len: usize)
@@ -3579,7 +3579,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProposalBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProposalBodyCombinatorAlias = AndThen<bytes::Variable, Mapped<ProposalBodyCombinator2, ProposalBodyMapper>>;
 
@@ -3635,14 +3635,14 @@ pub fn serialize_proposal_body<'a>(v: <ProposalBodyCombinator as Combinator<'a, 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_proposal_body(num_transforms@, proposal_length@, spi_size@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_proposal_body(num_transforms@, proposal_length@, spi_size@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_proposal_body(num_transforms@, proposal_length@, spi_size@).spec_serialize(v@))
         },
 {
     let combinator = proposal_body( num_transforms, proposal_length, spi_size );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn proposal_body_len<'a>(v: <ProposalBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num_transforms: u8, proposal_length: u16, spi_size: ProposalSpiSizeByte) -> (serialize_len: usize)
@@ -3865,7 +3865,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProposalCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProposalCombinatorAlias = Mapped<Pair<Pair<Pair<Pair<(Refined<U8, Predicate7277979220772363767>, (Refined<U8, TagPred<u8>>, Refined<U16Be, Predicate18193225726552524852>)), (Refined<U8, Predicate2172399096230090262>, IkeProtocolIdCombinator), ProposalCont3>, ProposalSpiSizeByteCombinator, ProposalCont2>, Refined<U8, Predicate3651688686135228051>, ProposalCont1>, ProposalBodyCombinator, ProposalCont0>, ProposalMapper>;
 
@@ -3977,14 +3977,14 @@ pub fn serialize_proposal<'a>(v: <ProposalCombinator as Combinator<'a, &'a [u8],
         spec_proposal().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_proposal().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_proposal().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_proposal().spec_serialize(v@))
         },
 {
     let combinator = proposal();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn proposal_len<'a>(v: <ProposalCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4258,7 +4258,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SaPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SaPayloadBodyCombinatorAlias = Mapped<AndThen<bytes::Variable, Repeat<ProposalCombinator>>, SaPayloadBodyMapper>;
 
@@ -4316,14 +4316,14 @@ pub fn serialize_sa_payload_body<'a>(v: <SaPayloadBodyCombinator as Combinator<'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_sa_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_sa_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_sa_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = sa_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn sa_payload_body_len<'a>(v: <SaPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -4534,7 +4534,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsIpv6Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsIpv6CombinatorAlias = Mapped<TsIpv6Combinator6, TsIpv6Mapper>;
 
@@ -4586,14 +4586,14 @@ pub fn serialize_ts_ipv6<'a>(v: <TsIpv6Combinator as Combinator<'a, &'a [u8], Ve
         spec_ts_ipv6().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_ipv6().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_ipv6().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_ipv6().spec_serialize(v@))
         },
 {
     let combinator = ts_ipv6();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ts_ipv6_len<'a>(v: <TsIpv6Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4731,7 +4731,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2SaPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2SaPayloadInnerCombinatorAlias = Mapped<AndThen<bytes::Tail, Repeat<ProposalCombinator>>, Ikev2SaPayloadInnerMapper>;
 
@@ -4783,14 +4783,14 @@ pub fn serialize_ikev2_sa_payload_inner<'a>(v: <Ikev2SaPayloadInnerCombinator as
         spec_ikev2_sa_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_sa_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_sa_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_sa_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_sa_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_sa_payload_inner_len<'a>(v: <Ikev2SaPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4928,7 +4928,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NoncePayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NoncePayloadBodyCombinatorAlias = Mapped<bytes::Variable, NoncePayloadBodyMapper>;
 
@@ -4986,14 +4986,14 @@ pub fn serialize_nonce_payload_body<'a>(v: <NoncePayloadBodyCombinator as Combin
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_nonce_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_nonce_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_nonce_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = nonce_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn nonce_payload_body_len<'a>(v: <NoncePayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -5075,7 +5075,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IdTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IdTypeCombinatorAlias = U8;
 
@@ -5119,14 +5119,14 @@ pub fn serialize_id_type<'a>(v: <IdTypeCombinator as Combinator<'a, &'a [u8], Ve
         spec_id_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_id_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_id_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_id_type().spec_serialize(v@))
         },
 {
     let combinator = id_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn id_type_len<'a>(v: <IdTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5293,7 +5293,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2IdPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2IdPayloadInnerCombinatorAlias = Mapped<Ikev2IdPayloadInnerCombinator2, Ikev2IdPayloadInnerMapper>;
 
@@ -5345,14 +5345,14 @@ pub fn serialize_ikev2_id_payload_inner<'a>(v: <Ikev2IdPayloadInnerCombinator as
         spec_ikev2_id_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_id_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_id_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_id_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_id_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_id_payload_inner_len<'a>(v: <Ikev2IdPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5500,7 +5500,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NotifyPayloadBodySpi0Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NotifyPayloadBodySpi0CombinatorAlias = Mapped<NotifyPayloadBodySpi0Combinator1, NotifyPayloadBodySpi0Mapper>;
 
@@ -5552,14 +5552,14 @@ pub fn serialize_notify_payload_body_spi0<'a>(v: <NotifyPayloadBodySpi0Combinato
         spec_notify_payload_body_spi0().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_notify_payload_body_spi0().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_notify_payload_body_spi0().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_notify_payload_body_spi0().spec_serialize(v@))
         },
 {
     let combinator = notify_payload_body_spi0();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn notify_payload_body_spi0_len<'a>(v: <NotifyPayloadBodySpi0Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5626,7 +5626,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CfgAttrTypeWordCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CfgAttrTypeWordCombinatorAlias = Refined<U16Be, Predicate5630542192344936318>;
 
@@ -5670,14 +5670,14 @@ pub fn serialize_cfg_attr_type_word<'a>(v: <CfgAttrTypeWordCombinator as Combina
         spec_cfg_attr_type_word().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cfg_attr_type_word().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cfg_attr_type_word().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cfg_attr_type_word().spec_serialize(v@))
         },
 {
     let combinator = cfg_attr_type_word();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cfg_attr_type_word_len<'a>(v: <CfgAttrTypeWordCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5821,7 +5821,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CfgAttributeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CfgAttributeCombinatorAlias = Mapped<Pair<Pair<CfgAttrTypeWordCombinator, U16Be, CfgAttributeCont1>, bytes::Variable, CfgAttributeCont0>, CfgAttributeMapper>;
 
@@ -5903,14 +5903,14 @@ pub fn serialize_cfg_attribute<'a>(v: <CfgAttributeCombinator as Combinator<'a, 
         spec_cfg_attribute().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cfg_attribute().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cfg_attribute().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cfg_attribute().spec_serialize(v@))
         },
 {
     let combinator = cfg_attribute();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cfg_attribute_len<'a>(v: <CfgAttributeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6045,7 +6045,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsTypeCombinatorAlias = U8;
 
@@ -6089,14 +6089,14 @@ pub fn serialize_ts_type<'a>(v: <TsTypeCombinator as Combinator<'a, &'a [u8], Ve
         spec_ts_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_type().spec_serialize(v@))
         },
 {
     let combinator = ts_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ts_type_len<'a>(v: <TsTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6293,7 +6293,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsIpv4SelectorBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsIpv4SelectorBodyCombinatorAlias = Mapped<TsIpv4SelectorBodyCombinator5, TsIpv4SelectorBodyMapper>;
 
@@ -6345,14 +6345,14 @@ pub fn serialize_ts_ipv4_selector_body<'a>(v: <TsIpv4SelectorBodyCombinator as C
         spec_ts_ipv4_selector_body().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_ipv4_selector_body().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_ipv4_selector_body().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_ipv4_selector_body().spec_serialize(v@))
         },
 {
     let combinator = ts_ipv4_selector_body();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ts_ipv4_selector_body_len<'a>(v: <TsIpv4SelectorBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6549,7 +6549,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsIpv6SelectorBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsIpv6SelectorBodyCombinatorAlias = Mapped<TsIpv6SelectorBodyCombinator5, TsIpv6SelectorBodyMapper>;
 
@@ -6601,14 +6601,14 @@ pub fn serialize_ts_ipv6_selector_body<'a>(v: <TsIpv6SelectorBodyCombinator as C
         spec_ts_ipv6_selector_body().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_ipv6_selector_body().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_ipv6_selector_body().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_ipv6_selector_body().spec_serialize(v@))
         },
 {
     let combinator = ts_ipv6_selector_body();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ts_ipv6_selector_body_len<'a>(v: <TsIpv6SelectorBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6772,7 +6772,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsUnknownInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsUnknownInnerCombinatorAlias = Mapped<Pair<(U8, Refined<U16Be, Predicate17149271707383182075>), bytes::Variable, TsUnknownInnerCont0>, TsUnknownInnerMapper>;
 
@@ -6839,14 +6839,14 @@ pub fn serialize_ts_unknown_inner<'a>(v: <TsUnknownInnerCombinator as Combinator
         spec_ts_unknown_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_unknown_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_unknown_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_unknown_inner().spec_serialize(v@))
         },
 {
     let combinator = ts_unknown_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ts_unknown_inner_len<'a>(v: <TsUnknownInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7062,7 +7062,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TrafficSelectorTsBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TrafficSelectorTsBodyCombinatorAlias = Mapped<TrafficSelectorTsBodyCombinator2, TrafficSelectorTsBodyMapper>;
 
@@ -7112,14 +7112,14 @@ pub fn serialize_traffic_selector_ts_body<'a>(v: <TrafficSelectorTsBodyCombinato
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_traffic_selector_ts_body(ts_type_byte@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_traffic_selector_ts_body(ts_type_byte@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_traffic_selector_ts_body(ts_type_byte@).spec_serialize(v@))
         },
 {
     let combinator = traffic_selector_ts_body( ts_type_byte );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn traffic_selector_ts_body_len<'a>(v: <TrafficSelectorTsBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ts_type_byte: u8) -> (serialize_len: usize)
@@ -7261,7 +7261,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TrafficSelectorCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TrafficSelectorCombinatorAlias = Mapped<Pair<TsTypeCombinator, TrafficSelectorTsBodyCombinator, TrafficSelectorCont0>, TrafficSelectorMapper>;
 
@@ -7328,14 +7328,14 @@ pub fn serialize_traffic_selector<'a>(v: <TrafficSelectorCombinator as Combinato
         spec_traffic_selector().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_traffic_selector().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_traffic_selector().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_traffic_selector().spec_serialize(v@))
         },
 {
     let combinator = traffic_selector();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn traffic_selector_len<'a>(v: <TrafficSelectorCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7517,7 +7517,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2TsPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2TsPayloadInnerCombinatorAlias = Mapped<Pair<Refined<U8, Predicate3651688686135228051>, (Refined<bytes::Fixed<3>, TagPred<[u8; 3]>>, AndThen<bytes::Tail, RepeatN<TrafficSelectorCombinator>>), Ikev2TsPayloadInnerCont0>, Ikev2TsPayloadInnerMapper>;
 
@@ -7584,14 +7584,14 @@ pub fn serialize_ikev2_ts_payload_inner<'a>(v: <Ikev2TsPayloadInnerCombinator as
         spec_ikev2_ts_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_ts_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_ts_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_ts_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_ts_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_ts_payload_inner_len<'a>(v: <Ikev2TsPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7771,7 +7771,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapSuccessRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapSuccessRestCombinatorAlias = Mapped<EapSuccessRestCombinator1, EapSuccessRestMapper>;
 
@@ -7823,14 +7823,14 @@ pub fn serialize_eap_success_rest<'a>(v: <EapSuccessRestCombinator as Combinator
         spec_eap_success_rest().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_success_rest().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_success_rest().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_success_rest().spec_serialize(v@))
         },
 {
     let combinator = eap_success_rest();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn eap_success_rest_len<'a>(v: <EapSuccessRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7917,7 +7917,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IpsecSpiSizeOrNoneCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IpsecSpiSizeOrNoneCombinatorAlias = Refined<U8, Predicate15445621259281350129>;
 
@@ -7961,14 +7961,14 @@ pub fn serialize_ipsec_spi_size_or_none<'a>(v: <IpsecSpiSizeOrNoneCombinator as 
         spec_ipsec_spi_size_or_none().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ipsec_spi_size_or_none().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ipsec_spi_size_or_none().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ipsec_spi_size_or_none().spec_serialize(v@))
         },
 {
     let combinator = ipsec_spi_size_or_none();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ipsec_spi_size_or_none_len<'a>(v: <IpsecSpiSizeOrNoneCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8043,7 +8043,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapCodeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapCodeCombinatorAlias = U8;
 
@@ -8087,14 +8087,14 @@ pub fn serialize_eap_code<'a>(v: <EapCodeCombinator as Combinator<'a, &'a [u8], 
         spec_eap_code().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_code().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_code().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_code().spec_serialize(v@))
         },
 {
     let combinator = eap_code();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn eap_code_len<'a>(v: <EapCodeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8243,7 +8243,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapFailureRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapFailureRestCombinatorAlias = Mapped<EapFailureRestCombinator1, EapFailureRestMapper>;
 
@@ -8295,14 +8295,14 @@ pub fn serialize_eap_failure_rest<'a>(v: <EapFailureRestCombinator as Combinator
         spec_eap_failure_rest().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_failure_rest().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_failure_rest().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_failure_rest().spec_serialize(v@))
         },
 {
     let combinator = eap_failure_rest();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn eap_failure_rest_len<'a>(v: <EapFailureRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8469,7 +8469,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapReqRespRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapReqRespRestCombinatorAlias = Mapped<Pair<(U8, Refined<U16Be, Predicate7010197279221949030>), (U8, bytes::Variable), EapReqRespRestCont0>, EapReqRespRestMapper>;
 
@@ -8536,14 +8536,14 @@ pub fn serialize_eap_req_resp_rest<'a>(v: <EapReqRespRestCombinator as Combinato
         spec_eap_req_resp_rest().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_req_resp_rest().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_req_resp_rest().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_req_resp_rest().spec_serialize(v@))
         },
 {
     let combinator = eap_req_resp_rest();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn eap_req_resp_rest_len<'a>(v: <EapReqRespRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8775,7 +8775,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2EapPayloadInnerEapRestCombin
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2EapPayloadInnerEapRestCombinatorAlias = Mapped<Ikev2EapPayloadInnerEapRestCombinator3, Ikev2EapPayloadInnerEapRestMapper>;
 
@@ -8825,14 +8825,14 @@ pub fn serialize_ikev2_eap_payload_inner_eap_rest<'a>(v: <Ikev2EapPayloadInnerEa
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_eap_payload_inner_eap_rest(code@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_eap_payload_inner_eap_rest(code@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_eap_payload_inner_eap_rest(code@).spec_serialize(v@))
         },
 {
     let combinator = ikev2_eap_payload_inner_eap_rest( code );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn ikev2_eap_payload_inner_eap_rest_len<'a>(v: <Ikev2EapPayloadInnerEapRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, code: u8) -> (serialize_len: usize)
@@ -8974,7 +8974,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2EapPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2EapPayloadInnerCombinatorAlias = Mapped<Pair<EapCodeCombinator, Ikev2EapPayloadInnerEapRestCombinator, Ikev2EapPayloadInnerCont0>, Ikev2EapPayloadInnerMapper>;
 
@@ -9041,14 +9041,14 @@ pub fn serialize_ikev2_eap_payload_inner<'a>(v: <Ikev2EapPayloadInnerCombinator 
         spec_ikev2_eap_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_eap_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_eap_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_eap_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_eap_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_eap_payload_inner_len<'a>(v: <Ikev2EapPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9170,7 +9170,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertEncodingCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertEncodingCombinatorAlias = U8;
 
@@ -9214,14 +9214,14 @@ pub fn serialize_cert_encoding<'a>(v: <CertEncodingCombinator as Combinator<'a, 
         spec_cert_encoding().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cert_encoding().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cert_encoding().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cert_encoding().spec_serialize(v@))
         },
 {
     let combinator = cert_encoding();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cert_encoding_len<'a>(v: <CertEncodingCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9369,7 +9369,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertreqPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertreqPayloadBodyCombinatorAlias = Mapped<CertreqPayloadBodyCombinator1, CertreqPayloadBodyMapper>;
 
@@ -9427,14 +9427,14 @@ pub fn serialize_certreq_payload_body<'a>(v: <CertreqPayloadBodyCombinator as Co
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certreq_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certreq_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certreq_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = certreq_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn certreq_payload_body_len<'a>(v: <CertreqPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -9636,7 +9636,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapPayloadBodyEapRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapPayloadBodyEapRestCombinatorAlias = Mapped<EapPayloadBodyEapRestCombinator3, EapPayloadBodyEapRestMapper>;
 
@@ -9686,14 +9686,14 @@ pub fn serialize_eap_payload_body_eap_rest<'a>(v: <EapPayloadBodyEapRestCombinat
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_payload_body_eap_rest(code@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_payload_body_eap_rest(code@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_payload_body_eap_rest(code@).spec_serialize(v@))
         },
 {
     let combinator = eap_payload_body_eap_rest( code );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn eap_payload_body_eap_rest_len<'a>(v: <EapPayloadBodyEapRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, code: u8) -> (serialize_len: usize)
@@ -9769,7 +9769,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CfgTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CfgTypeCombinatorAlias = U8;
 
@@ -9813,14 +9813,14 @@ pub fn serialize_cfg_type<'a>(v: <CfgTypeCombinator as Combinator<'a, &'a [u8], 
         spec_cfg_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cfg_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cfg_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cfg_type().spec_serialize(v@))
         },
 {
     let combinator = cfg_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cfg_type_len<'a>(v: <CfgTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9987,7 +9987,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CpPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CpPayloadBodyCombinatorAlias = Mapped<CpPayloadBodyCombinator2, CpPayloadBodyMapper>;
 
@@ -10045,14 +10045,14 @@ pub fn serialize_cp_payload_body<'a>(v: <CpPayloadBodyCombinator as Combinator<'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cp_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cp_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cp_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = cp_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn cp_payload_body_len<'a>(v: <CpPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -10194,7 +10194,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapPayloadBodyCombinatorAlias = Mapped<Pair<EapCodeCombinator, EapPayloadBodyEapRestCombinator, EapPayloadBodyCont0>, EapPayloadBodyMapper>;
 
@@ -10267,14 +10267,14 @@ pub fn serialize_eap_payload_body<'a>(v: <EapPayloadBodyCombinator as Combinator
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = eap_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn eap_payload_body_len<'a>(v: <EapPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -10387,7 +10387,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExchangeTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExchangeTypeCombinatorAlias = U8;
 
@@ -10431,14 +10431,14 @@ pub fn serialize_exchange_type<'a>(v: <ExchangeTypeCombinator as Combinator<'a, 
         spec_exchange_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_exchange_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_exchange_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_exchange_type().spec_serialize(v@))
         },
 {
     let combinator = exchange_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn exchange_type_len<'a>(v: <ExchangeTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10563,7 +10563,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NotifyMsgTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NotifyMsgTypeCombinatorAlias = U16Be;
 
@@ -10607,14 +10607,14 @@ pub fn serialize_notify_msg_type<'a>(v: <NotifyMsgTypeCombinator as Combinator<'
         spec_notify_msg_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_notify_msg_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_notify_msg_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_notify_msg_type().spec_serialize(v@))
         },
 {
     let combinator = notify_msg_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn notify_msg_type_len<'a>(v: <NotifyMsgTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10775,7 +10775,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for KePayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type KePayloadBodyCombinatorAlias = Mapped<KePayloadBodyCombinator2, KePayloadBodyMapper>;
 
@@ -10833,14 +10833,14 @@ pub fn serialize_ke_payload_body<'a>(v: <KePayloadBodyCombinator as Combinator<'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ke_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ke_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ke_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = ke_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn ke_payload_body_len<'a>(v: <KePayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -10942,7 +10942,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NextPayloadTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NextPayloadTypeCombinatorAlias = U8;
 
@@ -10986,14 +10986,14 @@ pub fn serialize_next_payload_type<'a>(v: <NextPayloadTypeCombinator as Combinat
         spec_next_payload_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_next_payload_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_next_payload_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_next_payload_type().spec_serialize(v@))
         },
 {
     let combinator = next_payload_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn next_payload_type_len<'a>(v: <NextPayloadTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11080,7 +11080,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IkeVersionByteCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IkeVersionByteCombinatorAlias = Refined<U8, Predicate10005340194363141588>;
 
@@ -11124,14 +11124,14 @@ pub fn serialize_ike_version_byte<'a>(v: <IkeVersionByteCombinator as Combinator
         spec_ike_version_byte().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ike_version_byte().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ike_version_byte().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ike_version_byte().spec_serialize(v@))
         },
 {
     let combinator = ike_version_byte();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ike_version_byte_len<'a>(v: <IkeVersionByteCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11318,7 +11318,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IkeFlagsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IkeFlagsCombinatorAlias = TryMap<U8, IkeFlagsMapper>;
 
@@ -11362,14 +11362,14 @@ pub fn serialize_ike_flags<'a>(v: <IkeFlagsCombinator as Combinator<'a, &'a [u8]
         spec_ike_flags().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ike_flags().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ike_flags().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ike_flags().spec_serialize(v@))
         },
 {
     let combinator = ike_flags();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ike_flags_len<'a>(v: <IkeFlagsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11609,7 +11609,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IkeHeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IkeHeaderCombinatorAlias = Mapped<IkeHeaderCombinator7, IkeHeaderMapper>;
 
@@ -11661,14 +11661,14 @@ pub fn serialize_ike_header<'a>(v: <IkeHeaderCombinator as Combinator<'a, &'a [u
         spec_ike_header().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ike_header().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ike_header().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ike_header().spec_serialize(v@))
         },
 {
     let combinator = ike_header();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ike_header_len<'a>(v: <IkeHeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11735,7 +11735,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DeletePayloadSpisNoneCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DeletePayloadSpisNoneCombinatorAlias = bytes::Fixed<0>;
 
@@ -11779,14 +11779,14 @@ pub fn serialize_delete_payload_spis_none<'a>(v: <DeletePayloadSpisNoneCombinato
         spec_delete_payload_spis_none().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_delete_payload_spis_none().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_delete_payload_spis_none().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_delete_payload_spis_none().spec_serialize(v@))
         },
 {
     let combinator = delete_payload_spis_none();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn delete_payload_spis_none_len<'a>(v: <DeletePayloadSpisNoneCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11965,7 +11965,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapMessageSuccessFailureCombinato
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapMessageSuccessFailureCombinatorAlias = Mapped<EapMessageSuccessFailureCombinator2, EapMessageSuccessFailureMapper>;
 
@@ -12017,14 +12017,14 @@ pub fn serialize_eap_message_success_failure<'a>(v: <EapMessageSuccessFailureCom
         spec_eap_message_success_failure().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_message_success_failure().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_message_success_failure().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_message_success_failure().spec_serialize(v@))
         },
 {
     let combinator = eap_message_success_failure();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn eap_message_success_failure_len<'a>(v: <EapMessageSuccessFailureCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12172,7 +12172,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2CertPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2CertPayloadInnerCombinatorAlias = Mapped<Ikev2CertPayloadInnerCombinator1, Ikev2CertPayloadInnerMapper>;
 
@@ -12224,14 +12224,14 @@ pub fn serialize_ikev2_cert_payload_inner<'a>(v: <Ikev2CertPayloadInnerCombinato
         spec_ikev2_cert_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_cert_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_cert_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_cert_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_cert_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_cert_payload_inner_len<'a>(v: <Ikev2CertPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12304,7 +12304,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AuthMethodCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AuthMethodCombinatorAlias = U8;
 
@@ -12348,14 +12348,14 @@ pub fn serialize_auth_method<'a>(v: <AuthMethodCombinator as Combinator<'a, &'a 
         spec_auth_method().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_auth_method().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_auth_method().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_auth_method().spec_serialize(v@))
         },
 {
     let combinator = auth_method();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn auth_method_len<'a>(v: <AuthMethodCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12522,7 +12522,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2AuthPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2AuthPayloadInnerCombinatorAlias = Mapped<Ikev2AuthPayloadInnerCombinator2, Ikev2AuthPayloadInnerMapper>;
 
@@ -12574,14 +12574,14 @@ pub fn serialize_ikev2_auth_payload_inner<'a>(v: <Ikev2AuthPayloadInnerCombinato
         spec_ikev2_auth_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_auth_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_auth_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_auth_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_auth_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_auth_payload_inner_len<'a>(v: <Ikev2AuthPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12719,7 +12719,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2NoncePayloadInnerCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2NoncePayloadInnerCombinatorAlias = Mapped<bytes::Tail, Ikev2NoncePayloadInnerMapper>;
 
@@ -12771,14 +12771,14 @@ pub fn serialize_ikev2_nonce_payload_inner<'a>(v: <Ikev2NoncePayloadInnerCombina
         spec_ikev2_nonce_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_nonce_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_nonce_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_nonce_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_nonce_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_nonce_payload_inner_len<'a>(v: <Ikev2NoncePayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12916,7 +12916,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2VendorIdPayloadInnerCombinat
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2VendorIdPayloadInnerCombinatorAlias = Mapped<bytes::Tail, Ikev2VendorIdPayloadInnerMapper>;
 
@@ -12968,14 +12968,14 @@ pub fn serialize_ikev2_vendor_id_payload_inner<'a>(v: <Ikev2VendorIdPayloadInner
         spec_ikev2_vendor_id_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_vendor_id_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_vendor_id_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_vendor_id_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_vendor_id_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_vendor_id_payload_inner_len<'a>(v: <Ikev2VendorIdPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13113,7 +13113,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SkPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SkPayloadBodyCombinatorAlias = Mapped<bytes::Variable, SkPayloadBodyMapper>;
 
@@ -13171,14 +13171,14 @@ pub fn serialize_sk_payload_body<'a>(v: <SkPayloadBodyCombinator as Combinator<'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_sk_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_sk_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_sk_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = sk_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn sk_payload_body_len<'a>(v: <SkPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -13359,7 +13359,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NotifyProtocolIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NotifyProtocolIdCombinatorAlias = TryMap<U8, NotifyProtocolIdMapper>;
 
@@ -13403,14 +13403,14 @@ pub fn serialize_notify_protocol_id<'a>(v: <NotifyProtocolIdCombinator as Combin
         spec_notify_protocol_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_notify_protocol_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_notify_protocol_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_notify_protocol_id().spec_serialize(v@))
         },
 {
     let combinator = notify_protocol_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn notify_protocol_id_len<'a>(v: <NotifyProtocolIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13560,7 +13560,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2NotifyPayloadInnerCombinator
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2NotifyPayloadInnerCombinatorAlias = Mapped<Pair<Pair<NotifyProtocolIdCombinator, IpsecSpiSizeOrNoneCombinator, Ikev2NotifyPayloadInnerCont1>, (NotifyMsgTypeCombinator, (bytes::Variable, bytes::Tail)), Ikev2NotifyPayloadInnerCont0>, Ikev2NotifyPayloadInnerMapper>;
 
@@ -13642,14 +13642,14 @@ pub fn serialize_ikev2_notify_payload_inner<'a>(v: <Ikev2NotifyPayloadInnerCombi
         spec_ikev2_notify_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_notify_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_notify_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_notify_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_notify_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_notify_payload_inner_len<'a>(v: <Ikev2NotifyPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13780,7 +13780,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DeletePayloadSpisIpsecCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DeletePayloadSpisIpsecCombinatorAlias = RepeatN<U32Be>;
 
@@ -13826,14 +13826,14 @@ pub fn serialize_delete_payload_spis_ipsec<'a>(v: <DeletePayloadSpisIpsecCombina
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_delete_payload_spis_ipsec(num_spis@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_delete_payload_spis_ipsec(num_spis@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_delete_payload_spis_ipsec(num_spis@).spec_serialize(v@))
         },
 {
     let combinator = delete_payload_spis_ipsec( num_spis );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn delete_payload_spis_ipsec_len<'a>(v: <DeletePayloadSpisIpsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num_spis: u16) -> (serialize_len: usize)
@@ -14001,7 +14001,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EapMessageReqRespCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EapMessageReqRespCombinatorAlias = Mapped<Pair<(Refined<EapCodeCombinator, Predicate8053454275691315570>, (U8, Refined<U16Be, Predicate7010197279221949030>)), (U8, bytes::Variable), EapMessageReqRespCont0>, EapMessageReqRespMapper>;
 
@@ -14068,14 +14068,14 @@ pub fn serialize_eap_message_req_resp<'a>(v: <EapMessageReqRespCombinator as Com
         spec_eap_message_req_resp().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_eap_message_req_resp().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_eap_message_req_resp().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_eap_message_req_resp().spec_serialize(v@))
         },
 {
     let combinator = eap_message_req_resp();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn eap_message_req_resp_len<'a>(v: <EapMessageReqRespCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14254,7 +14254,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NotifyPayloadBodySpi4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NotifyPayloadBodySpi4CombinatorAlias = Mapped<NotifyPayloadBodySpi4Combinator1, NotifyPayloadBodySpi4Mapper>;
 
@@ -14306,14 +14306,14 @@ pub fn serialize_notify_payload_body_spi4<'a>(v: <NotifyPayloadBodySpi4Combinato
         spec_notify_payload_body_spi4().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_notify_payload_body_spi4().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_notify_payload_body_spi4().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_notify_payload_body_spi4().spec_serialize(v@))
         },
 {
     let combinator = notify_payload_body_spi4();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn notify_payload_body_spi4_len<'a>(v: <NotifyPayloadBodySpi4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14482,7 +14482,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NotifyPayloadBodyRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NotifyPayloadBodyRestCombinatorAlias = AndThen<bytes::Variable, Mapped<NotifyPayloadBodyRestCombinator1, NotifyPayloadBodyRestMapper>>;
 
@@ -14535,14 +14535,14 @@ pub fn serialize_notify_payload_body_rest<'a>(v: <NotifyPayloadBodyRestCombinato
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_notify_payload_body_rest(payload_length@, spi_size@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_notify_payload_body_rest(payload_length@, spi_size@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_notify_payload_body_rest(payload_length@, spi_size@).spec_serialize(v@))
         },
 {
     let combinator = notify_payload_body_rest( payload_length, spi_size );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn notify_payload_body_rest_len<'a>(v: <NotifyPayloadBodyRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16, spi_size: IpsecSpiSizeOrNone) -> (serialize_len: usize)
@@ -14691,7 +14691,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NotifyPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NotifyPayloadBodyCombinatorAlias = Mapped<Pair<Pair<NotifyProtocolIdCombinator, IpsecSpiSizeOrNoneCombinator, NotifyPayloadBodyCont1>, (NotifyMsgTypeCombinator, NotifyPayloadBodyRestCombinator), NotifyPayloadBodyCont0>, NotifyPayloadBodyMapper>;
 
@@ -14779,14 +14779,14 @@ pub fn serialize_notify_payload_body<'a>(v: <NotifyPayloadBodyCombinator as Comb
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_notify_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_notify_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_notify_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = notify_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn notify_payload_body_len<'a>(v: <NotifyPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -15011,7 +15011,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertPayloadBodyCombinatorAlias = Mapped<CertPayloadBodyCombinator1, CertPayloadBodyMapper>;
 
@@ -15069,14 +15069,14 @@ pub fn serialize_cert_payload_body<'a>(v: <CertPayloadBodyCombinator as Combinat
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cert_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cert_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cert_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = cert_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn cert_payload_body_len<'a>(v: <CertPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -15228,7 +15228,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsPayloadBodyCombinatorAlias = Mapped<Pair<Refined<U8, Predicate3651688686135228051>, (Refined<bytes::Fixed<3>, TagPred<[u8; 3]>>, AndThen<bytes::Variable, RepeatN<TrafficSelectorCombinator>>), TsPayloadBodyCont0>, TsPayloadBodyMapper>;
 
@@ -15301,14 +15301,14 @@ pub fn serialize_ts_payload_body<'a>(v: <TsPayloadBodyCombinator as Combinator<'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = ts_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn ts_payload_body_len<'a>(v: <TsPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -15484,7 +15484,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for VendorIdPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type VendorIdPayloadBodyCombinatorAlias = Mapped<bytes::Variable, VendorIdPayloadBodyMapper>;
 
@@ -15542,14 +15542,14 @@ pub fn serialize_vendor_id_payload_body<'a>(v: <VendorIdPayloadBodyCombinator as
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_vendor_id_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_vendor_id_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_vendor_id_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = vendor_id_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn vendor_id_payload_body_len<'a>(v: <VendorIdPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -15723,7 +15723,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PayloadCriticalCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PayloadCriticalCombinatorAlias = TryMap<U8, PayloadCriticalMapper>;
 
@@ -15767,14 +15767,14 @@ pub fn serialize_payload_critical<'a>(v: <PayloadCriticalCombinator as Combinato
         spec_payload_critical().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_payload_critical().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_payload_critical().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_payload_critical().spec_serialize(v@))
         },
 {
     let combinator = payload_critical();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn payload_critical_len<'a>(v: <PayloadCriticalCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15943,7 +15943,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DeletePayloadBodySpisCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DeletePayloadBodySpisCombinatorAlias = Mapped<DeletePayloadBodySpisCombinator1, DeletePayloadBodySpisMapper>;
 
@@ -15993,14 +15993,14 @@ pub fn serialize_delete_payload_body_spis<'a>(v: <DeletePayloadBodySpisCombinato
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_delete_payload_body_spis(num_spis@, spi_size@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_delete_payload_body_spis(num_spis@, spi_size@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_delete_payload_body_spis(num_spis@, spi_size@).spec_serialize(v@))
         },
 {
     let combinator = delete_payload_body_spis( num_spis, spi_size );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn delete_payload_body_spis_len<'a>(v: <DeletePayloadBodySpisCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, num_spis: u16, spi_size: IpsecSpiSizeOrNone) -> (serialize_len: usize)
@@ -16148,7 +16148,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DeletePayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DeletePayloadBodyCombinatorAlias = Mapped<Pair<Pair<Pair<IkeProtocolIdCombinator, IpsecSpiSizeOrNoneCombinator, DeletePayloadBodyCont2>, U16Be, DeletePayloadBodyCont1>, DeletePayloadBodySpisCombinator, DeletePayloadBodyCont0>, DeletePayloadBodyMapper>;
 
@@ -16245,14 +16245,14 @@ pub fn serialize_delete_payload_body<'a>(v: <DeletePayloadBodyCombinator as Comb
         spec_delete_payload_body().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_delete_payload_body().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_delete_payload_body().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_delete_payload_body().spec_serialize(v@))
         },
 {
     let combinator = delete_payload_body();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn delete_payload_body_len<'a>(v: <DeletePayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16492,7 +16492,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IkeMessageCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IkeMessageCombinatorAlias = Mapped<Pair<IkeHeaderCombinator, bytes::Variable, IkeMessageCont0>, IkeMessageMapper>;
 
@@ -16559,14 +16559,14 @@ pub fn serialize_ike_message<'a>(v: <IkeMessageCombinator as Combinator<'a, &'a 
         spec_ike_message().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ike_message().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ike_message().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ike_message().spec_serialize(v@))
         },
 {
     let combinator = ike_message();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ike_message_len<'a>(v: <IkeMessageCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16755,7 +16755,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GenericPayloadHeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GenericPayloadHeaderCombinatorAlias = Mapped<GenericPayloadHeaderCombinator2, GenericPayloadHeaderMapper>;
 
@@ -16807,14 +16807,14 @@ pub fn serialize_generic_payload_header<'a>(v: <GenericPayloadHeaderCombinator a
         spec_generic_payload_header().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_generic_payload_header().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_generic_payload_header().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_generic_payload_header().spec_serialize(v@))
         },
 {
     let combinator = generic_payload_header();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn generic_payload_header_len<'a>(v: <GenericPayloadHeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16952,7 +16952,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2SkPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2SkPayloadInnerCombinatorAlias = Mapped<bytes::Tail, Ikev2SkPayloadInnerMapper>;
 
@@ -17004,14 +17004,14 @@ pub fn serialize_ikev2_sk_payload_inner<'a>(v: <Ikev2SkPayloadInnerCombinator as
         spec_ikev2_sk_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_sk_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_sk_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_sk_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_sk_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_sk_payload_inner_len<'a>(v: <Ikev2SkPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17221,7 +17221,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TsIpv4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TsIpv4CombinatorAlias = Mapped<TsIpv4Combinator6, TsIpv4Mapper>;
 
@@ -17273,14 +17273,14 @@ pub fn serialize_ts_ipv4<'a>(v: <TsIpv4Combinator as Combinator<'a, &'a [u8], Ve
         spec_ts_ipv4().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ts_ipv4().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ts_ipv4().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ts_ipv4().spec_serialize(v@))
         },
 {
     let combinator = ts_ipv4();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ts_ipv4_len<'a>(v: <TsIpv4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17447,7 +17447,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2CpPayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2CpPayloadInnerCombinatorAlias = Mapped<Ikev2CpPayloadInnerCombinator2, Ikev2CpPayloadInnerMapper>;
 
@@ -17499,14 +17499,14 @@ pub fn serialize_ikev2_cp_payload_inner<'a>(v: <Ikev2CpPayloadInnerCombinator as
         spec_ikev2_cp_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_cp_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_cp_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_cp_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_cp_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_cp_payload_inner_len<'a>(v: <Ikev2CpPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17667,7 +17667,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2KePayloadInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2KePayloadInnerCombinatorAlias = Mapped<Ikev2KePayloadInnerCombinator2, Ikev2KePayloadInnerMapper>;
 
@@ -17719,14 +17719,14 @@ pub fn serialize_ikev2_ke_payload_inner<'a>(v: <Ikev2KePayloadInnerCombinator as
         spec_ikev2_ke_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_ke_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_ke_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_ke_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_ke_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_ke_payload_inner_len<'a>(v: <Ikev2KePayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17893,7 +17893,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AuthPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AuthPayloadBodyCombinatorAlias = Mapped<AuthPayloadBodyCombinator2, AuthPayloadBodyMapper>;
 
@@ -17951,14 +17951,14 @@ pub fn serialize_auth_payload_body<'a>(v: <AuthPayloadBodyCombinator as Combinat
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_auth_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_auth_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_auth_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = auth_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn auth_payload_body_len<'a>(v: <AuthPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -18126,7 +18126,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IdPayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type IdPayloadBodyCombinatorAlias = Mapped<IdPayloadBodyCombinator2, IdPayloadBodyMapper>;
 
@@ -18184,14 +18184,14 @@ pub fn serialize_id_payload_body<'a>(v: <IdPayloadBodyCombinator as Combinator<'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_id_payload_body(payload_length@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_id_payload_body(payload_length@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_id_payload_body(payload_length@).spec_serialize(v@))
         },
 {
     let combinator = id_payload_body( payload_length );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn id_payload_body_len<'a>(v: <IdPayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, payload_length: u16) -> (serialize_len: usize)
@@ -18340,7 +18340,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2CertreqPayloadInnerCombinato
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2CertreqPayloadInnerCombinatorAlias = Mapped<Ikev2CertreqPayloadInnerCombinator1, Ikev2CertreqPayloadInnerMapper>;
 
@@ -18392,14 +18392,14 @@ pub fn serialize_ikev2_certreq_payload_inner<'a>(v: <Ikev2CertreqPayloadInnerCom
         spec_ikev2_certreq_payload_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_certreq_payload_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_certreq_payload_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_certreq_payload_inner().spec_serialize(v@))
         },
 {
     let combinator = ikev2_certreq_payload_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ikev2_certreq_payload_inner_len<'a>(v: <Ikev2CertreqPayloadInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18808,7 +18808,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2PayloadBodyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2PayloadBodyCombinatorAlias = Mapped<Ikev2PayloadBodyCombinator16, Ikev2PayloadBodyMapper>;
 
@@ -18858,14 +18858,14 @@ pub fn serialize_ikev2_payload_body<'a>(v: <Ikev2PayloadBodyCombinator as Combin
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_payload_body(next_pt@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_payload_body(next_pt@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_payload_body(next_pt@).spec_serialize(v@))
         },
 {
     let combinator = ikev2_payload_body( next_pt );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn ikev2_payload_body_len<'a>(v: <Ikev2PayloadBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, next_pt: u8) -> (serialize_len: usize)
@@ -19007,7 +19007,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Ikev2PayloadCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Ikev2PayloadCombinatorAlias = Mapped<Pair<GenericPayloadHeaderCombinator, AndThen<bytes::Variable, Ikev2PayloadBodyCombinator>, Ikev2PayloadCont0>, Ikev2PayloadMapper>;
 
@@ -19080,14 +19080,14 @@ pub fn serialize_ikev2_payload<'a>(v: <Ikev2PayloadCombinator as Combinator<'a, 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ikev2_payload(next_pt@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ikev2_payload(next_pt@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ikev2_payload(next_pt@).spec_serialize(v@))
         },
 {
     let combinator = ikev2_payload( next_pt );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn ikev2_payload_len<'a>(v: <Ikev2PayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, next_pt: u8) -> (serialize_len: usize)

--- a/vest-dsl/test/src/josh.rs
+++ b/vest-dsl/test/src/josh.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -148,7 +148,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TstTagCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TstTagCombinatorAlias = U8;
 
@@ -192,14 +192,14 @@ pub fn serialize_tst_tag<'a>(v: <TstTagCombinator as Combinator<'a, &'a [u8], Ve
         spec_tst_tag().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tst_tag().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tst_tag().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tst_tag().spec_serialize(v@))
         },
 {
     let combinator = tst_tag();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tst_tag_len<'a>(v: <TstTagCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -347,7 +347,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MydataCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MydataCombinatorAlias = Mapped<MydataCombinator1, MydataMapper>;
 
@@ -399,14 +399,14 @@ pub fn serialize_mydata<'a>(v: <MydataCombinator as Combinator<'a, &'a [u8], Vec
         spec_mydata().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mydata().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mydata().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mydata().spec_serialize(v@))
         },
 {
     let combinator = mydata();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mydata_len<'a>(v: <MydataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1039,7 +1039,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TstMydataCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TstMydataCombinatorAlias = Mapped<TstMydataCombinator30, TstMydataMapper>;
 
@@ -1089,14 +1089,14 @@ pub fn serialize_tst_mydata<'a>(v: <TstMydataCombinator as Combinator<'a, &'a [u
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tst_mydata(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tst_mydata(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tst_mydata(tag@).spec_serialize(v@))
         },
 {
     let combinator = tst_mydata( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn tst_mydata_len<'a>(v: <TstMydataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: u8) -> (serialize_len: usize)
@@ -1238,7 +1238,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TstCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TstCombinatorAlias = Mapped<Pair<TstTagCombinator, TstMydataCombinator, TstCont0>, TstMapper>;
 
@@ -1305,14 +1305,14 @@ pub fn serialize_tst<'a>(v: <TstCombinator as Combinator<'a, &'a [u8], Vec<u8>>>
         spec_tst().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tst().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tst().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tst().spec_serialize(v@))
         },
 {
     let combinator = tst();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tst_len<'a>(v: <TstCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1647,7 +1647,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PairStressCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PairStressCombinatorAlias = Mapped<PairStressCombinator14, PairStressMapper>;
 
@@ -1699,14 +1699,14 @@ pub fn serialize_pair_stress<'a>(v: <PairStressCombinator as Combinator<'a, &'a 
         spec_pair_stress().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_pair_stress().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_pair_stress().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_pair_stress().spec_serialize(v@))
         },
 {
     let combinator = pair_stress();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn pair_stress_len<'a>(v: <PairStressCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/length_expr.rs
+++ b/vest-dsl/test/src/length_expr.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -180,7 +180,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HeaderCombinatorAlias = Mapped<Pair<Refined<U16Le, Predicate12905524399844557818>, U8, HeaderCont0>, HeaderMapper>;
 
@@ -247,14 +247,14 @@ pub fn serialize_header<'a>(v: <HeaderCombinator as Combinator<'a, &'a [u8], Vec
         spec_header().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_header().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_header().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_header().spec_serialize(v@))
         },
 {
     let combinator = header();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn header_len<'a>(v: <HeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -352,7 +352,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HeaderAliasCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HeaderAliasCombinatorAlias = HeaderCombinator;
 
@@ -396,14 +396,14 @@ pub fn serialize_header_alias<'a>(v: <HeaderAliasCombinator as Combinator<'a, &'
         spec_header_alias().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_header_alias().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_header_alias().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_header_alias().spec_serialize(v@))
         },
 {
     let combinator = header_alias();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn header_alias_len<'a>(v: <HeaderAliasCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -541,7 +541,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DivideCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DivideCombinatorAlias = Mapped<bytes::Variable, DivideMapper>;
 
@@ -595,14 +595,14 @@ pub fn serialize_divide<'a>(v: <DivideCombinator as Combinator<'a, &'a [u8], Vec
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_divide(total@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_divide(total@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_divide(total@).spec_serialize(v@))
         },
 {
     let combinator = divide( total );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn divide_len<'a>(v: <DivideCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, total: u32) -> (serialize_len: usize)
@@ -771,7 +771,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FixedChoiceCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FixedChoiceCombinatorAlias = Mapped<FixedChoiceCombinator1, FixedChoiceMapper>;
 
@@ -817,14 +817,14 @@ pub fn serialize_fixed_choice<'a>(v: <FixedChoiceCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_fixed_choice(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_fixed_choice(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_fixed_choice(tag@).spec_serialize(v@))
         },
 {
     let combinator = fixed_choice( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn fixed_choice_len<'a>(v: <FixedChoiceCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: u8) -> (serialize_len: usize)
@@ -962,7 +962,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SimpleSubCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SimpleSubCombinatorAlias = Mapped<bytes::Variable, SimpleSubMapper>;
 
@@ -1020,14 +1020,14 @@ pub fn serialize_simple_sub<'a>(v: <SimpleSubCombinator as Combinator<'a, &'a [u
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_simple_sub(len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_simple_sub(len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_simple_sub(len@).spec_serialize(v@))
         },
 {
     let combinator = simple_sub( len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn simple_sub_len<'a>(v: <SimpleSubCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, len: u16) -> (serialize_len: usize)
@@ -1166,7 +1166,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AliasSizeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AliasSizeCombinatorAlias = Mapped<bytes::Fixed<3>, AliasSizeMapper>;
 
@@ -1218,14 +1218,14 @@ pub fn serialize_alias_size<'a>(v: <AliasSizeCombinator as Combinator<'a, &'a [u
         spec_alias_size().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_alias_size().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_alias_size().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_alias_size().spec_serialize(v@))
         },
 {
     let combinator = alias_size();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn alias_size_len<'a>(v: <AliasSizeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1363,7 +1363,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MultiArithCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MultiArithCombinatorAlias = Mapped<bytes::Variable, MultiArithMapper>;
 
@@ -1424,14 +1424,14 @@ pub fn serialize_multi_arith<'a>(v: <MultiArithCombinator as Combinator<'a, &'a 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_multi_arith(total@, hdr_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_multi_arith(total@, hdr_len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_multi_arith(total@, hdr_len@).spec_serialize(v@))
         },
 {
     let combinator = multi_arith( total, hdr_len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn multi_arith_len<'a>(v: <MultiArithCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, total: u32, hdr_len: u8) -> (serialize_len: usize)
@@ -1571,7 +1571,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SizeArithCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SizeArithCombinatorAlias = Mapped<bytes::Fixed<4>, SizeArithMapper>;
 
@@ -1623,14 +1623,14 @@ pub fn serialize_size_arith<'a>(v: <SizeArithCombinator as Combinator<'a, &'a [u
         spec_size_arith().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_size_arith().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_size_arith().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_size_arith().spec_serialize(v@))
         },
 {
     let combinator = size_arith();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn size_arith_len<'a>(v: <SizeArithCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1768,7 +1768,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PayloadWithHeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PayloadWithHeaderCombinatorAlias = Mapped<bytes::Variable, PayloadWithHeaderMapper>;
 
@@ -1826,14 +1826,14 @@ pub fn serialize_payload_with_header<'a>(v: <PayloadWithHeaderCombinator as Comb
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_payload_with_header(hdr@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_payload_with_header(hdr@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_payload_with_header(hdr@).spec_serialize(v@))
         },
 {
     let combinator = payload_with_header( hdr );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn payload_with_header_len<'a>(v: <PayloadWithHeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, hdr: Header) -> (serialize_len: usize)
@@ -1972,7 +1972,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MixedConstCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MixedConstCombinatorAlias = Mapped<bytes::Variable, MixedConstMapper>;
 
@@ -2030,14 +2030,14 @@ pub fn serialize_mixed_const<'a>(v: <MixedConstCombinator as Combinator<'a, &'a 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mixed_const(len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mixed_const(len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mixed_const(len@).spec_serialize(v@))
         },
 {
     let combinator = mixed_const( len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn mixed_const_len<'a>(v: <MixedConstCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, len: u16) -> (serialize_len: usize)
@@ -2105,7 +2105,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ChoiceTagCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ChoiceTagCombinatorAlias = bytes::Fixed<2>;
 
@@ -2149,14 +2149,14 @@ pub fn serialize_choice_tag<'a>(v: <ChoiceTagCombinator as Combinator<'a, &'a [u
         spec_choice_tag().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_choice_tag().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_choice_tag().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_choice_tag().spec_serialize(v@))
         },
 {
     let combinator = choice_tag();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn choice_tag_len<'a>(v: <ChoiceTagCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2294,7 +2294,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NamedSizeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NamedSizeCombinatorAlias = Mapped<bytes::Fixed<3>, NamedSizeMapper>;
 
@@ -2346,14 +2346,14 @@ pub fn serialize_named_size<'a>(v: <NamedSizeCombinator as Combinator<'a, &'a [u
         spec_named_size().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_named_size().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_named_size().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_named_size().spec_serialize(v@))
         },
 {
     let combinator = named_size();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn named_size_len<'a>(v: <NamedSizeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2491,7 +2491,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ChoiceFormatSizeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ChoiceFormatSizeCombinatorAlias = Mapped<bytes::Fixed<2>, ChoiceFormatSizeMapper>;
 
@@ -2543,14 +2543,14 @@ pub fn serialize_choice_format_size<'a>(v: <ChoiceFormatSizeCombinator as Combin
         spec_choice_format_size().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_choice_format_size().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_choice_format_size().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_choice_format_size().spec_serialize(v@))
         },
 {
     let combinator = choice_format_size();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn choice_format_size_len<'a>(v: <ChoiceFormatSizeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2617,7 +2617,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HeaderBytesCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HeaderBytesCombinatorAlias = AndThen<bytes::Variable, HeaderCombinator>;
 
@@ -2661,14 +2661,14 @@ pub fn serialize_header_bytes<'a>(v: <HeaderBytesCombinator as Combinator<'a, &'
         spec_header_bytes().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_header_bytes().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_header_bytes().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_header_bytes().spec_serialize(v@))
         },
 {
     let combinator = header_bytes();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn header_bytes_len<'a>(v: <HeaderBytesCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2806,7 +2806,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MultiplyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MultiplyCombinatorAlias = Mapped<bytes::Variable, MultiplyMapper>;
 
@@ -2864,14 +2864,14 @@ pub fn serialize_multiply<'a>(v: <MultiplyCombinator as Combinator<'a, &'a [u8],
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_multiply(count@, size@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_multiply(count@, size@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_multiply(count@, size@).spec_serialize(v@))
         },
 {
     let combinator = multiply( count, size );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn multiply_len<'a>(v: <MultiplyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, count: u16, size: u8) -> (serialize_len: usize)
@@ -3041,7 +3041,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ChoiceArraysFoldedBodyCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ChoiceArraysFoldedBodyCombinatorAlias = Mapped<ChoiceArraysFoldedBodyCombinator1, ChoiceArraysFoldedBodyMapper>;
 
@@ -3087,14 +3087,14 @@ pub fn serialize_choice_arrays_folded_body<'a>(v: <ChoiceArraysFoldedBodyCombina
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_choice_arrays_folded_body(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_choice_arrays_folded_body(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_choice_arrays_folded_body(tag@).spec_serialize(v@))
         },
 {
     let combinator = choice_arrays_folded_body( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn choice_arrays_folded_body_len<'a>(v: <ChoiceArraysFoldedBodyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: ChoiceTag) -> (serialize_len: usize)
@@ -3235,7 +3235,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ChoiceArraysFoldedCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ChoiceArraysFoldedCombinatorAlias = Mapped<Pair<ChoiceTagCombinator, ChoiceArraysFoldedBodyCombinator, ChoiceArraysFoldedCont0>, ChoiceArraysFoldedMapper>;
 
@@ -3302,14 +3302,14 @@ pub fn serialize_choice_arrays_folded<'a>(v: <ChoiceArraysFoldedCombinator as Co
         spec_choice_arrays_folded().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_choice_arrays_folded().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_choice_arrays_folded().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_choice_arrays_folded().spec_serialize(v@))
         },
 {
     let combinator = choice_arrays_folded();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn choice_arrays_folded_len<'a>(v: <ChoiceArraysFoldedCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3478,7 +3478,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParenExprCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParenExprCombinatorAlias = Mapped<bytes::Variable, ParenExprMapper>;
 
@@ -3542,14 +3542,14 @@ pub fn serialize_paren_expr<'a>(v: <ParenExprCombinator as Combinator<'a, &'a [u
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_paren_expr(a@, b@, c@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_paren_expr(a@, b@, c@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_paren_expr(a@, b@, c@).spec_serialize(v@))
         },
 {
     let combinator = paren_expr( a, b, c );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn paren_expr_len<'a>(v: <ParenExprCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, a: u16, b: u8, c: u8) -> (serialize_len: usize)
@@ -3690,7 +3690,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ReinterpretSizeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ReinterpretSizeCombinatorAlias = Mapped<bytes::Fixed<3>, ReinterpretSizeMapper>;
 
@@ -3742,14 +3742,14 @@ pub fn serialize_reinterpret_size<'a>(v: <ReinterpretSizeCombinator as Combinato
         spec_reinterpret_size().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_reinterpret_size().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_reinterpret_size().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_reinterpret_size().spec_serialize(v@))
         },
 {
     let combinator = reinterpret_size();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn reinterpret_size_len<'a>(v: <ReinterpretSizeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3897,7 +3897,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PrimitiveSizesCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PrimitiveSizesCombinatorAlias = Mapped<PrimitiveSizesCombinator1, PrimitiveSizesMapper>;
 
@@ -3949,14 +3949,14 @@ pub fn serialize_primitive_sizes<'a>(v: <PrimitiveSizesCombinator as Combinator<
         spec_primitive_sizes().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_primitive_sizes().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_primitive_sizes().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_primitive_sizes().spec_serialize(v@))
         },
 {
     let combinator = primitive_sizes();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn primitive_sizes_len<'a>(v: <PrimitiveSizesCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/matches.rs
+++ b/vest-dsl/test/src/matches.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -188,7 +188,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg5ContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg5ContentCombinatorAlias = Mapped<Msg5ContentCombinator1, Msg5ContentMapper>;
 
@@ -234,14 +234,14 @@ pub fn serialize_msg5_content<'a>(v: <Msg5ContentCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg5_content(i@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg5_content(i@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg5_content(i@).spec_serialize(v@))
         },
 {
     let combinator = msg5_content( i );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg5_content_len<'a>(v: <Msg5ContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, i: VarInt) -> (serialize_len: usize)
@@ -308,7 +308,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HelloRetryRequestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HelloRetryRequestCombinatorAlias = U16Le;
 
@@ -352,14 +352,14 @@ pub fn serialize_hello_retry_request<'a>(v: <HelloRetryRequestCombinator as Comb
         spec_hello_retry_request().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_hello_retry_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_hello_retry_request().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_hello_retry_request().spec_serialize(v@))
         },
 {
     let combinator = hello_retry_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn hello_retry_request_len<'a>(v: <HelloRetryRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -426,7 +426,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerHelloCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerHelloCombinatorAlias = U32Le;
 
@@ -470,14 +470,14 @@ pub fn serialize_server_hello<'a>(v: <ServerHelloCombinator as Combinator<'a, &'
         spec_server_hello().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_hello().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_hello().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_hello().spec_serialize(v@))
         },
 {
     let combinator = server_hello();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_hello_len<'a>(v: <ServerHelloCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -646,7 +646,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg1PayloadCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg1PayloadCombinatorAlias = Mapped<Msg1PayloadCombinator1, Msg1PayloadMapper>;
 
@@ -692,14 +692,14 @@ pub fn serialize_msg1_payload<'a>(v: <Msg1PayloadCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg1_payload(b@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg1_payload(b@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg1_payload(b@).spec_serialize(v@))
         },
 {
     let combinator = msg1_payload( b );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg1_payload_len<'a>(v: <Msg1PayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, b: &'a [u8]) -> (serialize_len: usize)
@@ -868,7 +868,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg4ContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg4ContentCombinatorAlias = Mapped<Msg4ContentCombinator1, Msg4ContentMapper>;
 
@@ -914,14 +914,14 @@ pub fn serialize_msg4_content<'a>(v: <Msg4ContentCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg4_content(i@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg4_content(i@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg4_content(i@).spec_serialize(v@))
         },
 {
     let combinator = msg4_content( i );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg4_content_len<'a>(v: <Msg4ContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, i: u24) -> (serialize_len: usize)
@@ -1122,7 +1122,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg3ContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg3ContentCombinatorAlias = Mapped<Msg3ContentCombinator3, Msg3ContentMapper>;
 
@@ -1168,14 +1168,14 @@ pub fn serialize_msg3_content<'a>(v: <Msg3ContentCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg3_content(i@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg3_content(i@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg3_content(i@).spec_serialize(v@))
         },
 {
     let combinator = msg3_content( i );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg3_content_len<'a>(v: <Msg3ContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, i: u8) -> (serialize_len: usize)
@@ -1316,7 +1316,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg3Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg3CombinatorAlias = Mapped<Pair<U8, Msg3ContentCombinator, Msg3Cont0>, Msg3Mapper>;
 
@@ -1383,14 +1383,14 @@ pub fn serialize_msg3<'a>(v: <Msg3Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg3().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg3().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg3().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg3().spec_serialize(v@))
         },
 {
     let combinator = msg3();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg3_len<'a>(v: <Msg3Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1562,7 +1562,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg5Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg5CombinatorAlias = Mapped<Pair<BtcVarint, Msg5ContentCombinator, Msg5Cont0>, Msg5Mapper>;
 
@@ -1629,14 +1629,14 @@ pub fn serialize_msg5<'a>(v: <Msg5Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg5().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg5().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg5().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg5().spec_serialize(v@))
         },
 {
     let combinator = msg5();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg5_len<'a>(v: <Msg5Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1836,7 +1836,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg2ContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg2ContentCombinatorAlias = Mapped<Msg2ContentCombinator1, Msg2ContentMapper>;
 
@@ -1882,14 +1882,14 @@ pub fn serialize_msg2_content<'a>(v: <Msg2ContentCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg2_content(b@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg2_content(b@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg2_content(b@).spec_serialize(v@))
         },
 {
     let combinator = msg2_content( b );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn msg2_content_len<'a>(v: <Msg2ContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, b: &'a [u8]) -> (serialize_len: usize)
@@ -2030,7 +2030,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg1Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg1CombinatorAlias = Mapped<Pair<bytes::Fixed<32>, Msg1PayloadCombinator, Msg1Cont0>, Msg1Mapper>;
 
@@ -2097,14 +2097,14 @@ pub fn serialize_msg1<'a>(v: <Msg1Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg1().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg1().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg1().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg1().spec_serialize(v@))
         },
 {
     let combinator = msg1();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg1_len<'a>(v: <Msg1Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2276,7 +2276,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg2Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg2CombinatorAlias = Mapped<Pair<bytes::Fixed<3>, Msg2ContentCombinator, Msg2Cont0>, Msg2Mapper>;
 
@@ -2343,14 +2343,14 @@ pub fn serialize_msg2<'a>(v: <Msg2Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg2().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg2().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg2().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg2().spec_serialize(v@))
         },
 {
     let combinator = msg2();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg2_len<'a>(v: <Msg2Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2522,7 +2522,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Msg4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Msg4CombinatorAlias = Mapped<Pair<U24Le, Msg4ContentCombinator, Msg4Cont0>, Msg4Mapper>;
 
@@ -2589,14 +2589,14 @@ pub fn serialize_msg4<'a>(v: <Msg4Combinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_msg4().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg4().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg4().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg4().spec_serialize(v@))
         },
 {
     let combinator = msg4();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg4_len<'a>(v: <Msg4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/nested_access.rs
+++ b/vest-dsl/test/src/nested_access.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -199,7 +199,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GenericHeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GenericHeaderCombinatorAlias = Mapped<GenericHeaderCombinator2, GenericHeaderMapper>;
 
@@ -251,14 +251,14 @@ pub fn serialize_generic_header<'a>(v: <GenericHeaderCombinator as Combinator<'a
         spec_generic_header().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_generic_header().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_generic_header().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_generic_header().spec_serialize(v@))
         },
 {
     let combinator = generic_header();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn generic_header_len<'a>(v: <GenericHeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -406,7 +406,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OuterHeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OuterHeaderCombinatorAlias = Mapped<OuterHeaderCombinator1, OuterHeaderMapper>;
 
@@ -458,14 +458,14 @@ pub fn serialize_outer_header<'a>(v: <OuterHeaderCombinator as Combinator<'a, &'
         spec_outer_header().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_outer_header().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_outer_header().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_outer_header().spec_serialize(v@))
         },
 {
     let combinator = outer_header();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn outer_header_len<'a>(v: <OuterHeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -606,7 +606,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PayloadWithHeaderCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PayloadWithHeaderCombinatorAlias = Mapped<Pair<GenericHeaderCombinator, bytes::Variable, PayloadWithHeaderCont0>, PayloadWithHeaderMapper>;
 
@@ -673,14 +673,14 @@ pub fn serialize_payload_with_header<'a>(v: <PayloadWithHeaderCombinator as Comb
         spec_payload_with_header().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_payload_with_header().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_payload_with_header().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_payload_with_header().spec_serialize(v@))
         },
 {
     let combinator = payload_with_header();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn payload_with_header_len<'a>(v: <PayloadWithHeaderCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -850,7 +850,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DeepNestedCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DeepNestedCombinatorAlias = Mapped<Pair<OuterHeaderCombinator, bytes::Variable, DeepNestedCont0>, DeepNestedMapper>;
 
@@ -917,14 +917,14 @@ pub fn serialize_deep_nested<'a>(v: <DeepNestedCombinator as Combinator<'a, &'a 
         spec_deep_nested().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_deep_nested().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_deep_nested().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_deep_nested().spec_serialize(v@))
         },
 {
     let combinator = deep_nested();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn deep_nested_len<'a>(v: <DeepNestedCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1094,7 +1094,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CombinedExampleCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CombinedExampleCombinatorAlias = Mapped<Pair<GenericHeaderCombinator, bytes::Variable, CombinedExampleCont0>, CombinedExampleMapper>;
 
@@ -1167,14 +1167,14 @@ pub fn serialize_combined_example<'a>(v: <CombinedExampleCombinator as Combinato
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_combined_example(total_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_combined_example(total_len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_combined_example(total_len@).spec_serialize(v@))
         },
 {
     let combinator = combined_example( total_len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn combined_example_len<'a>(v: <CombinedExampleCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, total_len: u32) -> (serialize_len: usize)

--- a/vest-dsl/test/src/opt.rs
+++ b/vest-dsl/test/src/opt.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -93,7 +93,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ACombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ACombinatorAlias = Terminated<Preceded<Tag<U8, u8>, Preceded<Tag<U8, u8>, bytes::Fixed<10>>>, Tag<U8, u8>>;
 
@@ -137,14 +137,14 @@ pub fn serialize_a<'a>(v: <ACombinator as Combinator<'a, &'a [u8], Vec<u8>>>::ST
         spec_a().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_a().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_a().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_a().spec_serialize(v@))
         },
 {
     let combinator = a();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn a_len<'a>(v: <ACombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -302,7 +302,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type BCombinatorAlias = Mapped<BCombinator1, BMapper>;
 
@@ -354,14 +354,14 @@ pub fn serialize_b<'a>(v: <BCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::ST
         spec_b().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_b().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_b().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_b().spec_serialize(v@))
         },
 {
     let combinator = b();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn b_len<'a>(v: <BCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -517,7 +517,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MsgCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MsgCombinatorAlias = Mapped<MsgCombinator1, MsgMapper>;
 
@@ -569,14 +569,14 @@ pub fn serialize_msg<'a>(v: <MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>
         spec_msg().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_msg().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_msg().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_msg().spec_serialize(v@))
         },
 {
     let combinator = msg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn msg_len<'a>(v: <MsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -643,7 +643,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OptmsgCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OptmsgCombinatorAlias = Opt<MsgCombinator>;
 
@@ -687,14 +687,14 @@ pub fn serialize_optmsg<'a>(v: <OptmsgCombinator as Combinator<'a, &'a [u8], Vec
         spec_optmsg().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_optmsg().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_optmsg().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_optmsg().spec_serialize(v@))
         },
 {
     let combinator = optmsg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn optmsg_len<'a>(v: <OptmsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/test/src/repeat.rs
+++ b/vest-dsl/test/src/repeat.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -180,7 +180,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OpaqueU16Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OpaqueU16CombinatorAlias = Mapped<Pair<Refined<U16Le, Predicate17626095872143391426>, bytes::Variable, OpaqueU16Cont0>, OpaqueU16Mapper>;
 
@@ -247,14 +247,14 @@ pub fn serialize_opaque_u16<'a>(v: <OpaqueU16Combinator as Combinator<'a, &'a [u
         spec_opaque_u16().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_u16().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_u16().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_u16().spec_serialize(v@))
         },
 {
     let combinator = opaque_u16();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_u16_len<'a>(v: <OpaqueU16Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -352,7 +352,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for RepeatFixCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type RepeatFixCombinatorAlias = RepeatN<U16Le>;
 
@@ -396,14 +396,14 @@ pub fn serialize_repeat_fix<'a>(v: <RepeatFixCombinator as Combinator<'a, &'a [u
         spec_repeat_fix().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_repeat_fix().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_repeat_fix().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_repeat_fix().spec_serialize(v@))
         },
 {
     let combinator = repeat_fix();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn repeat_fix_len<'a>(v: <RepeatFixCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -470,7 +470,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ResponderIdCombinatorAlias = OpaqueU16Combinator;
 
@@ -514,14 +514,14 @@ pub fn serialize_responder_id<'a>(v: <ResponderIdCombinator as Combinator<'a, &'
         spec_responder_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_responder_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_responder_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_responder_id().spec_serialize(v@))
         },
 {
     let combinator = responder_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn responder_id_len<'a>(v: <ResponderIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -682,7 +682,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ResponderIdListCombinatorAlias = Mapped<Pair<Refined<U16Le, Predicate2984462868727922620>, AndThen<bytes::Variable, Repeat<ResponderIdCombinator>>, ResponderIdListCont0>, ResponderIdListMapper>;
 
@@ -749,14 +749,14 @@ pub fn serialize_responder_id_list<'a>(v: <ResponderIdListCombinator as Combinat
         spec_responder_id_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_responder_id_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_responder_id_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_responder_id_list().spec_serialize(v@))
         },
 {
     let combinator = responder_id_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn responder_id_list_len<'a>(v: <ResponderIdListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -928,7 +928,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for RepeatDynCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type RepeatDynCombinatorAlias = Mapped<Pair<BtcVarint, RepeatN<ResponderIdListCombinator>, RepeatDynCont0>, RepeatDynMapper>;
 
@@ -995,14 +995,14 @@ pub fn serialize_repeat_dyn<'a>(v: <RepeatDynCombinator as Combinator<'a, &'a [u
         spec_repeat_dyn().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_repeat_dyn().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_repeat_dyn().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_repeat_dyn().spec_serialize(v@))
         },
 {
     let combinator = repeat_dyn();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn repeat_dyn_len<'a>(v: <RepeatDynCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/tls/src/tls_combinators.rs
+++ b/vest-dsl/tls/src/tls_combinators.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -192,7 +192,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AlertLevelCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AlertLevelCombinatorAlias = TryMap<U8, AlertLevelMapper>;
 
@@ -236,14 +236,14 @@ pub fn serialize_alert_level<'a>(v: <AlertLevelCombinator as Combinator<'a, &'a 
         spec_alert_level().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_alert_level().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_alert_level().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_alert_level().spec_serialize(v@))
         },
 {
     let combinator = alert_level();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn alert_level_len<'a>(v: <AlertLevelCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -310,7 +310,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EmptyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EmptyCombinatorAlias = bytes::Fixed<0>;
 
@@ -354,14 +354,14 @@ pub fn serialize_empty<'a>(v: <EmptyCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_empty().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_empty().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_empty().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_empty().spec_serialize(v@))
         },
 {
     let combinator = empty();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn empty_len<'a>(v: <EmptyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -502,7 +502,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque0FfffCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque0FfffCombinatorAlias = Mapped<Pair<U16Be, bytes::Variable, Opaque0FfffCont0>, Opaque0FfffMapper>;
 
@@ -569,14 +569,14 @@ pub fn serialize_opaque_0_ffff<'a>(v: <Opaque0FfffCombinator as Combinator<'a, &
         spec_opaque_0_ffff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_0_ffff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_0_ffff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_0_ffff().spec_serialize(v@))
         },
 {
     let combinator = opaque_0_ffff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_0_ffff_len<'a>(v: <Opaque0FfffCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -674,7 +674,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OcspExtensionsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OcspExtensionsCombinatorAlias = Opaque0FfffCombinator;
 
@@ -718,14 +718,14 @@ pub fn serialize_ocsp_extensions<'a>(v: <OcspExtensionsCombinator as Combinator<
         spec_ocsp_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ocsp_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ocsp_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ocsp_extensions().spec_serialize(v@))
         },
 {
     let combinator = ocsp_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ocsp_extensions_len<'a>(v: <OcspExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -846,7 +846,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExtensionTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExtensionTypeCombinatorAlias = U16Be;
 
@@ -890,14 +890,14 @@ pub fn serialize_extension_type<'a>(v: <ExtensionTypeCombinator as Combinator<'a
         spec_extension_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_extension_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_extension_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_extension_type().spec_serialize(v@))
         },
 {
     let combinator = extension_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn extension_type_len<'a>(v: <ExtensionTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1000,7 +1000,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SignatureSchemeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SignatureSchemeCombinatorAlias = U16Be;
 
@@ -1044,14 +1044,14 @@ pub fn serialize_signature_scheme<'a>(v: <SignatureSchemeCombinator as Combinato
         spec_signature_scheme().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_signature_scheme().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_signature_scheme().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_signature_scheme().spec_serialize(v@))
         },
 {
     let combinator = signature_scheme();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn signature_scheme_len<'a>(v: <SignatureSchemeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1212,7 +1212,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SignatureSchemeListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SignatureSchemeListCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate15206902916018849611>, AndThen<bytes::Variable, Repeat<SignatureSchemeCombinator>>, SignatureSchemeListCont0>, SignatureSchemeListMapper>;
 
@@ -1279,14 +1279,14 @@ pub fn serialize_signature_scheme_list<'a>(v: <SignatureSchemeListCombinator as 
         spec_signature_scheme_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_signature_scheme_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_signature_scheme_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_signature_scheme_list().spec_serialize(v@))
         },
 {
     let combinator = signature_scheme_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn signature_scheme_list_len<'a>(v: <SignatureSchemeListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1478,7 +1478,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque1FfffCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque1FfffCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate17626095872143391426>, bytes::Variable, Opaque1FfffCont0>, Opaque1FfffMapper>;
 
@@ -1545,14 +1545,14 @@ pub fn serialize_opaque_1_ffff<'a>(v: <Opaque1FfffCombinator as Combinator<'a, &
         spec_opaque_1_ffff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_1_ffff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_1_ffff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_1_ffff().spec_serialize(v@))
         },
 {
     let combinator = opaque_1_ffff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_1_ffff_len<'a>(v: <Opaque1FfffCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1650,7 +1650,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DistinguishedNameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DistinguishedNameCombinatorAlias = Opaque1FfffCombinator;
 
@@ -1694,14 +1694,14 @@ pub fn serialize_distinguished_name<'a>(v: <DistinguishedNameCombinator as Combi
         spec_distinguished_name().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_distinguished_name().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_distinguished_name().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_distinguished_name().spec_serialize(v@))
         },
 {
     let combinator = distinguished_name();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn distinguished_name_len<'a>(v: <DistinguishedNameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1862,7 +1862,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateAuthoritiesExtensionCo
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateAuthoritiesExtensionCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate7402808336413996182>, AndThen<bytes::Variable, Repeat<DistinguishedNameCombinator>>, CertificateAuthoritiesExtensionCont0>, CertificateAuthoritiesExtensionMapper>;
 
@@ -1929,14 +1929,14 @@ pub fn serialize_certificate_authorities_extension<'a>(v: <CertificateAuthoritie
         spec_certificate_authorities_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_authorities_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_authorities_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_authorities_extension().spec_serialize(v@))
         },
 {
     let combinator = certificate_authorities_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_authorities_extension_len<'a>(v: <CertificateAuthoritiesExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2034,7 +2034,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ResponderIdCombinatorAlias = Opaque1FfffCombinator;
 
@@ -2078,14 +2078,14 @@ pub fn serialize_responder_id<'a>(v: <ResponderIdCombinator as Combinator<'a, &'
         spec_responder_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_responder_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_responder_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_responder_id().spec_serialize(v@))
         },
 {
     let combinator = responder_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn responder_id_len<'a>(v: <ResponderIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2226,7 +2226,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ResponderIdListCombinatorAlias = Mapped<Pair<U16Be, AndThen<bytes::Variable, Repeat<ResponderIdCombinator>>, ResponderIdListCont0>, ResponderIdListMapper>;
 
@@ -2293,14 +2293,14 @@ pub fn serialize_responder_id_list<'a>(v: <ResponderIdListCombinator as Combinat
         spec_responder_id_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_responder_id_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_responder_id_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_responder_id_list().spec_serialize(v@))
         },
 {
     let combinator = responder_id_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn responder_id_list_len<'a>(v: <ResponderIdListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2479,7 +2479,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OscpStatusRequestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OscpStatusRequestCombinatorAlias = Mapped<OscpStatusRequestCombinator1, OscpStatusRequestMapper>;
 
@@ -2531,14 +2531,14 @@ pub fn serialize_oscp_status_request<'a>(v: <OscpStatusRequestCombinator as Comb
         spec_oscp_status_request().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_oscp_status_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_oscp_status_request().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_oscp_status_request().spec_serialize(v@))
         },
 {
     let combinator = oscp_status_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn oscp_status_request_len<'a>(v: <OscpStatusRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2687,7 +2687,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateStatusRequestCombinato
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateStatusRequestCombinatorAlias = Mapped<CertificateStatusRequestCombinator1, CertificateStatusRequestMapper>;
 
@@ -2739,14 +2739,14 @@ pub fn serialize_certificate_status_request<'a>(v: <CertificateStatusRequestComb
         spec_certificate_status_request().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_status_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_status_request().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_status_request().spec_serialize(v@))
         },
 {
     let combinator = certificate_status_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_status_request_len<'a>(v: <CertificateStatusRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2813,7 +2813,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SerializedSctCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SerializedSctCombinatorAlias = Opaque1FfffCombinator;
 
@@ -2857,14 +2857,14 @@ pub fn serialize_serialized_sct<'a>(v: <SerializedSctCombinator as Combinator<'a
         spec_serialized_sct().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_serialized_sct().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_serialized_sct().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_serialized_sct().spec_serialize(v@))
         },
 {
     let combinator = serialized_sct();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn serialized_sct_len<'a>(v: <SerializedSctCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3025,7 +3025,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SignedCertificateTimestampListCom
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SignedCertificateTimestampListCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate16977634203518580913>, AndThen<bytes::Variable, Repeat<SerializedSctCombinator>>, SignedCertificateTimestampListCont0>, SignedCertificateTimestampListMapper>;
 
@@ -3092,14 +3092,14 @@ pub fn serialize_signed_certificate_timestamp_list<'a>(v: <SignedCertificateTime
         spec_signed_certificate_timestamp_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_signed_certificate_timestamp_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_signed_certificate_timestamp_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_signed_certificate_timestamp_list().spec_serialize(v@))
         },
 {
     let combinator = signed_certificate_timestamp_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn signed_certificate_timestamp_list_len<'a>(v: <SignedCertificateTimestampListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3291,7 +3291,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque1FfCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque1FfCombinatorAlias = Mapped<Pair<Refined<U8, Predicate3651688686135228051>, bytes::Variable, Opaque1FfCont0>, Opaque1FfMapper>;
 
@@ -3358,14 +3358,14 @@ pub fn serialize_opaque_1_ff<'a>(v: <Opaque1FfCombinator as Combinator<'a, &'a [
         spec_opaque_1_ff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_1_ff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_1_ff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_1_ff().spec_serialize(v@))
         },
 {
     let combinator = opaque_1_ff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_1_ff_len<'a>(v: <Opaque1FfCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3544,7 +3544,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OidFilterCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OidFilterCombinatorAlias = Mapped<OidFilterCombinator1, OidFilterMapper>;
 
@@ -3596,14 +3596,14 @@ pub fn serialize_oid_filter<'a>(v: <OidFilterCombinator as Combinator<'a, &'a [u
         spec_oid_filter().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_oid_filter().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_oid_filter().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_oid_filter().spec_serialize(v@))
         },
 {
     let combinator = oid_filter();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn oid_filter_len<'a>(v: <OidFilterCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3744,7 +3744,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OidFilterExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OidFilterExtensionCombinatorAlias = Mapped<Pair<U16Be, AndThen<bytes::Variable, Repeat<OidFilterCombinator>>, OidFilterExtensionCont0>, OidFilterExtensionMapper>;
 
@@ -3811,14 +3811,14 @@ pub fn serialize_oid_filter_extension<'a>(v: <OidFilterExtensionCombinator as Co
         spec_oid_filter_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_oid_filter_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_oid_filter_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_oid_filter_extension().spec_serialize(v@))
         },
 {
     let combinator = oid_filter_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn oid_filter_extension_len<'a>(v: <OidFilterExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4098,7 +4098,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateRequestExtensionExtens
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateRequestExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<CertificateRequestExtensionExtensionDataCombinator6, CertificateRequestExtensionExtensionDataMapper>>;
 
@@ -4148,14 +4148,14 @@ pub fn serialize_certificate_request_extension_extension_data<'a>(v: <Certificat
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_request_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_request_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_request_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
     let combinator = certificate_request_extension_extension_data( ext_len, extension_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn certificate_request_extension_extension_data_len<'a>(v: <CertificateRequestExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
@@ -4300,7 +4300,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateRequestExtensionCombin
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateRequestExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, CertificateRequestExtensionCont1>, CertificateRequestExtensionExtensionDataCombinator, CertificateRequestExtensionCont0>, CertificateRequestExtensionMapper>;
 
@@ -4382,14 +4382,14 @@ pub fn serialize_certificate_request_extension<'a>(v: <CertificateRequestExtensi
         spec_certificate_request_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_request_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_request_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_request_extension().spec_serialize(v@))
         },
 {
     let combinator = certificate_request_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_request_extension_len<'a>(v: <CertificateRequestExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4522,7 +4522,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NameTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NameTypeCombinatorAlias = U8;
 
@@ -4566,14 +4566,14 @@ pub fn serialize_name_type<'a>(v: <NameTypeCombinator as Combinator<'a, &'a [u8]
         spec_name_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_name_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_name_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_name_type().spec_serialize(v@))
         },
 {
     let combinator = name_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn name_type_len<'a>(v: <NameTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4734,7 +4734,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SessionIdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SessionIdCombinatorAlias = Mapped<Pair<Refined<U8, Predicate14254733753739482027>, bytes::Variable, SessionIdCont0>, SessionIdMapper>;
 
@@ -4801,14 +4801,14 @@ pub fn serialize_session_id<'a>(v: <SessionIdCombinator as Combinator<'a, &'a [u
         spec_session_id().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_session_id().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_session_id().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_session_id().spec_serialize(v@))
         },
 {
     let combinator = session_id();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn session_id_len<'a>(v: <SessionIdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4916,7 +4916,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CipherSuiteCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CipherSuiteCombinatorAlias = U16Be;
 
@@ -4960,14 +4960,14 @@ pub fn serialize_cipher_suite<'a>(v: <CipherSuiteCombinator as Combinator<'a, &'
         spec_cipher_suite().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cipher_suite().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cipher_suite().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cipher_suite().spec_serialize(v@))
         },
 {
     let combinator = cipher_suite();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cipher_suite_len<'a>(v: <CipherSuiteCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5044,7 +5044,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProtocolVersionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProtocolVersionCombinatorAlias = U16Be;
 
@@ -5088,14 +5088,14 @@ pub fn serialize_protocol_version<'a>(v: <ProtocolVersionCombinator as Combinato
         spec_protocol_version().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_protocol_version().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_protocol_version().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_protocol_version().spec_serialize(v@))
         },
 {
     let combinator = protocol_version();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn protocol_version_len<'a>(v: <ProtocolVersionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5159,7 +5159,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SupportedVersionsServerCombinator
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SupportedVersionsServerCombinatorAlias = ProtocolVersionCombinator;
 
@@ -5203,14 +5203,14 @@ pub fn serialize_supported_versions_server<'a>(v: <SupportedVersionsServerCombin
         spec_supported_versions_server().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_supported_versions_server().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_supported_versions_server().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_supported_versions_server().spec_serialize(v@))
         },
 {
     let combinator = supported_versions_server();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn supported_versions_server_len<'a>(v: <SupportedVersionsServerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5277,7 +5277,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CookieCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CookieCombinatorAlias = Opaque1FfffCombinator;
 
@@ -5321,14 +5321,14 @@ pub fn serialize_cookie<'a>(v: <CookieCombinator as Combinator<'a, &'a [u8], Vec
         spec_cookie().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cookie().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cookie().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cookie().spec_serialize(v@))
         },
 {
     let combinator = cookie();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cookie_len<'a>(v: <CookieCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5459,7 +5459,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NamedGroupCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NamedGroupCombinatorAlias = U16Be;
 
@@ -5503,14 +5503,14 @@ pub fn serialize_named_group<'a>(v: <NamedGroupCombinator as Combinator<'a, &'a 
         spec_named_group().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_named_group().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_named_group().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_named_group().spec_serialize(v@))
         },
 {
     let combinator = named_group();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn named_group_len<'a>(v: <NamedGroupCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5711,76 +5711,76 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HelloRetryExtensionExtensionDataC
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HelloRetryExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<HelloRetryExtensionExtensionDataCombinator3, HelloRetryExtensionExtensionDataMapper>>;
 
 
-pub open spec fn spec_hello_retry_extension_extension_data(extension_type: u16, ext_len: u16) -> SpecHelloRetryExtensionExtensionDataCombinator {
+pub open spec fn spec_hello_retry_extension_extension_data(ext_len: u16, extension_type: u16) -> SpecHelloRetryExtensionExtensionDataCombinator {
     SpecHelloRetryExtensionExtensionDataCombinator(AndThen(bytes::Variable((usize::spec_from(ext_len)) as usize), Mapped { inner: Choice(Cond { cond: extension_type == ExtensionType::SPEC_SupportedVersions, inner: spec_supported_versions_server() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_Cookie, inner: spec_cookie() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_KeyShare, inner: spec_named_group() }, Cond { cond: !(extension_type == ExtensionType::SPEC_SupportedVersions || extension_type == ExtensionType::SPEC_Cookie || extension_type == ExtensionType::SPEC_KeyShare), inner: bytes::Variable((usize::spec_from(ext_len)) as usize) }))), mapper: HelloRetryExtensionExtensionDataMapper }))
 }
 
-pub fn hello_retry_extension_extension_data<'a>(extension_type: u16, ext_len: u16) -> (o: HelloRetryExtensionExtensionDataCombinator)
+pub fn hello_retry_extension_extension_data<'a>(ext_len: u16, extension_type: u16) -> (o: HelloRetryExtensionExtensionDataCombinator)
     requires
         spec_extension_type().wf(extension_type@),
 
-    ensures o@ == spec_hello_retry_extension_extension_data(extension_type@, ext_len@),
+    ensures o@ == spec_hello_retry_extension_extension_data(ext_len@, extension_type@),
             o@.requires(),
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = HelloRetryExtensionExtensionDataCombinator(AndThen(bytes::Variable((usize::ex_from(ext_len)) as usize), Mapped { inner: HelloRetryExtensionExtensionDataCombinator3(Choice::new(Cond { cond: extension_type == ExtensionType::SupportedVersions, inner: supported_versions_server() }, HelloRetryExtensionExtensionDataCombinator2(Choice::new(Cond { cond: extension_type == ExtensionType::Cookie, inner: cookie() }, HelloRetryExtensionExtensionDataCombinator1(Choice::new(Cond { cond: extension_type == ExtensionType::KeyShare, inner: named_group() }, Cond { cond: !(extension_type == ExtensionType::SupportedVersions || extension_type == ExtensionType::Cookie || extension_type == ExtensionType::KeyShare), inner: bytes::Variable((usize::ex_from(ext_len)) as usize) })))))), mapper: HelloRetryExtensionExtensionDataMapper }));
     // assert({
-    //     &&& combinator@ == spec_hello_retry_extension_extension_data(extension_type@, ext_len@)
+    //     &&& combinator@ == spec_hello_retry_extension_extension_data(ext_len@, extension_type@)
     //     &&& combinator@.requires()
     //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
     // });
     combinator
 }
 
-pub fn parse_hello_retry_extension_extension_data<'a>(input: &'a [u8], extension_type: u16, ext_len: u16) -> (res: PResult<<HelloRetryExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+pub fn parse_hello_retry_extension_extension_data<'a>(input: &'a [u8], ext_len: u16, extension_type: u16) -> (res: PResult<<HelloRetryExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
     requires
         input.len() <= usize::MAX,
         spec_extension_type().wf(extension_type@),
 
     ensures
-        res matches Ok((n, v)) ==> spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) == Some((n as int, v@)),
-        spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) matches Some((n, v))
+        res matches Ok((n, v)) ==> spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) == Some((n as int, v@)),
+        spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) matches Some((n, v))
             ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) is None,
-        spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) is None ==> res is Err,
+        res is Err ==> spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) is None,
+        spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) is None ==> res is Err,
 {
-    let combinator = hello_retry_extension_extension_data( extension_type, ext_len );
+    let combinator = hello_retry_extension_extension_data( ext_len, extension_type );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
 }
 
-pub fn serialize_hello_retry_extension_extension_data<'a>(v: <HelloRetryExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, extension_type: u16, ext_len: u16) -> (o: SResult<usize, SerializeError>)
+pub fn serialize_hello_retry_extension_extension_data<'a>(v: <HelloRetryExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, ext_len: u16, extension_type: u16) -> (o: SResult<usize, SerializeError>)
     requires
         pos <= old(data)@.len() <= usize::MAX,
-        spec_hello_retry_extension_extension_data(extension_type@, ext_len@).wf(v@),
+        spec_hello_retry_extension_extension_data(ext_len@, extension_type@).wf(v@),
         spec_extension_type().wf(extension_type@),
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@))
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
-    let combinator = hello_retry_extension_extension_data( extension_type, ext_len );
-    combinator.serialize(v, data, pos)
+    let combinator = hello_retry_extension_extension_data( ext_len, extension_type );
+    combinator.serialize(v, &mut *data, pos)
 }
 
-pub fn hello_retry_extension_extension_data_len<'a>(v: <HelloRetryExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, extension_type: u16, ext_len: u16) -> (serialize_len: usize)
+pub fn hello_retry_extension_extension_data_len<'a>(v: <HelloRetryExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
     requires
-        spec_hello_retry_extension_extension_data(extension_type@, ext_len@).wf(v@),
-        spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len() <= usize::MAX,
+        spec_hello_retry_extension_extension_data(ext_len@, extension_type@).wf(v@),
+        spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len() <= usize::MAX,
         spec_extension_type().wf(extension_type@),
 
     ensures
-        serialize_len == spec_hello_retry_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len(),
+        serialize_len == spec_hello_retry_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len(),
 {
-    let combinator = hello_retry_extension_extension_data( extension_type, ext_len );
+    let combinator = hello_retry_extension_extension_data( ext_len, extension_type );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -5913,7 +5913,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HelloRetryExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HelloRetryExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, HelloRetryExtensionCont1>, HelloRetryExtensionExtensionDataCombinator, HelloRetryExtensionCont0>, HelloRetryExtensionMapper>;
 
@@ -5943,7 +5943,7 @@ impl View for HelloRetryExtensionCont1 {
 
 pub open spec fn spec_hello_retry_extension_cont0(deps: (u16, u16)) -> SpecHelloRetryExtensionExtensionDataCombinator {
     let (extension_type, ext_len) = deps;
-    spec_hello_retry_extension_extension_data(extension_type, ext_len)
+    spec_hello_retry_extension_extension_data(ext_len, extension_type)
 }
 
 impl View for HelloRetryExtensionCont0 {
@@ -5995,14 +5995,14 @@ pub fn serialize_hello_retry_extension<'a>(v: <HelloRetryExtensionCombinator as 
         spec_hello_retry_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_hello_retry_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_hello_retry_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_hello_retry_extension().spec_serialize(v@))
         },
 {
     let combinator = hello_retry_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn hello_retry_extension_len<'a>(v: <HelloRetryExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6069,13 +6069,13 @@ impl<'a, 'b, 'x> Continuation<HelloRetryExtensionCont0Input<'a, 'b, 'x>> for Hel
                 let (extension_type, ext_len) = deps;
                 let extension_type = *extension_type;
                 let ext_len = *ext_len;
-                hello_retry_extension_extension_data(extension_type, ext_len)
+                hello_retry_extension_extension_data(ext_len, extension_type)
             }
             POrSType::S(deps) => {
                 let (extension_type, ext_len) = deps;
                 let extension_type = *extension_type;
                 let ext_len = *ext_len;
-                hello_retry_extension_extension_data(extension_type, ext_len)
+                hello_retry_extension_extension_data(ext_len, extension_type)
             }
         }
     }
@@ -6227,7 +6227,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HelloRetryExtensionsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HelloRetryExtensionsCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate14496530480760116989>, AndThen<bytes::Variable, Repeat<HelloRetryExtensionCombinator>>, HelloRetryExtensionsCont0>, HelloRetryExtensionsMapper>;
 
@@ -6294,14 +6294,14 @@ pub fn serialize_hello_retry_extensions<'a>(v: <HelloRetryExtensionsCombinator a
         spec_hello_retry_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_hello_retry_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_hello_retry_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_hello_retry_extensions().spec_serialize(v@))
         },
 {
     let combinator = hello_retry_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn hello_retry_extensions_len<'a>(v: <HelloRetryExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6505,7 +6505,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HelloRetryRequestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HelloRetryRequestCombinatorAlias = Mapped<HelloRetryRequestCombinator3, HelloRetryRequestMapper>;
 
@@ -6557,14 +6557,14 @@ pub fn serialize_hello_retry_request<'a>(v: <HelloRetryRequestCombinator as Comb
         spec_hello_retry_request().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_hello_retry_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_hello_retry_request().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_hello_retry_request().spec_serialize(v@))
         },
 {
     let combinator = hello_retry_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn hello_retry_request_len<'a>(v: <HelloRetryRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6702,7 +6702,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PreSharedKeyServerExtensionCombin
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PreSharedKeyServerExtensionCombinatorAlias = Mapped<U16Be, PreSharedKeyServerExtensionMapper>;
 
@@ -6754,14 +6754,14 @@ pub fn serialize_pre_shared_key_server_extension<'a>(v: <PreSharedKeyServerExten
         spec_pre_shared_key_server_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_pre_shared_key_server_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_pre_shared_key_server_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_pre_shared_key_server_extension().spec_serialize(v@))
         },
 {
     let combinator = pre_shared_key_server_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn pre_shared_key_server_extension_len<'a>(v: <PreSharedKeyServerExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6905,7 +6905,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for KeyShareEntryCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type KeyShareEntryCombinatorAlias = Mapped<Pair<Pair<NamedGroupCombinator, Refined<U16Be, Predicate16977634203518580913>, KeyShareEntryCont1>, bytes::Variable, KeyShareEntryCont0>, KeyShareEntryMapper>;
 
@@ -6987,14 +6987,14 @@ pub fn serialize_key_share_entry<'a>(v: <KeyShareEntryCombinator as Combinator<'
         spec_key_share_entry().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_key_share_entry().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_key_share_entry().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_key_share_entry().spec_serialize(v@))
         },
 {
     let combinator = key_share_entry();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn key_share_entry_len<'a>(v: <KeyShareEntryCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7259,7 +7259,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SeverHelloExtensionExtensionDataC
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SeverHelloExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<SeverHelloExtensionExtensionDataCombinator3, SeverHelloExtensionExtensionDataMapper>>;
 
@@ -7309,14 +7309,14 @@ pub fn serialize_sever_hello_extension_extension_data<'a>(v: <SeverHelloExtensio
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_sever_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_sever_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_sever_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
     let combinator = sever_hello_extension_extension_data( ext_len, extension_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn sever_hello_extension_extension_data_len<'a>(v: <SeverHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
@@ -7461,7 +7461,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SeverHelloExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SeverHelloExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, SeverHelloExtensionCont1>, SeverHelloExtensionExtensionDataCombinator, SeverHelloExtensionCont0>, SeverHelloExtensionMapper>;
 
@@ -7543,14 +7543,14 @@ pub fn serialize_sever_hello_extension<'a>(v: <SeverHelloExtensionCombinator as 
         spec_sever_hello_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_sever_hello_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_sever_hello_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_sever_hello_extension().spec_serialize(v@))
         },
 {
     let combinator = sever_hello_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn sever_hello_extension_len<'a>(v: <SeverHelloExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7755,7 +7755,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerExtensionsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerExtensionsCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate14496530480760116989>, AndThen<bytes::Variable, Repeat<SeverHelloExtensionCombinator>>, ServerExtensionsCont0>, ServerExtensionsMapper>;
 
@@ -7822,14 +7822,14 @@ pub fn serialize_server_extensions<'a>(v: <ServerExtensionsCombinator as Combina
         spec_server_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_extensions().spec_serialize(v@))
         },
 {
     let combinator = server_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_extensions_len<'a>(v: <ServerExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8033,7 +8033,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerHelloCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerHelloCombinatorAlias = Mapped<ServerHelloCombinator3, ServerHelloMapper>;
 
@@ -8085,14 +8085,14 @@ pub fn serialize_server_hello<'a>(v: <ServerHelloCombinator as Combinator<'a, &'
         spec_server_hello().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_hello().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_hello().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_hello().spec_serialize(v@))
         },
 {
     let combinator = server_hello();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_hello_len<'a>(v: <ServerHelloCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8261,7 +8261,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ShOrHrrPayloadCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ShOrHrrPayloadCombinatorAlias = Mapped<ShOrHrrPayloadCombinator1, ShOrHrrPayloadMapper>;
 
@@ -8307,14 +8307,14 @@ pub fn serialize_sh_or_hrr_payload<'a>(v: <ShOrHrrPayloadCombinator as Combinato
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_sh_or_hrr_payload(random@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_sh_or_hrr_payload(random@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_sh_or_hrr_payload(random@).spec_serialize(v@))
         },
 {
     let combinator = sh_or_hrr_payload( random );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn sh_or_hrr_payload_len<'a>(v: <ShOrHrrPayloadCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, random: &'a [u8]) -> (serialize_len: usize)
@@ -8459,7 +8459,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ShOrHrrCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ShOrHrrCombinatorAlias = Mapped<Pair<(Refined<U16Be, TagPred<u16>>, bytes::Fixed<32>), ShOrHrrPayloadCombinator, ShOrHrrCont0>, ShOrHrrMapper>;
 
@@ -8526,14 +8526,14 @@ pub fn serialize_sh_or_hrr<'a>(v: <ShOrHrrCombinator as Combinator<'a, &'a [u8],
         spec_sh_or_hrr().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_sh_or_hrr().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_sh_or_hrr().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_sh_or_hrr().spec_serialize(v@))
         },
 {
     let combinator = sh_or_hrr();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn sh_or_hrr_len<'a>(v: <ShOrHrrCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8793,7 +8793,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HandshakeTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HandshakeTypeCombinatorAlias = TryMap<U8, HandshakeTypeMapper>;
 
@@ -8837,14 +8837,14 @@ pub fn serialize_handshake_type<'a>(v: <HandshakeTypeCombinator as Combinator<'a
         spec_handshake_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_handshake_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_handshake_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_handshake_type().spec_serialize(v@))
         },
 {
     let combinator = handshake_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn handshake_type_len<'a>(v: <HandshakeTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8985,7 +8985,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CipherSuiteListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CipherSuiteListCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate15206902916018849611>, AndThen<bytes::Variable, Repeat<CipherSuiteCombinator>>, CipherSuiteListCont0>, CipherSuiteListMapper>;
 
@@ -9052,14 +9052,14 @@ pub fn serialize_cipher_suite_list<'a>(v: <CipherSuiteListCombinator as Combinat
         spec_cipher_suite_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_cipher_suite_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_cipher_suite_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_cipher_suite_list().spec_serialize(v@))
         },
 {
     let combinator = cipher_suite_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn cipher_suite_list_len<'a>(v: <CipherSuiteListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9157,7 +9157,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HostNameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HostNameCombinatorAlias = Opaque1FfffCombinator;
 
@@ -9201,14 +9201,14 @@ pub fn serialize_host_name<'a>(v: <HostNameCombinator as Combinator<'a, &'a [u8]
         spec_host_name().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_host_name().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_host_name().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_host_name().spec_serialize(v@))
         },
 {
     let combinator = host_name();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn host_name_len<'a>(v: <HostNameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9275,7 +9275,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for UnknownNameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type UnknownNameCombinatorAlias = Opaque1FfffCombinator;
 
@@ -9319,14 +9319,14 @@ pub fn serialize_unknown_name<'a>(v: <UnknownNameCombinator as Combinator<'a, &'
         spec_unknown_name().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_unknown_name().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_unknown_name().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_unknown_name().spec_serialize(v@))
         },
 {
     let combinator = unknown_name();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn unknown_name_len<'a>(v: <UnknownNameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9495,7 +9495,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerNameNameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerNameNameCombinatorAlias = Mapped<ServerNameNameCombinator1, ServerNameNameMapper>;
 
@@ -9545,14 +9545,14 @@ pub fn serialize_server_name_name<'a>(v: <ServerNameNameCombinator as Combinator
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_name_name(name_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_name_name(name_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_name_name(name_type@).spec_serialize(v@))
         },
 {
     let combinator = server_name_name( name_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn server_name_name_len<'a>(v: <ServerNameNameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, name_type: u8) -> (serialize_len: usize)
@@ -9694,7 +9694,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerNameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerNameCombinatorAlias = Mapped<Pair<NameTypeCombinator, ServerNameNameCombinator, ServerNameCont0>, ServerNameMapper>;
 
@@ -9761,14 +9761,14 @@ pub fn serialize_server_name<'a>(v: <ServerNameCombinator as Combinator<'a, &'a 
         spec_server_name().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_name().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_name().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_name().spec_serialize(v@))
         },
 {
     let combinator = server_name();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_name_len<'a>(v: <ServerNameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9940,7 +9940,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerNameListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerNameListCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate16977634203518580913>, AndThen<bytes::Variable, Repeat<ServerNameCombinator>>, ServerNameListCont0>, ServerNameListMapper>;
 
@@ -10007,14 +10007,14 @@ pub fn serialize_server_name_list<'a>(v: <ServerNameListCombinator as Combinator
         spec_server_name_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_name_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_name_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_name_list().spec_serialize(v@))
         },
 {
     let combinator = server_name_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_name_list_len<'a>(v: <ServerNameListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10206,7 +10206,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NamedGroupListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NamedGroupListCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate8195707947578446211>, AndThen<bytes::Variable, Repeat<NamedGroupCombinator>>, NamedGroupListCont0>, NamedGroupListMapper>;
 
@@ -10273,14 +10273,14 @@ pub fn serialize_named_group_list<'a>(v: <NamedGroupListCombinator as Combinator
         spec_named_group_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_named_group_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_named_group_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_named_group_list().spec_serialize(v@))
         },
 {
     let combinator = named_group_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn named_group_list_len<'a>(v: <NamedGroupListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10378,7 +10378,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProtocolNameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProtocolNameCombinatorAlias = Opaque1FfCombinator;
 
@@ -10422,14 +10422,14 @@ pub fn serialize_protocol_name<'a>(v: <ProtocolNameCombinator as Combinator<'a, 
         spec_protocol_name().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_protocol_name().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_protocol_name().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_protocol_name().spec_serialize(v@))
         },
 {
     let combinator = protocol_name();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn protocol_name_len<'a>(v: <ProtocolNameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10570,7 +10570,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ProtocolNameListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ProtocolNameListCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate8195707947578446211>, AndThen<bytes::Variable, Repeat<ProtocolNameCombinator>>, ProtocolNameListCont0>, ProtocolNameListMapper>;
 
@@ -10637,14 +10637,14 @@ pub fn serialize_protocol_name_list<'a>(v: <ProtocolNameListCombinator as Combin
         spec_protocol_name_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_protocol_name_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_protocol_name_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_protocol_name_list().spec_serialize(v@))
         },
 {
     let combinator = protocol_name_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn protocol_name_list_len<'a>(v: <ProtocolNameListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10836,7 +10836,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SupportedVersionsClientCombinator
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SupportedVersionsClientCombinatorAlias = Mapped<Pair<Refined<U8, Predicate7470776374180795781>, AndThen<bytes::Variable, Repeat<ProtocolVersionCombinator>>, SupportedVersionsClientCont0>, SupportedVersionsClientMapper>;
 
@@ -10903,14 +10903,14 @@ pub fn serialize_supported_versions_client<'a>(v: <SupportedVersionsClientCombin
         spec_supported_versions_client().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_supported_versions_client().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_supported_versions_client().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_supported_versions_client().spec_serialize(v@))
         },
 {
     let combinator = supported_versions_client();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn supported_versions_client_len<'a>(v: <SupportedVersionsClientCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11082,7 +11082,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for KeyShareClientHelloCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type KeyShareClientHelloCombinatorAlias = Mapped<Pair<U16Be, AndThen<bytes::Variable, Repeat<KeyShareEntryCombinator>>, KeyShareClientHelloCont0>, KeyShareClientHelloMapper>;
 
@@ -11149,14 +11149,14 @@ pub fn serialize_key_share_client_hello<'a>(v: <KeyShareClientHelloCombinator as
         spec_key_share_client_hello().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_key_share_client_hello().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_key_share_client_hello().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_key_share_client_hello().spec_serialize(v@))
         },
 {
     let combinator = key_share_client_hello();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn key_share_client_hello_len<'a>(v: <KeyShareClientHelloCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11258,7 +11258,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PskKeyExchangeModeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PskKeyExchangeModeCombinatorAlias = U8;
 
@@ -11302,14 +11302,14 @@ pub fn serialize_psk_key_exchange_mode<'a>(v: <PskKeyExchangeModeCombinator as C
         spec_psk_key_exchange_mode().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_psk_key_exchange_mode().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_psk_key_exchange_mode().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_psk_key_exchange_mode().spec_serialize(v@))
         },
 {
     let combinator = psk_key_exchange_mode();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn psk_key_exchange_mode_len<'a>(v: <PskKeyExchangeModeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11470,7 +11470,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PskKeyExchangeModesCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PskKeyExchangeModesCombinatorAlias = Mapped<Pair<Refined<U8, Predicate13984338198318635021>, AndThen<bytes::Variable, Repeat<PskKeyExchangeModeCombinator>>, PskKeyExchangeModesCont0>, PskKeyExchangeModesMapper>;
 
@@ -11537,14 +11537,14 @@ pub fn serialize_psk_key_exchange_modes<'a>(v: <PskKeyExchangeModesCombinator as
         spec_psk_key_exchange_modes().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_psk_key_exchange_modes().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_psk_key_exchange_modes().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_psk_key_exchange_modes().spec_serialize(v@))
         },
 {
     let combinator = psk_key_exchange_modes();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn psk_key_exchange_modes_len<'a>(v: <PskKeyExchangeModesCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11723,7 +11723,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PskIdentityCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PskIdentityCombinatorAlias = Mapped<PskIdentityCombinator1, PskIdentityMapper>;
 
@@ -11775,14 +11775,14 @@ pub fn serialize_psk_identity<'a>(v: <PskIdentityCombinator as Combinator<'a, &'
         spec_psk_identity().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_psk_identity().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_psk_identity().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_psk_identity().spec_serialize(v@))
         },
 {
     let combinator = psk_identity();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn psk_identity_len<'a>(v: <PskIdentityCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11943,7 +11943,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PskIdentitiesCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PskIdentitiesCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate22012019403780218>, AndThen<bytes::Variable, Repeat<PskIdentityCombinator>>, PskIdentitiesCont0>, PskIdentitiesMapper>;
 
@@ -12010,14 +12010,14 @@ pub fn serialize_psk_identities<'a>(v: <PskIdentitiesCombinator as Combinator<'a
         spec_psk_identities().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_psk_identities().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_psk_identities().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_psk_identities().spec_serialize(v@))
         },
 {
     let combinator = psk_identities();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn psk_identities_len<'a>(v: <PskIdentitiesCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12209,7 +12209,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PskBinderEntryCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PskBinderEntryCombinatorAlias = Mapped<Pair<Refined<U8, Predicate12415296748708102903>, bytes::Variable, PskBinderEntryCont0>, PskBinderEntryMapper>;
 
@@ -12276,14 +12276,14 @@ pub fn serialize_psk_binder_entry<'a>(v: <PskBinderEntryCombinator as Combinator
         spec_psk_binder_entry().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_psk_binder_entry().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_psk_binder_entry().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_psk_binder_entry().spec_serialize(v@))
         },
 {
     let combinator = psk_binder_entry();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn psk_binder_entry_len<'a>(v: <PskBinderEntryCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12475,7 +12475,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PskBinderEntriesCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PskBinderEntriesCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate2895184764579107747>, AndThen<bytes::Variable, Repeat<PskBinderEntryCombinator>>, PskBinderEntriesCont0>, PskBinderEntriesMapper>;
 
@@ -12542,14 +12542,14 @@ pub fn serialize_psk_binder_entries<'a>(v: <PskBinderEntriesCombinator as Combin
         spec_psk_binder_entries().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_psk_binder_entries().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_psk_binder_entries().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_psk_binder_entries().spec_serialize(v@))
         },
 {
     let combinator = psk_binder_entries();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn psk_binder_entries_len<'a>(v: <PskBinderEntriesCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12728,7 +12728,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OfferedPsksCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OfferedPsksCombinatorAlias = Mapped<OfferedPsksCombinator1, OfferedPsksMapper>;
 
@@ -12780,14 +12780,14 @@ pub fn serialize_offered_psks<'a>(v: <OfferedPsksCombinator as Combinator<'a, &'
         spec_offered_psks().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_offered_psks().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_offered_psks().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_offered_psks().spec_serialize(v@))
         },
 {
     let combinator = offered_psks();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn offered_psks_len<'a>(v: <OfferedPsksCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12925,7 +12925,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PreSharedKeyClientExtensionCombin
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PreSharedKeyClientExtensionCombinatorAlias = Mapped<OfferedPsksCombinator, PreSharedKeyClientExtensionMapper>;
 
@@ -12977,14 +12977,14 @@ pub fn serialize_pre_shared_key_client_extension<'a>(v: <PreSharedKeyClientExten
         spec_pre_shared_key_client_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_pre_shared_key_client_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_pre_shared_key_client_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_pre_shared_key_client_extension().spec_serialize(v@))
         },
 {
     let combinator = pre_shared_key_client_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn pre_shared_key_client_extension_len<'a>(v: <PreSharedKeyClientExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13059,7 +13059,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MaxFragmentLengthCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MaxFragmentLengthCombinatorAlias = U8;
 
@@ -13103,14 +13103,14 @@ pub fn serialize_max_fragment_length<'a>(v: <MaxFragmentLengthCombinator as Comb
         spec_max_fragment_length().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_max_fragment_length().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_max_fragment_length().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_max_fragment_length().spec_serialize(v@))
         },
 {
     let combinator = max_fragment_length();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn max_fragment_length_len<'a>(v: <MaxFragmentLengthCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13181,7 +13181,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HeartbeatModeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HeartbeatModeCombinatorAlias = U8;
 
@@ -13225,14 +13225,14 @@ pub fn serialize_heartbeat_mode<'a>(v: <HeartbeatModeCombinator as Combinator<'a
         spec_heartbeat_mode().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_heartbeat_mode().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_heartbeat_mode().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_heartbeat_mode().spec_serialize(v@))
         },
 {
     let combinator = heartbeat_mode();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn heartbeat_mode_len<'a>(v: <HeartbeatModeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13303,7 +13303,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateTypeCombinatorAlias = U8;
 
@@ -13347,14 +13347,14 @@ pub fn serialize_certificate_type<'a>(v: <CertificateTypeCombinator as Combinato
         spec_certificate_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_type().spec_serialize(v@))
         },
 {
     let combinator = certificate_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_type_len<'a>(v: <CertificateTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13495,7 +13495,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientCertTypeClientExtensionComb
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientCertTypeClientExtensionCombinatorAlias = Mapped<Pair<Refined<U8, Predicate13984338198318635021>, AndThen<bytes::Variable, Repeat<CertificateTypeCombinator>>, ClientCertTypeClientExtensionCont0>, ClientCertTypeClientExtensionMapper>;
 
@@ -13562,14 +13562,14 @@ pub fn serialize_client_cert_type_client_extension<'a>(v: <ClientCertTypeClientE
         spec_client_cert_type_client_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_client_cert_type_client_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_cert_type_client_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_cert_type_client_extension().spec_serialize(v@))
         },
 {
     let combinator = client_cert_type_client_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn client_cert_type_client_extension_len<'a>(v: <ClientCertTypeClientExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13741,7 +13741,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerCertTypeClientExtensionComb
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerCertTypeClientExtensionCombinatorAlias = Mapped<Pair<Refined<U8, Predicate13984338198318635021>, AndThen<bytes::Variable, Repeat<CertificateTypeCombinator>>, ServerCertTypeClientExtensionCont0>, ServerCertTypeClientExtensionMapper>;
 
@@ -13808,14 +13808,14 @@ pub fn serialize_server_cert_type_client_extension<'a>(v: <ServerCertTypeClientE
         spec_server_cert_type_client_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_cert_type_client_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_cert_type_client_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_cert_type_client_extension().spec_serialize(v@))
         },
 {
     let combinator = server_cert_type_client_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_cert_type_client_extension_len<'a>(v: <ServerCertTypeClientExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14159,7 +14159,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientHelloExtensionRestCombinato
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientHelloExtensionRestCombinatorAlias = Mapped<ClientHelloExtensionRestCombinator10, ClientHelloExtensionRestMapper>;
 
@@ -14209,14 +14209,14 @@ pub fn serialize_client_hello_extension_rest<'a>(v: <ClientHelloExtensionRestCom
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_client_hello_extension_rest(ext_len@, extension_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_hello_extension_rest(ext_len@, extension_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_hello_extension_rest(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
     let combinator = client_hello_extension_rest( ext_len, extension_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn client_hello_extension_rest_len<'a>(v: <ClientHelloExtensionRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
@@ -14514,76 +14514,76 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientHelloExtensionExtensionData
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientHelloExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<ClientHelloExtensionExtensionDataCombinator9, ClientHelloExtensionExtensionDataMapper>>;
 
 
-pub open spec fn spec_client_hello_extension_extension_data(extension_type: u16, ext_len: u16) -> SpecClientHelloExtensionExtensionDataCombinator {
+pub open spec fn spec_client_hello_extension_extension_data(ext_len: u16, extension_type: u16) -> SpecClientHelloExtensionExtensionDataCombinator {
     SpecClientHelloExtensionExtensionDataCombinator(AndThen(bytes::Variable((usize::spec_from(ext_len)) as usize), Mapped { inner: Choice(Cond { cond: extension_type == ExtensionType::SPEC_ServerName, inner: spec_server_name_list() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_SignatureAlgorithms, inner: spec_signature_scheme_list() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_SupportedGroups, inner: spec_named_group_list() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_StatusRequest, inner: spec_certificate_status_request() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_ApplicationLayerProtocolNegotiation, inner: spec_protocol_name_list() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_SupportedVersions, inner: spec_supported_versions_client() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_KeyShare, inner: spec_key_share_client_hello() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_PskKeyExchangeModes, inner: spec_psk_key_exchange_modes() }, Choice(Cond { cond: extension_type == ExtensionType::SPEC_PreSharedKey, inner: spec_pre_shared_key_client_extension() }, Cond { cond: !(extension_type == ExtensionType::SPEC_ServerName || extension_type == ExtensionType::SPEC_SignatureAlgorithms || extension_type == ExtensionType::SPEC_SupportedGroups || extension_type == ExtensionType::SPEC_StatusRequest || extension_type == ExtensionType::SPEC_ApplicationLayerProtocolNegotiation || extension_type == ExtensionType::SPEC_SupportedVersions || extension_type == ExtensionType::SPEC_KeyShare || extension_type == ExtensionType::SPEC_PskKeyExchangeModes || extension_type == ExtensionType::SPEC_PreSharedKey), inner: spec_client_hello_extension_rest(ext_len, extension_type) }))))))))), mapper: ClientHelloExtensionExtensionDataMapper }))
 }
 
-pub fn client_hello_extension_extension_data<'a>(extension_type: u16, ext_len: u16) -> (o: ClientHelloExtensionExtensionDataCombinator)
+pub fn client_hello_extension_extension_data<'a>(ext_len: u16, extension_type: u16) -> (o: ClientHelloExtensionExtensionDataCombinator)
     requires
         spec_extension_type().wf(extension_type@),
 
-    ensures o@ == spec_client_hello_extension_extension_data(extension_type@, ext_len@),
+    ensures o@ == spec_client_hello_extension_extension_data(ext_len@, extension_type@),
             o@.requires(),
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = ClientHelloExtensionExtensionDataCombinator(AndThen(bytes::Variable((usize::ex_from(ext_len)) as usize), Mapped { inner: ClientHelloExtensionExtensionDataCombinator9(Choice::new(Cond { cond: extension_type == ExtensionType::ServerName, inner: server_name_list() }, ClientHelloExtensionExtensionDataCombinator8(Choice::new(Cond { cond: extension_type == ExtensionType::SignatureAlgorithms, inner: signature_scheme_list() }, ClientHelloExtensionExtensionDataCombinator7(Choice::new(Cond { cond: extension_type == ExtensionType::SupportedGroups, inner: named_group_list() }, ClientHelloExtensionExtensionDataCombinator6(Choice::new(Cond { cond: extension_type == ExtensionType::StatusRequest, inner: certificate_status_request() }, ClientHelloExtensionExtensionDataCombinator5(Choice::new(Cond { cond: extension_type == ExtensionType::ApplicationLayerProtocolNegotiation, inner: protocol_name_list() }, ClientHelloExtensionExtensionDataCombinator4(Choice::new(Cond { cond: extension_type == ExtensionType::SupportedVersions, inner: supported_versions_client() }, ClientHelloExtensionExtensionDataCombinator3(Choice::new(Cond { cond: extension_type == ExtensionType::KeyShare, inner: key_share_client_hello() }, ClientHelloExtensionExtensionDataCombinator2(Choice::new(Cond { cond: extension_type == ExtensionType::PskKeyExchangeModes, inner: psk_key_exchange_modes() }, ClientHelloExtensionExtensionDataCombinator1(Choice::new(Cond { cond: extension_type == ExtensionType::PreSharedKey, inner: pre_shared_key_client_extension() }, Cond { cond: !(extension_type == ExtensionType::ServerName || extension_type == ExtensionType::SignatureAlgorithms || extension_type == ExtensionType::SupportedGroups || extension_type == ExtensionType::StatusRequest || extension_type == ExtensionType::ApplicationLayerProtocolNegotiation || extension_type == ExtensionType::SupportedVersions || extension_type == ExtensionType::KeyShare || extension_type == ExtensionType::PskKeyExchangeModes || extension_type == ExtensionType::PreSharedKey), inner: client_hello_extension_rest(ext_len, extension_type) })))))))))))))))))), mapper: ClientHelloExtensionExtensionDataMapper }));
     // assert({
-    //     &&& combinator@ == spec_client_hello_extension_extension_data(extension_type@, ext_len@)
+    //     &&& combinator@ == spec_client_hello_extension_extension_data(ext_len@, extension_type@)
     //     &&& combinator@.requires()
     //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
     // });
     combinator
 }
 
-pub fn parse_client_hello_extension_extension_data<'a>(input: &'a [u8], extension_type: u16, ext_len: u16) -> (res: PResult<<ClientHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+pub fn parse_client_hello_extension_extension_data<'a>(input: &'a [u8], ext_len: u16, extension_type: u16) -> (res: PResult<<ClientHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
     requires
         input.len() <= usize::MAX,
         spec_extension_type().wf(extension_type@),
 
     ensures
-        res matches Ok((n, v)) ==> spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) == Some((n as int, v@)),
-        spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) matches Some((n, v))
+        res matches Ok((n, v)) ==> spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) == Some((n as int, v@)),
+        spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) matches Some((n, v))
             ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) is None,
-        spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) is None ==> res is Err,
+        res is Err ==> spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) is None,
+        spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) is None ==> res is Err,
 {
-    let combinator = client_hello_extension_extension_data( extension_type, ext_len );
+    let combinator = client_hello_extension_extension_data( ext_len, extension_type );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
 }
 
-pub fn serialize_client_hello_extension_extension_data<'a>(v: <ClientHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, extension_type: u16, ext_len: u16) -> (o: SResult<usize, SerializeError>)
+pub fn serialize_client_hello_extension_extension_data<'a>(v: <ClientHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, ext_len: u16, extension_type: u16) -> (o: SResult<usize, SerializeError>)
     requires
         pos <= old(data)@.len() <= usize::MAX,
-        spec_client_hello_extension_extension_data(extension_type@, ext_len@).wf(v@),
+        spec_client_hello_extension_extension_data(ext_len@, extension_type@).wf(v@),
         spec_extension_type().wf(extension_type@),
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@))
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
-    let combinator = client_hello_extension_extension_data( extension_type, ext_len );
-    combinator.serialize(v, data, pos)
+    let combinator = client_hello_extension_extension_data( ext_len, extension_type );
+    combinator.serialize(v, &mut *data, pos)
 }
 
-pub fn client_hello_extension_extension_data_len<'a>(v: <ClientHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, extension_type: u16, ext_len: u16) -> (serialize_len: usize)
+pub fn client_hello_extension_extension_data_len<'a>(v: <ClientHelloExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
     requires
-        spec_client_hello_extension_extension_data(extension_type@, ext_len@).wf(v@),
-        spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len() <= usize::MAX,
+        spec_client_hello_extension_extension_data(ext_len@, extension_type@).wf(v@),
+        spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len() <= usize::MAX,
         spec_extension_type().wf(extension_type@),
 
     ensures
-        serialize_len == spec_client_hello_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len(),
+        serialize_len == spec_client_hello_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len(),
 {
-    let combinator = client_hello_extension_extension_data( extension_type, ext_len );
+    let combinator = client_hello_extension_extension_data( ext_len, extension_type );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -14716,7 +14716,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientHelloExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientHelloExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, ClientHelloExtensionCont1>, ClientHelloExtensionExtensionDataCombinator, ClientHelloExtensionCont0>, ClientHelloExtensionMapper>;
 
@@ -14746,7 +14746,7 @@ impl View for ClientHelloExtensionCont1 {
 
 pub open spec fn spec_client_hello_extension_cont0(deps: (u16, u16)) -> SpecClientHelloExtensionExtensionDataCombinator {
     let (extension_type, ext_len) = deps;
-    spec_client_hello_extension_extension_data(extension_type, ext_len)
+    spec_client_hello_extension_extension_data(ext_len, extension_type)
 }
 
 impl View for ClientHelloExtensionCont0 {
@@ -14798,14 +14798,14 @@ pub fn serialize_client_hello_extension<'a>(v: <ClientHelloExtensionCombinator a
         spec_client_hello_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_client_hello_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_hello_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_hello_extension().spec_serialize(v@))
         },
 {
     let combinator = client_hello_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn client_hello_extension_len<'a>(v: <ClientHelloExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14872,13 +14872,13 @@ impl<'a, 'b, 'x> Continuation<ClientHelloExtensionCont0Input<'a, 'b, 'x>> for Cl
                 let (extension_type, ext_len) = deps;
                 let extension_type = *extension_type;
                 let ext_len = *ext_len;
-                client_hello_extension_extension_data(extension_type, ext_len)
+                client_hello_extension_extension_data(ext_len, extension_type)
             }
             POrSType::S(deps) => {
                 let (extension_type, ext_len) = deps;
                 let extension_type = *extension_type;
                 let ext_len = *ext_len;
-                client_hello_extension_extension_data(extension_type, ext_len)
+                client_hello_extension_extension_data(ext_len, extension_type)
             }
         }
     }
@@ -15030,7 +15030,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientExtensionsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientExtensionsCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate9952414989822543135>, AndThen<bytes::Variable, Repeat<ClientHelloExtensionCombinator>>, ClientExtensionsCont0>, ClientExtensionsMapper>;
 
@@ -15097,14 +15097,14 @@ pub fn serialize_client_extensions<'a>(v: <ClientExtensionsCombinator as Combina
         spec_client_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_client_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_extensions().spec_serialize(v@))
         },
 {
     let combinator = client_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn client_extensions_len<'a>(v: <ClientExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15332,7 +15332,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientHelloCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientHelloCombinatorAlias = Mapped<ClientHelloCombinator5, ClientHelloMapper>;
 
@@ -15384,14 +15384,14 @@ pub fn serialize_client_hello<'a>(v: <ClientHelloCombinator as Combinator<'a, &'
         spec_client_hello().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_client_hello().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_hello().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_hello().spec_serialize(v@))
         },
 {
     let combinator = client_hello();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn client_hello_len<'a>(v: <ClientHelloCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15532,7 +15532,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque0FfCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque0FfCombinatorAlias = Mapped<Pair<U8, bytes::Variable, Opaque0FfCont0>, Opaque0FfMapper>;
 
@@ -15599,14 +15599,14 @@ pub fn serialize_opaque_0_ff<'a>(v: <Opaque0FfCombinator as Combinator<'a, &'a [
         spec_opaque_0_ff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_0_ff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_0_ff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_0_ff().spec_serialize(v@))
         },
 {
     let combinator = opaque_0_ff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_0_ff_len<'a>(v: <Opaque0FfCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15775,7 +15775,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EarlyDataIndicationNewSessionTick
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EarlyDataIndicationNewSessionTicketCombinatorAlias = Mapped<U32Be, EarlyDataIndicationNewSessionTicketMapper>;
 
@@ -15827,14 +15827,14 @@ pub fn serialize_early_data_indication_new_session_ticket<'a>(v: <EarlyDataIndic
         spec_early_data_indication_new_session_ticket().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_early_data_indication_new_session_ticket().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_early_data_indication_new_session_ticket().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_early_data_indication_new_session_ticket().spec_serialize(v@))
         },
 {
     let combinator = early_data_indication_new_session_ticket();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn early_data_indication_new_session_ticket_len<'a>(v: <EarlyDataIndicationNewSessionTicketCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16003,76 +16003,76 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NewSessionTicketExtensionExtensio
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NewSessionTicketExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<NewSessionTicketExtensionExtensionDataCombinator1, NewSessionTicketExtensionExtensionDataMapper>>;
 
 
-pub open spec fn spec_new_session_ticket_extension_extension_data(extension_type: u16, ext_len: u16) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
+pub open spec fn spec_new_session_ticket_extension_extension_data(ext_len: u16, extension_type: u16) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
     SpecNewSessionTicketExtensionExtensionDataCombinator(AndThen(bytes::Variable((usize::spec_from(ext_len)) as usize), Mapped { inner: Choice(Cond { cond: extension_type == ExtensionType::SPEC_EarlyData, inner: spec_early_data_indication_new_session_ticket() }, Cond { cond: !(extension_type == ExtensionType::SPEC_EarlyData), inner: bytes::Variable((usize::spec_from(ext_len)) as usize) }), mapper: NewSessionTicketExtensionExtensionDataMapper }))
 }
 
-pub fn new_session_ticket_extension_extension_data<'a>(extension_type: u16, ext_len: u16) -> (o: NewSessionTicketExtensionExtensionDataCombinator)
+pub fn new_session_ticket_extension_extension_data<'a>(ext_len: u16, extension_type: u16) -> (o: NewSessionTicketExtensionExtensionDataCombinator)
     requires
         spec_extension_type().wf(extension_type@),
 
-    ensures o@ == spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@),
+    ensures o@ == spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@),
             o@.requires(),
             <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&o),
 {
     let combinator = NewSessionTicketExtensionExtensionDataCombinator(AndThen(bytes::Variable((usize::ex_from(ext_len)) as usize), Mapped { inner: NewSessionTicketExtensionExtensionDataCombinator1(Choice::new(Cond { cond: extension_type == ExtensionType::EarlyData, inner: early_data_indication_new_session_ticket() }, Cond { cond: !(extension_type == ExtensionType::EarlyData), inner: bytes::Variable((usize::ex_from(ext_len)) as usize) })), mapper: NewSessionTicketExtensionExtensionDataMapper }));
     // assert({
-    //     &&& combinator@ == spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@)
+    //     &&& combinator@ == spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@)
     //     &&& combinator@.requires()
     //     &&& <_ as Combinator<'a, &'a [u8], Vec<u8>>>::ex_requires(&combinator)
     // });
     combinator
 }
 
-pub fn parse_new_session_ticket_extension_extension_data<'a>(input: &'a [u8], extension_type: u16, ext_len: u16) -> (res: PResult<<NewSessionTicketExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
+pub fn parse_new_session_ticket_extension_extension_data<'a>(input: &'a [u8], ext_len: u16, extension_type: u16) -> (res: PResult<<NewSessionTicketExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::Type, ParseError>)
     requires
         input.len() <= usize::MAX,
         spec_extension_type().wf(extension_type@),
 
     ensures
-        res matches Ok((n, v)) ==> spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) == Some((n as int, v@)),
-        spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) matches Some((n, v))
+        res matches Ok((n, v)) ==> spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) == Some((n as int, v@)),
+        spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) matches Some((n, v))
             ==> res matches Ok((m, u)) && m == n && v == u@,
-        res is Err ==> spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) is None,
-        spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_parse(input@) is None ==> res is Err,
+        res is Err ==> spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) is None,
+        spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_parse(input@) is None ==> res is Err,
 {
-    let combinator = new_session_ticket_extension_extension_data( extension_type, ext_len );
+    let combinator = new_session_ticket_extension_extension_data( ext_len, extension_type );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&combinator, input)
 }
 
-pub fn serialize_new_session_ticket_extension_extension_data<'a>(v: <NewSessionTicketExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, extension_type: u16, ext_len: u16) -> (o: SResult<usize, SerializeError>)
+pub fn serialize_new_session_ticket_extension_extension_data<'a>(v: <NewSessionTicketExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, data: &mut Vec<u8>, pos: usize, ext_len: u16, extension_type: u16) -> (o: SResult<usize, SerializeError>)
     requires
         pos <= old(data)@.len() <= usize::MAX,
-        spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).wf(v@),
+        spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).wf(v@),
         spec_extension_type().wf(extension_type@),
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
-            &&& n == spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@))
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
+            &&& n == spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
-    let combinator = new_session_ticket_extension_extension_data( extension_type, ext_len );
-    combinator.serialize(v, data, pos)
+    let combinator = new_session_ticket_extension_extension_data( ext_len, extension_type );
+    combinator.serialize(v, &mut *data, pos)
 }
 
-pub fn new_session_ticket_extension_extension_data_len<'a>(v: <NewSessionTicketExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, extension_type: u16, ext_len: u16) -> (serialize_len: usize)
+pub fn new_session_ticket_extension_extension_data_len<'a>(v: <NewSessionTicketExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
     requires
-        spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).wf(v@),
-        spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len() <= usize::MAX,
+        spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).wf(v@),
+        spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len() <= usize::MAX,
         spec_extension_type().wf(extension_type@),
 
     ensures
-        serialize_len == spec_new_session_ticket_extension_extension_data(extension_type@, ext_len@).spec_serialize(v@).len(),
+        serialize_len == spec_new_session_ticket_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len(),
 {
-    let combinator = new_session_ticket_extension_extension_data( extension_type, ext_len );
+    let combinator = new_session_ticket_extension_extension_data( ext_len, extension_type );
     <_ as Combinator<'a, &'a [u8], Vec<u8>>>::length(&combinator, v)
 }
 
@@ -16205,7 +16205,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NewSessionTicketExtensionCombinat
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NewSessionTicketExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, NewSessionTicketExtensionCont1>, NewSessionTicketExtensionExtensionDataCombinator, NewSessionTicketExtensionCont0>, NewSessionTicketExtensionMapper>;
 
@@ -16235,7 +16235,7 @@ impl View for NewSessionTicketExtensionCont1 {
 
 pub open spec fn spec_new_session_ticket_extension_cont0(deps: (u16, u16)) -> SpecNewSessionTicketExtensionExtensionDataCombinator {
     let (extension_type, ext_len) = deps;
-    spec_new_session_ticket_extension_extension_data(extension_type, ext_len)
+    spec_new_session_ticket_extension_extension_data(ext_len, extension_type)
 }
 
 impl View for NewSessionTicketExtensionCont0 {
@@ -16287,14 +16287,14 @@ pub fn serialize_new_session_ticket_extension<'a>(v: <NewSessionTicketExtensionC
         spec_new_session_ticket_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_new_session_ticket_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_new_session_ticket_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_new_session_ticket_extension().spec_serialize(v@))
         },
 {
     let combinator = new_session_ticket_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn new_session_ticket_extension_len<'a>(v: <NewSessionTicketExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16361,13 +16361,13 @@ impl<'a, 'b, 'x> Continuation<NewSessionTicketExtensionCont0Input<'a, 'b, 'x>> f
                 let (extension_type, ext_len) = deps;
                 let extension_type = *extension_type;
                 let ext_len = *ext_len;
-                new_session_ticket_extension_extension_data(extension_type, ext_len)
+                new_session_ticket_extension_extension_data(ext_len, extension_type)
             }
             POrSType::S(deps) => {
                 let (extension_type, ext_len) = deps;
                 let extension_type = *extension_type;
                 let ext_len = *ext_len;
-                new_session_ticket_extension_extension_data(extension_type, ext_len)
+                new_session_ticket_extension_extension_data(ext_len, extension_type)
             }
         }
     }
@@ -16519,7 +16519,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NewSessionTicketExtensionsCombina
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NewSessionTicketExtensionsCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate14514213152276180162>, AndThen<bytes::Variable, Repeat<NewSessionTicketExtensionCombinator>>, NewSessionTicketExtensionsCont0>, NewSessionTicketExtensionsMapper>;
 
@@ -16586,14 +16586,14 @@ pub fn serialize_new_session_ticket_extensions<'a>(v: <NewSessionTicketExtension
         spec_new_session_ticket_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_new_session_ticket_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_new_session_ticket_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_new_session_ticket_extensions().spec_serialize(v@))
         },
 {
     let combinator = new_session_ticket_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn new_session_ticket_extensions_len<'a>(v: <NewSessionTicketExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16808,7 +16808,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NewSessionTicketCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NewSessionTicketCombinatorAlias = Mapped<NewSessionTicketCombinator4, NewSessionTicketMapper>;
 
@@ -16860,14 +16860,14 @@ pub fn serialize_new_session_ticket<'a>(v: <NewSessionTicketCombinator as Combin
         spec_new_session_ticket().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_new_session_ticket().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_new_session_ticket().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_new_session_ticket().spec_serialize(v@))
         },
 {
     let combinator = new_session_ticket();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn new_session_ticket_len<'a>(v: <NewSessionTicketCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17148,7 +17148,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EncryptedExtensionExtensionDataCo
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EncryptedExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<EncryptedExtensionExtensionDataCombinator8, EncryptedExtensionExtensionDataMapper>>;
 
@@ -17198,14 +17198,14 @@ pub fn serialize_encrypted_extension_extension_data<'a>(v: <EncryptedExtensionEx
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_encrypted_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_encrypted_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_encrypted_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
     let combinator = encrypted_extension_extension_data( ext_len, extension_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn encrypted_extension_extension_data_len<'a>(v: <EncryptedExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
@@ -17350,7 +17350,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EncryptedExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EncryptedExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, EncryptedExtensionCont1>, EncryptedExtensionExtensionDataCombinator, EncryptedExtensionCont0>, EncryptedExtensionMapper>;
 
@@ -17432,14 +17432,14 @@ pub fn serialize_encrypted_extension<'a>(v: <EncryptedExtensionCombinator as Com
         spec_encrypted_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_encrypted_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_encrypted_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_encrypted_extension().spec_serialize(v@))
         },
 {
     let combinator = encrypted_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn encrypted_extension_len<'a>(v: <EncryptedExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17644,7 +17644,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EncryptedExtensionsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EncryptedExtensionsCombinatorAlias = Mapped<Pair<U16Be, AndThen<bytes::Variable, Repeat<EncryptedExtensionCombinator>>, EncryptedExtensionsCont0>, EncryptedExtensionsMapper>;
 
@@ -17711,14 +17711,14 @@ pub fn serialize_encrypted_extensions<'a>(v: <EncryptedExtensionsCombinator as C
         spec_encrypted_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_encrypted_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_encrypted_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_encrypted_extensions().spec_serialize(v@))
         },
 {
     let combinator = encrypted_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn encrypted_extensions_len<'a>(v: <EncryptedExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17910,7 +17910,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque1FfffffCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque1FfffffCombinatorAlias = Mapped<Pair<Refined<U24Be, Predicate15036445817960576151>, bytes::Variable, Opaque1FfffffCont0>, Opaque1FfffffMapper>;
 
@@ -17977,14 +17977,14 @@ pub fn serialize_opaque_1_ffffff<'a>(v: <Opaque1FfffffCombinator as Combinator<'
         spec_opaque_1_ffffff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_1_ffffff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_1_ffffff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_1_ffffff().spec_serialize(v@))
         },
 {
     let combinator = opaque_1_ffffff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_1_ffffff_len<'a>(v: <Opaque1FfffffCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18082,7 +18082,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OcspResponseCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type OcspResponseCombinatorAlias = Opaque1FfffffCombinator;
 
@@ -18126,14 +18126,14 @@ pub fn serialize_ocsp_response<'a>(v: <OcspResponseCombinator as Combinator<'a, 
         spec_ocsp_response().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ocsp_response().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ocsp_response().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ocsp_response().spec_serialize(v@))
         },
 {
     let combinator = ocsp_response();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ocsp_response_len<'a>(v: <OcspResponseCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18282,7 +18282,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateStatusCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateStatusCombinatorAlias = Mapped<CertificateStatusCombinator1, CertificateStatusMapper>;
 
@@ -18334,14 +18334,14 @@ pub fn serialize_certificate_status<'a>(v: <CertificateStatusCombinator as Combi
         spec_certificate_status().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_status().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_status().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_status().spec_serialize(v@))
         },
 {
     let combinator = certificate_status();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_status_len<'a>(v: <CertificateStatusCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18526,7 +18526,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateExtensionExtensionData
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateExtensionExtensionDataCombinatorAlias = AndThen<bytes::Variable, Mapped<CertificateExtensionExtensionDataCombinator2, CertificateExtensionExtensionDataMapper>>;
 
@@ -18576,14 +18576,14 @@ pub fn serialize_certificate_extension_extension_data<'a>(v: <CertificateExtensi
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_extension_extension_data(ext_len@, extension_type@).spec_serialize(v@))
         },
 {
     let combinator = certificate_extension_extension_data( ext_len, extension_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn certificate_extension_extension_data_len<'a>(v: <CertificateExtensionExtensionDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16, extension_type: u16) -> (serialize_len: usize)
@@ -18728,7 +18728,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateExtensionCombinatorAlias = Mapped<Pair<Pair<ExtensionTypeCombinator, U16Be, CertificateExtensionCont1>, CertificateExtensionExtensionDataCombinator, CertificateExtensionCont0>, CertificateExtensionMapper>;
 
@@ -18810,14 +18810,14 @@ pub fn serialize_certificate_extension<'a>(v: <CertificateExtensionCombinator as
         spec_certificate_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_extension().spec_serialize(v@))
         },
 {
     let combinator = certificate_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_extension_len<'a>(v: <CertificateExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19022,7 +19022,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateExtensionsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateExtensionsCombinatorAlias = Mapped<Pair<U16Be, AndThen<bytes::Variable, Repeat<CertificateExtensionCombinator>>, CertificateExtensionsCont0>, CertificateExtensionsMapper>;
 
@@ -19089,14 +19089,14 @@ pub fn serialize_certificate_extensions<'a>(v: <CertificateExtensionsCombinator 
         spec_certificate_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_extensions().spec_serialize(v@))
         },
 {
     let combinator = certificate_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_extensions_len<'a>(v: <CertificateExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19275,7 +19275,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateEntryOpaqueCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateEntryOpaqueCombinatorAlias = Mapped<CertificateEntryOpaqueCombinator1, CertificateEntryOpaqueMapper>;
 
@@ -19327,14 +19327,14 @@ pub fn serialize_certificate_entry_opaque<'a>(v: <CertificateEntryOpaqueCombinat
         spec_certificate_entry_opaque().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_entry_opaque().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_entry_opaque().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_entry_opaque().spec_serialize(v@))
         },
 {
     let combinator = certificate_entry_opaque();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_entry_opaque_len<'a>(v: <CertificateEntryOpaqueCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19475,7 +19475,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateListCombinatorAlias = Mapped<Pair<U24Be, AndThen<bytes::Variable, Repeat<CertificateEntryOpaqueCombinator>>, CertificateListCont0>, CertificateListMapper>;
 
@@ -19542,14 +19542,14 @@ pub fn serialize_certificate_list<'a>(v: <CertificateListCombinator as Combinato
         spec_certificate_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_list().spec_serialize(v@))
         },
 {
     let combinator = certificate_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_list_len<'a>(v: <CertificateListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19728,7 +19728,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateCombinatorAlias = Mapped<CertificateCombinator1, CertificateMapper>;
 
@@ -19780,14 +19780,14 @@ pub fn serialize_certificate<'a>(v: <CertificateCombinator as Combinator<'a, &'a
         spec_certificate().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate().spec_serialize(v@))
         },
 {
     let combinator = certificate();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_len<'a>(v: <CertificateCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19928,7 +19928,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateRequestExtensionsCombi
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateRequestExtensionsCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate8195707947578446211>, AndThen<bytes::Variable, Repeat<CertificateRequestExtensionCombinator>>, CertificateRequestExtensionsCont0>, CertificateRequestExtensionsMapper>;
 
@@ -19995,14 +19995,14 @@ pub fn serialize_certificate_request_extensions<'a>(v: <CertificateRequestExtens
         spec_certificate_request_extensions().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_request_extensions().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_request_extensions().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_request_extensions().spec_serialize(v@))
         },
 {
     let combinator = certificate_request_extensions();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_request_extensions_len<'a>(v: <CertificateRequestExtensionsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20181,7 +20181,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateRequestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateRequestCombinatorAlias = Mapped<CertificateRequestCombinator1, CertificateRequestMapper>;
 
@@ -20233,14 +20233,14 @@ pub fn serialize_certificate_request<'a>(v: <CertificateRequestCombinator as Com
         spec_certificate_request().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_request().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_request().spec_serialize(v@))
         },
 {
     let combinator = certificate_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_request_len<'a>(v: <CertificateRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20388,7 +20388,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateVerifyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateVerifyCombinatorAlias = Mapped<CertificateVerifyCombinator1, CertificateVerifyMapper>;
 
@@ -20440,14 +20440,14 @@ pub fn serialize_certificate_verify<'a>(v: <CertificateVerifyCombinator as Combi
         spec_certificate_verify().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_verify().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_verify().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_verify().spec_serialize(v@))
         },
 {
     let combinator = certificate_verify();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn certificate_verify_len<'a>(v: <CertificateVerifyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20680,7 +20680,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FinishedCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FinishedCombinatorAlias = Mapped<FinishedCombinator5, FinishedMapper>;
 
@@ -20730,14 +20730,14 @@ pub fn serialize_finished<'a>(v: <FinishedCombinator as Combinator<'a, &'a [u8],
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_finished(size@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_finished(size@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_finished(size@).spec_serialize(v@))
         },
 {
     let combinator = finished( size );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn finished_len<'a>(v: <FinishedCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, size: u24) -> (serialize_len: usize)
@@ -20911,7 +20911,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for KeyUpdateRequestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type KeyUpdateRequestCombinatorAlias = TryMap<U8, KeyUpdateRequestMapper>;
 
@@ -20955,14 +20955,14 @@ pub fn serialize_key_update_request<'a>(v: <KeyUpdateRequestCombinator as Combin
         spec_key_update_request().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_key_update_request().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_key_update_request().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_key_update_request().spec_serialize(v@))
         },
 {
     let combinator = key_update_request();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn key_update_request_len<'a>(v: <KeyUpdateRequestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21100,7 +21100,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for KeyUpdateCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type KeyUpdateCombinatorAlias = Mapped<KeyUpdateRequestCombinator, KeyUpdateMapper>;
 
@@ -21152,14 +21152,14 @@ pub fn serialize_key_update<'a>(v: <KeyUpdateCombinator as Combinator<'a, &'a [u
         spec_key_update().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_key_update().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_key_update().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_key_update().spec_serialize(v@))
         },
 {
     let combinator = key_update();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn key_update_len<'a>(v: <KeyUpdateCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21456,7 +21456,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HandshakeMsgCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HandshakeMsgCombinatorAlias = AndThen<bytes::Variable, Mapped<HandshakeMsgCombinator9, HandshakeMsgMapper>>;
 
@@ -21506,14 +21506,14 @@ pub fn serialize_handshake_msg<'a>(v: <HandshakeMsgCombinator as Combinator<'a, 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_handshake_msg(length@, msg_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_handshake_msg(length@, msg_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_handshake_msg(length@, msg_type@).spec_serialize(v@))
         },
 {
     let combinator = handshake_msg( length, msg_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn handshake_msg_len<'a>(v: <HandshakeMsgCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, length: u24, msg_type: HandshakeType) -> (serialize_len: usize)
@@ -21658,7 +21658,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HandshakeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HandshakeCombinatorAlias = Mapped<Pair<Pair<HandshakeTypeCombinator, U24Be, HandshakeCont1>, HandshakeMsgCombinator, HandshakeCont0>, HandshakeMapper>;
 
@@ -21740,14 +21740,14 @@ pub fn serialize_handshake<'a>(v: <HandshakeCombinator as Combinator<'a, &'a [u8
         spec_handshake().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_handshake().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_handshake().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_handshake().spec_serialize(v@))
         },
 {
     let combinator = handshake();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn handshake_len<'a>(v: <HandshakeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21950,7 +21950,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ZeroByteCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ZeroByteCombinatorAlias = Mapped<Refined<U8, TagPred<u8>>, ZeroByteMapper>;
 
@@ -22002,14 +22002,14 @@ pub fn serialize_zero_byte<'a>(v: <ZeroByteCombinator as Combinator<'a, &'a [u8]
         spec_zero_byte().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_zero_byte().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_zero_byte().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_zero_byte().spec_serialize(v@))
         },
 {
     let combinator = zero_byte();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn zero_byte_len<'a>(v: <ZeroByteCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22150,7 +22150,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PaddingExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PaddingExtensionCombinatorAlias = Mapped<Pair<U16Be, AndThen<bytes::Variable, Repeat<ZeroByteCombinator>>, PaddingExtensionCont0>, PaddingExtensionMapper>;
 
@@ -22219,14 +22219,14 @@ pub fn serialize_padding_extension<'a>(v: <PaddingExtensionCombinator as Combina
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_padding_extension(ext_len@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_padding_extension(ext_len@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_padding_extension(ext_len@).spec_serialize(v@))
         },
 {
     let combinator = padding_extension( ext_len );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn padding_extension_len<'a>(v: <PaddingExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, ext_len: u16) -> (serialize_len: usize)
@@ -22410,7 +22410,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExtensionCombinatorAlias = Mapped<ExtensionCombinator1, ExtensionMapper>;
 
@@ -22462,14 +22462,14 @@ pub fn serialize_extension<'a>(v: <ExtensionCombinator as Combinator<'a, &'a [u8
         spec_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_extension().spec_serialize(v@))
         },
 {
     let combinator = extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn extension_len<'a>(v: <ExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22607,7 +22607,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ClientCertTypeServerExtensionComb
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ClientCertTypeServerExtensionCombinatorAlias = Mapped<CertificateTypeCombinator, ClientCertTypeServerExtensionMapper>;
 
@@ -22659,14 +22659,14 @@ pub fn serialize_client_cert_type_server_extension<'a>(v: <ClientCertTypeServerE
         spec_client_cert_type_server_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_client_cert_type_server_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_client_cert_type_server_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_client_cert_type_server_extension().spec_serialize(v@))
         },
 {
     let combinator = client_cert_type_server_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn client_cert_type_server_extension_len<'a>(v: <ClientCertTypeServerExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22860,7 +22860,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ContentTypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ContentTypeCombinatorAlias = TryMap<U8, ContentTypeMapper>;
 
@@ -22904,14 +22904,14 @@ pub fn serialize_content_type<'a>(v: <ContentTypeCombinator as Combinator<'a, &'
         spec_content_type().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_content_type().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_content_type().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_content_type().spec_serialize(v@))
         },
 {
     let combinator = content_type();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn content_type_len<'a>(v: <ContentTypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23071,7 +23071,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TlsPlaintextCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TlsPlaintextCombinatorAlias = Mapped<TlsPlaintextCombinator2, TlsPlaintextMapper>;
 
@@ -23123,14 +23123,14 @@ pub fn serialize_tls_plaintext<'a>(v: <TlsPlaintextCombinator as Combinator<'a, 
         spec_tls_plaintext().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tls_plaintext().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tls_plaintext().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tls_plaintext().spec_serialize(v@))
         },
 {
     let combinator = tls_plaintext();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tls_plaintext_len<'a>(v: <TlsPlaintextCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23478,7 +23478,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AlertDescriptionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AlertDescriptionCombinatorAlias = TryMap<U8, AlertDescriptionMapper>;
 
@@ -23522,14 +23522,14 @@ pub fn serialize_alert_description<'a>(v: <AlertDescriptionCombinator as Combina
         spec_alert_description().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_alert_description().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_alert_description().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_alert_description().spec_serialize(v@))
         },
 {
     let combinator = alert_description();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn alert_description_len<'a>(v: <AlertDescriptionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23596,7 +23596,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SrtpProtectionProfileCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SrtpProtectionProfileCombinatorAlias = bytes::Fixed<2>;
 
@@ -23640,14 +23640,14 @@ pub fn serialize_srtp_protection_profile<'a>(v: <SrtpProtectionProfileCombinator
         spec_srtp_protection_profile().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_srtp_protection_profile().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_srtp_protection_profile().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_srtp_protection_profile().spec_serialize(v@))
         },
 {
     let combinator = srtp_protection_profile();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn srtp_protection_profile_len<'a>(v: <SrtpProtectionProfileCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23788,7 +23788,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SrtpProtectionProfilesCombinator 
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SrtpProtectionProfilesCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate8195707947578446211>, AndThen<bytes::Variable, Repeat<SrtpProtectionProfileCombinator>>, SrtpProtectionProfilesCont0>, SrtpProtectionProfilesMapper>;
 
@@ -23855,14 +23855,14 @@ pub fn serialize_srtp_protection_profiles<'a>(v: <SrtpProtectionProfilesCombinat
         spec_srtp_protection_profiles().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_srtp_protection_profiles().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_srtp_protection_profiles().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_srtp_protection_profiles().spec_serialize(v@))
         },
 {
     let combinator = srtp_protection_profiles();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn srtp_protection_profiles_len<'a>(v: <SrtpProtectionProfilesCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24041,7 +24041,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for UseSrtpDataCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type UseSrtpDataCombinatorAlias = Mapped<UseSrtpDataCombinator1, UseSrtpDataMapper>;
 
@@ -24093,14 +24093,14 @@ pub fn serialize_use_srtp_data<'a>(v: <UseSrtpDataCombinator as Combinator<'a, &
         spec_use_srtp_data().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_use_srtp_data().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_use_srtp_data().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_use_srtp_data().spec_serialize(v@))
         },
 {
     let combinator = use_srtp_data();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn use_srtp_data_len<'a>(v: <UseSrtpDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24167,7 +24167,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FinishedOpaqueCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FinishedOpaqueCombinatorAlias = bytes::Variable;
 
@@ -24213,14 +24213,14 @@ pub fn serialize_finished_opaque<'a>(v: <FinishedOpaqueCombinator as Combinator<
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_finished_opaque(digest_size@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_finished_opaque(digest_size@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_finished_opaque(digest_size@).spec_serialize(v@))
         },
 {
     let combinator = finished_opaque( digest_size );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn finished_opaque_len<'a>(v: <FinishedOpaqueCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, digest_size: u24) -> (serialize_len: usize)
@@ -24381,7 +24381,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque2FfffCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque2FfffCombinatorAlias = Mapped<Pair<Refined<U16Be, Predicate3016150102856496288>, bytes::Variable, Opaque2FfffCont0>, Opaque2FfffMapper>;
 
@@ -24448,14 +24448,14 @@ pub fn serialize_opaque_2_ffff<'a>(v: <Opaque2FfffCombinator as Combinator<'a, &
         spec_opaque_2_ffff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_2_ffff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_2_ffff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_2_ffff().spec_serialize(v@))
         },
 {
     let combinator = opaque_2_ffff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_2_ffff_len<'a>(v: <Opaque2FfffCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24634,7 +24634,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for AlertCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type AlertCombinatorAlias = Mapped<AlertCombinator1, AlertMapper>;
 
@@ -24686,14 +24686,14 @@ pub fn serialize_alert<'a>(v: <AlertCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_alert().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_alert().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_alert().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_alert().spec_serialize(v@))
         },
 {
     let combinator = alert();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn alert_len<'a>(v: <AlertCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24831,7 +24831,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ServerCertTypeServerExtensionComb
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ServerCertTypeServerExtensionCombinatorAlias = Mapped<CertificateTypeCombinator, ServerCertTypeServerExtensionMapper>;
 
@@ -24883,14 +24883,14 @@ pub fn serialize_server_cert_type_server_extension<'a>(v: <ServerCertTypeServerE
         spec_server_cert_type_server_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_server_cert_type_server_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_server_cert_type_server_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_server_cert_type_server_extension().spec_serialize(v@))
         },
 {
     let combinator = server_cert_type_server_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn server_cert_type_server_extension_len<'a>(v: <ServerCertTypeServerExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24957,7 +24957,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for UnknownExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type UnknownExtensionCombinatorAlias = Opaque0FfffCombinator;
 
@@ -25001,14 +25001,14 @@ pub fn serialize_unknown_extension<'a>(v: <UnknownExtensionCombinator as Combina
         spec_unknown_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_unknown_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_unknown_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_unknown_extension().spec_serialize(v@))
         },
 {
     let combinator = unknown_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn unknown_extension_len<'a>(v: <UnknownExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25087,7 +25087,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DigestSizeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DigestSizeCombinatorAlias = U24Be;
 
@@ -25131,14 +25131,14 @@ pub fn serialize_digest_size<'a>(v: <DigestSizeCombinator as Combinator<'a, &'a 
         spec_digest_size().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_digest_size().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_digest_size().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_digest_size().spec_serialize(v@))
         },
 {
     let combinator = digest_size();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn digest_size_len<'a>(v: <DigestSizeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25276,7 +25276,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for HeartbeatExtensionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type HeartbeatExtensionCombinatorAlias = Mapped<HeartbeatModeCombinator, HeartbeatExtensionMapper>;
 
@@ -25328,14 +25328,14 @@ pub fn serialize_heartbeat_extension<'a>(v: <HeartbeatExtensionCombinator as Com
         spec_heartbeat_extension().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_heartbeat_extension().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_heartbeat_extension().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_heartbeat_extension().spec_serialize(v@))
         },
 {
     let combinator = heartbeat_extension();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn heartbeat_extension_len<'a>(v: <HeartbeatExtensionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25408,7 +25408,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EcPointFormatCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EcPointFormatCombinatorAlias = U8;
 
@@ -25452,14 +25452,14 @@ pub fn serialize_ec_point_format<'a>(v: <EcPointFormatCombinator as Combinator<'
         spec_ec_point_format().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ec_point_format().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ec_point_format().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ec_point_format().spec_serialize(v@))
         },
 {
     let combinator = ec_point_format();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ec_point_format_len<'a>(v: <EcPointFormatCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25600,7 +25600,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EcPointFormatListCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EcPointFormatListCombinatorAlias = Mapped<Pair<Refined<U8, Predicate13984338198318635021>, AndThen<bytes::Variable, Repeat<EcPointFormatCombinator>>, EcPointFormatListCont0>, EcPointFormatListMapper>;
 
@@ -25667,14 +25667,14 @@ pub fn serialize_ec_point_format_list<'a>(v: <EcPointFormatListCombinator as Com
         spec_ec_point_format_list().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ec_point_format_list().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ec_point_format_list().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ec_point_format_list().spec_serialize(v@))
         },
 {
     let combinator = ec_point_format_list();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn ec_point_format_list_len<'a>(v: <EcPointFormatListCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25874,7 +25874,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateEntryDataCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateEntryDataCombinatorAlias = Mapped<CertificateEntryDataCombinator1, CertificateEntryDataMapper>;
 
@@ -25924,14 +25924,14 @@ pub fn serialize_certificate_entry_data<'a>(v: <CertificateEntryDataCombinator a
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_entry_data(cert_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_entry_data(cert_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_entry_data(cert_type@).spec_serialize(v@))
         },
 {
     let combinator = certificate_entry_data( cert_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn certificate_entry_data_len<'a>(v: <CertificateEntryDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, cert_type: u8) -> (serialize_len: usize)
@@ -26080,7 +26080,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CertificateEntryCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CertificateEntryCombinatorAlias = Mapped<CertificateEntryCombinator1, CertificateEntryMapper>;
 
@@ -26138,14 +26138,14 @@ pub fn serialize_certificate_entry<'a>(v: <CertificateEntryCombinator as Combina
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_certificate_entry(cert_type@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_certificate_entry(cert_type@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_certificate_entry(cert_type@).spec_serialize(v@))
         },
 {
     let combinator = certificate_entry( cert_type );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn certificate_entry_len<'a>(v: <CertificateEntryCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, cert_type: u8) -> (serialize_len: usize)
@@ -26306,7 +26306,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TlsCiphertextCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TlsCiphertextCombinatorAlias = Mapped<TlsCiphertextCombinator2, TlsCiphertextMapper>;
 
@@ -26358,14 +26358,14 @@ pub fn serialize_tls_ciphertext<'a>(v: <TlsCiphertextCombinator as Combinator<'a
         spec_tls_ciphertext().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tls_ciphertext().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tls_ciphertext().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tls_ciphertext().spec_serialize(v@))
         },
 {
     let combinator = tls_ciphertext();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tls_ciphertext_len<'a>(v: <TlsCiphertextCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -26506,7 +26506,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Opaque0FfffffCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Opaque0FfffffCombinatorAlias = Mapped<Pair<U24Be, bytes::Variable, Opaque0FfffffCont0>, Opaque0FfffffMapper>;
 
@@ -26573,14 +26573,14 @@ pub fn serialize_opaque_0_ffffff<'a>(v: <Opaque0FfffffCombinator as Combinator<'
         spec_opaque_0_ffffff().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_opaque_0_ffffff().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_opaque_0_ffffff().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_opaque_0_ffffff().spec_serialize(v@))
         },
 {
     let combinator = opaque_0_ffffff();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn opaque_0_ffffff_len<'a>(v: <Opaque0FfffffCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-dsl/wasm/src/vest_wasm.rs
+++ b/vest-dsl/wasm/src/vest_wasm.rs
@@ -28,7 +28,7 @@ macro_rules! impl_wrapper_combinator {
                 fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
                 { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::parse(&self.0, s) }
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+                { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
             }
         } // verus!
     };
@@ -86,7 +86,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EmptyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EmptyCombinatorAlias = bytes::Fixed<0>;
 
@@ -130,14 +130,14 @@ pub fn serialize_empty<'a>(v: <EmptyCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_empty().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_empty().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_empty().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_empty().spec_serialize(v@))
         },
 {
     let combinator = empty();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn empty_len<'a>(v: <EmptyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -324,7 +324,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NumtypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NumtypeCombinatorAlias = TryMap<U8, NumtypeMapper>;
 
@@ -368,14 +368,14 @@ pub fn serialize_numtype<'a>(v: <NumtypeCombinator as Combinator<'a, &'a [u8], V
         spec_numtype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_numtype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_numtype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_numtype().spec_serialize(v@))
         },
 {
     let combinator = numtype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn numtype_len<'a>(v: <NumtypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -541,7 +541,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for VectypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type VectypeCombinatorAlias = TryMap<U8, VectypeMapper>;
 
@@ -585,14 +585,14 @@ pub fn serialize_vectype<'a>(v: <VectypeCombinator as Combinator<'a, &'a [u8], V
         spec_vectype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_vectype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_vectype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_vectype().spec_serialize(v@))
         },
 {
     let combinator = vectype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn vectype_len<'a>(v: <VectypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -765,7 +765,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ReftypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ReftypeCombinatorAlias = TryMap<U8, ReftypeMapper>;
 
@@ -809,14 +809,14 @@ pub fn serialize_reftype<'a>(v: <ReftypeCombinator as Combinator<'a, &'a [u8], V
         spec_reftype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_reftype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_reftype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_reftype().spec_serialize(v@))
         },
 {
     let combinator = reftype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn reftype_len<'a>(v: <ReftypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1021,7 +1021,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ValtypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ValtypeCombinatorAlias = Mapped<ValtypeCombinator2, ValtypeMapper>;
 
@@ -1065,14 +1065,14 @@ pub fn serialize_valtype<'a>(v: <ValtypeCombinator as Combinator<'a, &'a [u8], V
         spec_valtype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_valtype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_valtype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_valtype().spec_serialize(v@))
         },
 {
     let combinator = valtype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn valtype_len<'a>(v: <ValtypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1213,7 +1213,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for SelectTCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type SelectTCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<ValtypeCombinator>, SelectTCont0>, SelectTMapper>;
 
@@ -1280,14 +1280,14 @@ pub fn serialize_select_t<'a>(v: <SelectTCombinator as Combinator<'a, &'a [u8], 
         spec_select_t().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_select_t().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_select_t().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_select_t().spec_serialize(v@))
         },
 {
     let combinator = select_t();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn select_t_len<'a>(v: <SelectTCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1491,7 +1491,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MutTCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MutTCombinatorAlias = TryMap<U8, MutTMapper>;
 
@@ -1535,14 +1535,14 @@ pub fn serialize_mut_t<'a>(v: <MutTCombinator as Combinator<'a, &'a [u8], Vec<u8
         spec_mut_t().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mut_t().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mut_t().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mut_t().spec_serialize(v@))
         },
 {
     let combinator = mut_t();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mut_t_len<'a>(v: <MutTCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1609,7 +1609,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableidxCombinatorAlias = UnsignedLEB128;
 
@@ -1653,14 +1653,14 @@ pub fn serialize_tableidx<'a>(v: <TableidxCombinator as Combinator<'a, &'a [u8],
         spec_tableidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tableidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tableidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tableidx().spec_serialize(v@))
         },
 {
     let combinator = tableidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tableidx_len<'a>(v: <TableidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -1727,7 +1727,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableFillCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableFillCombinatorAlias = TableidxCombinator;
 
@@ -1771,14 +1771,14 @@ pub fn serialize_table_fill<'a>(v: <TableFillCombinator as Combinator<'a, &'a [u
         spec_table_fill().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_table_fill().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_table_fill().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_table_fill().spec_serialize(v@))
         },
 {
     let combinator = table_fill();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn table_fill_len<'a>(v: <TableFillCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2215,7 +2215,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrBytecodeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrBytecodeCombinatorAlias = U8;
 
@@ -2259,14 +2259,14 @@ pub fn serialize_instr_bytecode<'a>(v: <InstrBytecodeCombinator as Combinator<'a
         spec_instr_bytecode().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_bytecode().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_bytecode().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_bytecode().spec_serialize(v@))
         },
 {
     let combinator = instr_bytecode();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn instr_bytecode_len<'a>(v: <InstrBytecodeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2333,7 +2333,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LocalidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LocalidxCombinatorAlias = UnsignedLEB128;
 
@@ -2377,14 +2377,14 @@ pub fn serialize_localidx<'a>(v: <LocalidxCombinator as Combinator<'a, &'a [u8],
         spec_localidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_localidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_localidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_localidx().spec_serialize(v@))
         },
 {
     let combinator = localidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn localidx_len<'a>(v: <LocalidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2451,7 +2451,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GlobalidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GlobalidxCombinatorAlias = UnsignedLEB128;
 
@@ -2495,14 +2495,14 @@ pub fn serialize_globalidx<'a>(v: <GlobalidxCombinator as Combinator<'a, &'a [u8
         spec_globalidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_globalidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_globalidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_globalidx().spec_serialize(v@))
         },
 {
     let combinator = globalidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn globalidx_len<'a>(v: <GlobalidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2719,7 +2719,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrVariableCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrVariableCombinatorAlias = Mapped<InstrVariableCombinator4, InstrVariableMapper>;
 
@@ -2769,14 +2769,14 @@ pub fn serialize_instr_variable<'a>(v: <InstrVariableCombinator as Combinator<'a
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_variable(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_variable(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_variable(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_variable( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_variable_len<'a>(v: <InstrVariableCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -2844,7 +2844,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LabelidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LabelidxCombinatorAlias = UnsignedLEB128;
 
@@ -2888,14 +2888,14 @@ pub fn serialize_labelidx<'a>(v: <LabelidxCombinator as Combinator<'a, &'a [u8],
         spec_labelidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_labelidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_labelidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_labelidx().spec_serialize(v@))
         },
 {
     let combinator = labelidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn labelidx_len<'a>(v: <LabelidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -2962,7 +2962,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FuncidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FuncidxCombinatorAlias = UnsignedLEB128;
 
@@ -3006,14 +3006,14 @@ pub fn serialize_funcidx<'a>(v: <FuncidxCombinator as Combinator<'a, &'a [u8], V
         spec_funcidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_funcidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_funcidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_funcidx().spec_serialize(v@))
         },
 {
     let combinator = funcidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn funcidx_len<'a>(v: <FuncidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3154,7 +3154,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LabelidxVecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LabelidxVecCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<LabelidxCombinator>, LabelidxVecCont0>, LabelidxVecMapper>;
 
@@ -3221,14 +3221,14 @@ pub fn serialize_labelidx_vec<'a>(v: <LabelidxVecCombinator as Combinator<'a, &'
         spec_labelidx_vec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_labelidx_vec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_labelidx_vec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_labelidx_vec().spec_serialize(v@))
         },
 {
     let combinator = labelidx_vec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn labelidx_vec_len<'a>(v: <LabelidxVecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3407,7 +3407,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BrTableCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type BrTableCombinatorAlias = Mapped<BrTableCombinator1, BrTableMapper>;
 
@@ -3459,14 +3459,14 @@ pub fn serialize_br_table<'a>(v: <BrTableCombinator as Combinator<'a, &'a [u8], 
         spec_br_table().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_br_table().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_br_table().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_br_table().spec_serialize(v@))
         },
 {
     let combinator = br_table();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn br_table_len<'a>(v: <BrTableCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3533,7 +3533,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TypeidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TypeidxCombinatorAlias = UnsignedLEB128;
 
@@ -3577,14 +3577,14 @@ pub fn serialize_typeidx<'a>(v: <TypeidxCombinator as Combinator<'a, &'a [u8], V
         spec_typeidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_typeidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_typeidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_typeidx().spec_serialize(v@))
         },
 {
     let combinator = typeidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn typeidx_len<'a>(v: <TypeidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -3732,7 +3732,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CallIndirectCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CallIndirectCombinatorAlias = Mapped<CallIndirectCombinator1, CallIndirectMapper>;
 
@@ -3784,14 +3784,14 @@ pub fn serialize_call_indirect<'a>(v: <CallIndirectCombinator as Combinator<'a, 
         spec_call_indirect().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_call_indirect().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_call_indirect().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_call_indirect().spec_serialize(v@))
         },
 {
     let combinator = call_indirect();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn call_indirect_len<'a>(v: <CallIndirectCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4040,7 +4040,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrControl2Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrControl2CombinatorAlias = Mapped<InstrControl2Combinator6, InstrControl2Mapper>;
 
@@ -4090,14 +4090,14 @@ pub fn serialize_instr_control2<'a>(v: <InstrControl2Combinator as Combinator<'a
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_control2(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_control2(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_control2(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_control2( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_control2_len<'a>(v: <InstrControl2Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -4266,7 +4266,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for EmptyBlockCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type EmptyBlockCombinatorAlias = Mapped<EmptyBlockCombinator1, EmptyBlockMapper>;
 
@@ -4318,14 +4318,14 @@ pub fn serialize_empty_block<'a>(v: <EmptyBlockCombinator as Combinator<'a, &'a 
         spec_empty_block().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_empty_block().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_empty_block().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_empty_block().spec_serialize(v@))
         },
 {
     let combinator = empty_block();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn empty_block_len<'a>(v: <EmptyBlockCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4493,7 +4493,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ValtypeBlockCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ValtypeBlockCombinatorAlias = Mapped<ValtypeBlockCombinator1, ValtypeBlockMapper>;
 
@@ -4545,14 +4545,14 @@ pub fn serialize_valtype_block<'a>(v: <ValtypeBlockCombinator as Combinator<'a, 
         spec_valtype_block().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_valtype_block().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_valtype_block().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_valtype_block().spec_serialize(v@))
         },
 {
     let combinator = valtype_block();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn valtype_block_len<'a>(v: <ValtypeBlockCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4720,7 +4720,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TypeidxBlockCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TypeidxBlockCombinatorAlias = Mapped<TypeidxBlockCombinator1, TypeidxBlockMapper>;
 
@@ -4772,14 +4772,14 @@ pub fn serialize_typeidx_block<'a>(v: <TypeidxBlockCombinator as Combinator<'a, 
         spec_typeidx_block().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_typeidx_block().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_typeidx_block().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_typeidx_block().spec_serialize(v@))
         },
 {
     let combinator = typeidx_block();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn typeidx_block_len<'a>(v: <TypeidxBlockCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -4984,7 +4984,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BlocktypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type BlocktypeCombinatorAlias = Mapped<BlocktypeCombinator2, BlocktypeMapper>;
 
@@ -5028,14 +5028,14 @@ pub fn serialize_blocktype<'a>(v: <BlocktypeCombinator as Combinator<'a, &'a [u8
         spec_blocktype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_blocktype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_blocktype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_blocktype().spec_serialize(v@))
         },
 {
     let combinator = blocktype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn blocktype_len<'a>(v: <BlocktypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5268,7 +5268,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrControl1Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrControl1CombinatorAlias = Mapped<InstrControl1Combinator5, InstrControl1Mapper>;
 
@@ -5318,14 +5318,14 @@ pub fn serialize_instr_control1<'a>(v: <InstrControl1Combinator as Combinator<'a
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_control1(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_control1(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_control1(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_control1( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_control1_len<'a>(v: <InstrControl1Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -5474,7 +5474,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemargCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemargCombinatorAlias = Mapped<MemargCombinator1, MemargMapper>;
 
@@ -5526,14 +5526,14 @@ pub fn serialize_memarg<'a>(v: <MemargCombinator as Combinator<'a, &'a [u8], Vec
         spec_memarg().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memarg().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memarg().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memarg().spec_serialize(v@))
         },
 {
     let combinator = memarg();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memarg_len<'a>(v: <MemargCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5672,7 +5672,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ByteZeroCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ByteZeroCombinatorAlias = Mapped<Refined<U8, TagPred<u8>>, ByteZeroMapper>;
 
@@ -5724,14 +5724,14 @@ pub fn serialize_byte_zero<'a>(v: <ByteZeroCombinator as Combinator<'a, &'a [u8]
         spec_byte_zero().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_byte_zero().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_byte_zero().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_byte_zero().spec_serialize(v@))
         },
 {
     let combinator = byte_zero();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn byte_zero_len<'a>(v: <ByteZeroCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -5980,7 +5980,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrMemoryCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrMemoryCombinatorAlias = Mapped<InstrMemoryCombinator6, InstrMemoryMapper>;
 
@@ -6030,14 +6030,14 @@ pub fn serialize_instr_memory<'a>(v: <InstrMemoryCombinator as Combinator<'a, &'
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_memory(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_memory(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_memory(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_memory( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_memory_len<'a>(v: <InstrMemoryCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -6223,7 +6223,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrReferenceCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrReferenceCombinatorAlias = Mapped<InstrReferenceCombinator2, InstrReferenceMapper>;
 
@@ -6273,14 +6273,14 @@ pub fn serialize_instr_reference<'a>(v: <InstrReferenceCombinator as Combinator<
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_reference(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_reference(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_reference(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_reference( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_reference_len<'a>(v: <InstrReferenceCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -6466,7 +6466,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrParametricCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrParametricCombinatorAlias = Mapped<InstrParametricCombinator2, InstrParametricMapper>;
 
@@ -6516,14 +6516,14 @@ pub fn serialize_instr_parametric<'a>(v: <InstrParametricCombinator as Combinato
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_parametric(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_parametric(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_parametric(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_parametric( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_parametric_len<'a>(v: <InstrParametricCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -6693,7 +6693,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrTableCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrTableCombinatorAlias = Mapped<InstrTableCombinator1, InstrTableMapper>;
 
@@ -6743,14 +6743,14 @@ pub fn serialize_instr_table<'a>(v: <InstrTableCombinator as Combinator<'a, &'a 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_table(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_table(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_table(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_table( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_table_len<'a>(v: <InstrTableCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -6818,7 +6818,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for F32Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type F32CombinatorAlias = bytes::Fixed<4>;
 
@@ -6862,14 +6862,14 @@ pub fn serialize_f32<'a>(v: <F32Combinator as Combinator<'a, &'a [u8], Vec<u8>>>
         spec_f32().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_f32().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_f32().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_f32().spec_serialize(v@))
         },
 {
     let combinator = f32();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn f32_len<'a>(v: <F32Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -6936,7 +6936,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for F64Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type F64CombinatorAlias = bytes::Fixed<8>;
 
@@ -6980,14 +6980,14 @@ pub fn serialize_f64<'a>(v: <F64Combinator as Combinator<'a, &'a [u8], Vec<u8>>>
         spec_f64().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_f64().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_f64().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_f64().spec_serialize(v@))
         },
 {
     let combinator = f64();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn f64_len<'a>(v: <F64Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7204,7 +7204,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrNumericCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrNumericCombinatorAlias = Mapped<InstrNumericCombinator4, InstrNumericMapper>;
 
@@ -7254,14 +7254,14 @@ pub fn serialize_instr_numeric<'a>(v: <InstrNumericCombinator as Combinator<'a, 
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_numeric(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_numeric(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_numeric(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_numeric( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_numeric_len<'a>(v: <InstrNumericCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -7329,7 +7329,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ElemidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ElemidxCombinatorAlias = UnsignedLEB128;
 
@@ -7373,14 +7373,14 @@ pub fn serialize_elemidx<'a>(v: <ElemidxCombinator as Combinator<'a, &'a [u8], V
         spec_elemidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_elemidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_elemidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_elemidx().spec_serialize(v@))
         },
 {
     let combinator = elemidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn elemidx_len<'a>(v: <ElemidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7528,7 +7528,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableInitCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableInitCombinatorAlias = Mapped<TableInitCombinator1, TableInitMapper>;
 
@@ -7580,14 +7580,14 @@ pub fn serialize_table_init<'a>(v: <TableInitCombinator as Combinator<'a, &'a [u
         spec_table_init().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_table_init().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_table_init().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_table_init().spec_serialize(v@))
         },
 {
     let combinator = table_init();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn table_init_len<'a>(v: <TableInitCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7654,7 +7654,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ElemDropCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ElemDropCombinatorAlias = ElemidxCombinator;
 
@@ -7698,14 +7698,14 @@ pub fn serialize_elem_drop<'a>(v: <ElemDropCombinator as Combinator<'a, &'a [u8]
         spec_elem_drop().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_elem_drop().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_elem_drop().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_elem_drop().spec_serialize(v@))
         },
 {
     let combinator = elem_drop();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn elem_drop_len<'a>(v: <ElemDropCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7853,7 +7853,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableCopyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableCopyCombinatorAlias = Mapped<TableCopyCombinator1, TableCopyMapper>;
 
@@ -7905,14 +7905,14 @@ pub fn serialize_table_copy<'a>(v: <TableCopyCombinator as Combinator<'a, &'a [u
         spec_table_copy().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_table_copy().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_table_copy().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_table_copy().spec_serialize(v@))
         },
 {
     let combinator = table_copy();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn table_copy_len<'a>(v: <TableCopyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -7979,7 +7979,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableGrowCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableGrowCombinatorAlias = TableidxCombinator;
 
@@ -8023,14 +8023,14 @@ pub fn serialize_table_grow<'a>(v: <TableGrowCombinator as Combinator<'a, &'a [u
         spec_table_grow().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_table_grow().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_table_grow().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_table_grow().spec_serialize(v@))
         },
 {
     let combinator = table_grow();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn table_grow_len<'a>(v: <TableGrowCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8097,7 +8097,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableSizeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableSizeCombinatorAlias = TableidxCombinator;
 
@@ -8141,14 +8141,14 @@ pub fn serialize_table_size<'a>(v: <TableSizeCombinator as Combinator<'a, &'a [u
         spec_table_size().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_table_size().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_table_size().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_table_size().spec_serialize(v@))
         },
 {
     let combinator = table_size();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn table_size_len<'a>(v: <TableSizeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8215,7 +8215,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DataidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DataidxCombinatorAlias = UnsignedLEB128;
 
@@ -8259,14 +8259,14 @@ pub fn serialize_dataidx<'a>(v: <DataidxCombinator as Combinator<'a, &'a [u8], V
         spec_dataidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_dataidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_dataidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_dataidx().spec_serialize(v@))
         },
 {
     let combinator = dataidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn dataidx_len<'a>(v: <DataidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8336,7 +8336,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemoryInitCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemoryInitCombinatorAlias = Terminated<DataidxCombinator, Tag<U8, u8>>;
 
@@ -8380,14 +8380,14 @@ pub fn serialize_memory_init<'a>(v: <MemoryInitCombinator as Combinator<'a, &'a 
         spec_memory_init().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memory_init().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memory_init().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memory_init().spec_serialize(v@))
         },
 {
     let combinator = memory_init();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memory_init_len<'a>(v: <MemoryInitCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8454,7 +8454,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DataDropCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DataDropCombinatorAlias = DataidxCombinator;
 
@@ -8498,14 +8498,14 @@ pub fn serialize_data_drop<'a>(v: <DataDropCombinator as Combinator<'a, &'a [u8]
         spec_data_drop().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_data_drop().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_data_drop().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_data_drop().spec_serialize(v@))
         },
 {
     let combinator = data_drop();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn data_drop_len<'a>(v: <DataDropCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8650,7 +8650,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemoryCopyCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemoryCopyCombinatorAlias = Mapped<Refined<bytes::Fixed<2>, TagPred<[u8; 2]>>, MemoryCopyMapper>;
 
@@ -8702,14 +8702,14 @@ pub fn serialize_memory_copy<'a>(v: <MemoryCopyCombinator as Combinator<'a, &'a 
         spec_memory_copy().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memory_copy().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memory_copy().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memory_copy().spec_serialize(v@))
         },
 {
     let combinator = memory_copy();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memory_copy_len<'a>(v: <MemoryCopyCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -8848,7 +8848,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemoryFillCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemoryFillCombinatorAlias = Mapped<Refined<U8, TagPred<u8>>, MemoryFillMapper>;
 
@@ -8900,14 +8900,14 @@ pub fn serialize_memory_fill<'a>(v: <MemoryFillCombinator as Combinator<'a, &'a 
         spec_memory_fill().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memory_fill().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memory_fill().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memory_fill().spec_serialize(v@))
         },
 {
     let combinator = memory_fill();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memory_fill_len<'a>(v: <MemoryFillCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9220,7 +9220,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrWithFcRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrWithFcRestCombinatorAlias = Mapped<InstrWithFcRestCombinator10, InstrWithFcRestMapper>;
 
@@ -9266,14 +9266,14 @@ pub fn serialize_instr_with_fc_rest<'a>(v: <InstrWithFcRestCombinator as Combina
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_with_fc_rest(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_with_fc_rest(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_with_fc_rest(tag@).spec_serialize(v@))
         },
 {
     let combinator = instr_with_fc_rest( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_with_fc_rest_len<'a>(v: <InstrWithFcRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: u64) -> (serialize_len: usize)
@@ -9414,7 +9414,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrWithFcCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrWithFcCombinatorAlias = Mapped<Pair<UnsignedLEB128, InstrWithFcRestCombinator, InstrWithFcCont0>, InstrWithFcMapper>;
 
@@ -9481,14 +9481,14 @@ pub fn serialize_instr_with_fc<'a>(v: <InstrWithFcCombinator as Combinator<'a, &
         spec_instr_with_fc().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_with_fc().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_with_fc().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_with_fc().spec_serialize(v@))
         },
 {
     let combinator = instr_with_fc();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn instr_with_fc_len<'a>(v: <InstrWithFcCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9586,7 +9586,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LaneidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LaneidxCombinatorAlias = U8;
 
@@ -9630,14 +9630,14 @@ pub fn serialize_laneidx<'a>(v: <LaneidxCombinator as Combinator<'a, &'a [u8], V
         spec_laneidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_laneidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_laneidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_laneidx().spec_serialize(v@))
         },
 {
     let combinator = laneidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn laneidx_len<'a>(v: <LaneidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9785,7 +9785,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for V128LaneCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type V128LaneCombinatorAlias = Mapped<V128LaneCombinator1, V128LaneMapper>;
 
@@ -9837,14 +9837,14 @@ pub fn serialize_v128_lane<'a>(v: <V128LaneCombinator as Combinator<'a, &'a [u8]
         spec_v128_lane().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_v128_lane().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_v128_lane().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_v128_lane().spec_serialize(v@))
         },
 {
     let combinator = v128_lane();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn v128_lane_len<'a>(v: <V128LaneCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -9911,7 +9911,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for V128ConstCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type V128ConstCombinatorAlias = bytes::Fixed<16>;
 
@@ -9955,14 +9955,14 @@ pub fn serialize_v128_const<'a>(v: <V128ConstCombinator as Combinator<'a, &'a [u
         spec_v128_const().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_v128_const().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_v128_const().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_v128_const().spec_serialize(v@))
         },
 {
     let combinator = v128_const();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn v128_const_len<'a>(v: <V128ConstCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10029,7 +10029,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ShuffleCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ShuffleCombinatorAlias = RepeatN<LaneidxCombinator>;
 
@@ -10073,14 +10073,14 @@ pub fn serialize_shuffle<'a>(v: <ShuffleCombinator as Combinator<'a, &'a [u8], V
         spec_shuffle().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_shuffle().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_shuffle().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_shuffle().spec_serialize(v@))
         },
 {
     let combinator = shuffle();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn shuffle_len<'a>(v: <ShuffleCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10345,7 +10345,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrWithFdRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrWithFdRestCombinatorAlias = Mapped<InstrWithFdRestCombinator7, InstrWithFdRestMapper>;
 
@@ -10391,14 +10391,14 @@ pub fn serialize_instr_with_fd_rest<'a>(v: <InstrWithFdRestCombinator as Combina
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_with_fd_rest(tag@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_with_fd_rest(tag@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_with_fd_rest(tag@).spec_serialize(v@))
         },
 {
     let combinator = instr_with_fd_rest( tag );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_with_fd_rest_len<'a>(v: <InstrWithFdRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, tag: u64) -> (serialize_len: usize)
@@ -10539,7 +10539,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrWithFdCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrWithFdCombinatorAlias = Mapped<Pair<UnsignedLEB128, InstrWithFdRestCombinator, InstrWithFdCont0>, InstrWithFdMapper>;
 
@@ -10606,14 +10606,14 @@ pub fn serialize_instr_with_fd<'a>(v: <InstrWithFdCombinator as Combinator<'a, &
         spec_instr_with_fd().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_with_fd().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_with_fd().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_with_fd().spec_serialize(v@))
         },
 {
     let combinator = instr_with_fd();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn instr_with_fd_len<'a>(v: <InstrWithFdCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -10957,7 +10957,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrRestCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrRestCombinatorAlias = Mapped<InstrRestCombinator10, InstrRestMapper>;
 
@@ -11007,14 +11007,14 @@ pub fn serialize_instr_rest<'a>(v: <InstrRestCombinator as Combinator<'a, &'a [u
 
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr_rest(opcode@).spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr_rest(opcode@).spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr_rest(opcode@).spec_serialize(v@))
         },
 {
     let combinator = instr_rest( opcode );
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn instr_rest_len<'a>(v: <InstrRestCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType, opcode: u8) -> (serialize_len: usize)
@@ -11156,7 +11156,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for InstrCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type InstrCombinatorAlias = Mapped<Pair<InstrBytecodeCombinator, InstrRestCombinator, InstrCont0>, InstrMapper>;
 
@@ -11223,14 +11223,14 @@ pub fn serialize_instr<'a>(v: <InstrCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_instr().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_instr().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_instr().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_instr().spec_serialize(v@))
         },
 {
     let combinator = instr();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn instr_len<'a>(v: <InstrCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11399,7 +11399,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LimitMinCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LimitMinCombinatorAlias = Mapped<UnsignedLEB128, LimitMinMapper>;
 
@@ -11451,14 +11451,14 @@ pub fn serialize_limit_min<'a>(v: <LimitMinCombinator as Combinator<'a, &'a [u8]
         spec_limit_min().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_limit_min().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_limit_min().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_limit_min().spec_serialize(v@))
         },
 {
     let combinator = limit_min();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn limit_min_len<'a>(v: <LimitMinCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11606,7 +11606,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LimitMinMaxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LimitMinMaxCombinatorAlias = Mapped<LimitMinMaxCombinator1, LimitMinMaxMapper>;
 
@@ -11658,14 +11658,14 @@ pub fn serialize_limit_min_max<'a>(v: <LimitMinMaxCombinator as Combinator<'a, &
         spec_limit_min_max().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_limit_min_max().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_limit_min_max().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_limit_min_max().spec_serialize(v@))
         },
 {
     let combinator = limit_min_max();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn limit_min_max_len<'a>(v: <LimitMinMaxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11840,7 +11840,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LimitsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LimitsCombinatorAlias = Mapped<LimitsCombinator1, LimitsMapper>;
 
@@ -11884,14 +11884,14 @@ pub fn serialize_limits<'a>(v: <LimitsCombinator as Combinator<'a, &'a [u8], Vec
         spec_limits().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_limits().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_limits().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_limits().spec_serialize(v@))
         },
 {
     let combinator = limits();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn limits_len<'a>(v: <LimitsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -11958,7 +11958,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemtypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemtypeCombinatorAlias = LimitsCombinator;
 
@@ -12002,14 +12002,14 @@ pub fn serialize_memtype<'a>(v: <MemtypeCombinator as Combinator<'a, &'a [u8], V
         spec_memtype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memtype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memtype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memtype().spec_serialize(v@))
         },
 {
     let combinator = memtype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memtype_len<'a>(v: <MemtypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12147,7 +12147,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemCombinatorAlias = Mapped<MemtypeCombinator, MemMapper>;
 
@@ -12199,14 +12199,14 @@ pub fn serialize_mem<'a>(v: <MemCombinator as Combinator<'a, &'a [u8], Vec<u8>>>
         spec_mem().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_mem().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_mem().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_mem().spec_serialize(v@))
         },
 {
     let combinator = mem();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn mem_len<'a>(v: <MemCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12347,7 +12347,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemsecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemsecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<MemCombinator>, MemsecContentCont0>, MemsecContentMapper>;
 
@@ -12414,14 +12414,14 @@ pub fn serialize_memsec_content<'a>(v: <MemsecContentCombinator as Combinator<'a
         spec_memsec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memsec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memsec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memsec_content().spec_serialize(v@))
         },
 {
     let combinator = memsec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memsec_content_len<'a>(v: <MemsecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12593,7 +12593,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, MemsecContentCombinator>, MemsecCont0>, MemsecMapper>;
 
@@ -12660,14 +12660,14 @@ pub fn serialize_memsec<'a>(v: <MemsecCombinator as Combinator<'a, &'a [u8], Vec
         spec_memsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memsec().spec_serialize(v@))
         },
 {
     let combinator = memsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memsec_len<'a>(v: <MemsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12765,7 +12765,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MemidxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MemidxCombinatorAlias = UnsignedLEB128;
 
@@ -12809,14 +12809,14 @@ pub fn serialize_memidx<'a>(v: <MemidxCombinator as Combinator<'a, &'a [u8], Vec
         spec_memidx().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_memidx().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_memidx().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_memidx().spec_serialize(v@))
         },
 {
     let combinator = memidx();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn memidx_len<'a>(v: <MemidxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -12957,7 +12957,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExprInnerCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExprInnerCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<InstrCombinator>, ExprInnerCont0>, ExprInnerMapper>;
 
@@ -13024,14 +13024,14 @@ pub fn serialize_expr_inner<'a>(v: <ExprInnerCombinator as Combinator<'a, &'a [u
         spec_expr_inner().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_expr_inner().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_expr_inner().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_expr_inner().spec_serialize(v@))
         },
 {
     let combinator = expr_inner();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn expr_inner_len<'a>(v: <ExprInnerCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13132,7 +13132,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExprCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExprCombinatorAlias = Terminated<ExprInnerCombinator, Tag<U8, u8>>;
 
@@ -13176,14 +13176,14 @@ pub fn serialize_expr<'a>(v: <ExprCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_expr().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_expr().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_expr().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_expr().spec_serialize(v@))
         },
 {
     let combinator = expr();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn expr_len<'a>(v: <ExprCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13324,7 +13324,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ByteVecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ByteVecCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<U8>, ByteVecCont0>, ByteVecMapper>;
 
@@ -13391,14 +13391,14 @@ pub fn serialize_byte_vec<'a>(v: <ByteVecCombinator as Combinator<'a, &'a [u8], 
         spec_byte_vec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_byte_vec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_byte_vec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_byte_vec().spec_serialize(v@))
         },
 {
     let combinator = byte_vec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn byte_vec_len<'a>(v: <ByteVecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13589,7 +13589,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ActiveDataxCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ActiveDataxCombinatorAlias = Mapped<ActiveDataxCombinator2, ActiveDataxMapper>;
 
@@ -13641,14 +13641,14 @@ pub fn serialize_active_datax<'a>(v: <ActiveDataxCombinator as Combinator<'a, &'
         spec_active_datax().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_active_datax().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_active_datax().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_active_datax().spec_serialize(v@))
         },
 {
     let combinator = active_datax();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn active_datax_len<'a>(v: <ActiveDataxCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13715,7 +13715,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for NameCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type NameCombinatorAlias = ByteVecCombinator;
 
@@ -13759,14 +13759,14 @@ pub fn serialize_name<'a>(v: <NameCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_name().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_name().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_name().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_name().spec_serialize(v@))
         },
 {
     let combinator = name();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn name_len<'a>(v: <NameCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -13979,7 +13979,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExportdescCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExportdescCombinatorAlias = Mapped<ExportdescCombinator3, ExportdescMapper>;
 
@@ -14023,14 +14023,14 @@ pub fn serialize_exportdesc<'a>(v: <ExportdescCombinator as Combinator<'a, &'a [
         spec_exportdesc().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_exportdesc().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_exportdesc().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_exportdesc().spec_serialize(v@))
         },
 {
     let combinator = exportdesc();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn exportdesc_len<'a>(v: <ExportdescCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14178,7 +14178,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExportCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExportCombinatorAlias = Mapped<ExportCombinator1, ExportMapper>;
 
@@ -14230,14 +14230,14 @@ pub fn serialize_export<'a>(v: <ExportCombinator as Combinator<'a, &'a [u8], Vec
         spec_export().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_export().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_export().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_export().spec_serialize(v@))
         },
 {
     let combinator = export();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn export_len<'a>(v: <ExportCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14378,7 +14378,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResulttypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ResulttypeCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<ValtypeCombinator>, ResulttypeCont0>, ResulttypeMapper>;
 
@@ -14445,14 +14445,14 @@ pub fn serialize_resulttype<'a>(v: <ResulttypeCombinator as Combinator<'a, &'a [
         spec_resulttype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_resulttype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_resulttype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_resulttype().spec_serialize(v@))
         },
 {
     let combinator = resulttype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn resulttype_len<'a>(v: <ResulttypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14644,7 +14644,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FunctypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FunctypeCombinatorAlias = Mapped<FunctypeCombinator2, FunctypeMapper>;
 
@@ -14696,14 +14696,14 @@ pub fn serialize_functype<'a>(v: <FunctypeCombinator as Combinator<'a, &'a [u8],
         spec_functype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_functype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_functype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_functype().spec_serialize(v@))
         },
 {
     let combinator = functype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn functype_len<'a>(v: <FunctypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -14844,7 +14844,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TypesecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TypesecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<FunctypeCombinator>, TypesecContentCont0>, TypesecContentMapper>;
 
@@ -14911,14 +14911,14 @@ pub fn serialize_typesec_content<'a>(v: <TypesecContentCombinator as Combinator<
         spec_typesec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_typesec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_typesec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_typesec_content().spec_serialize(v@))
         },
 {
     let combinator = typesec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn typesec_content_len<'a>(v: <TypesecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15090,7 +15090,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TypesecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TypesecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, TypesecContentCombinator>, TypesecCont0>, TypesecMapper>;
 
@@ -15157,14 +15157,14 @@ pub fn serialize_typesec<'a>(v: <TypesecCombinator as Combinator<'a, &'a [u8], V
         spec_typesec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_typesec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_typesec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_typesec().spec_serialize(v@))
         },
 {
     let combinator = typesec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn typesec_len<'a>(v: <TypesecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15343,7 +15343,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TabletypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TabletypeCombinatorAlias = Mapped<TabletypeCombinator1, TabletypeMapper>;
 
@@ -15395,14 +15395,14 @@ pub fn serialize_tabletype<'a>(v: <TabletypeCombinator as Combinator<'a, &'a [u8
         spec_tabletype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tabletype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tabletype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tabletype().spec_serialize(v@))
         },
 {
     let combinator = tabletype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tabletype_len<'a>(v: <TabletypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15550,7 +15550,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GlobaltypeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GlobaltypeCombinatorAlias = Mapped<GlobaltypeCombinator1, GlobaltypeMapper>;
 
@@ -15602,14 +15602,14 @@ pub fn serialize_globaltype<'a>(v: <GlobaltypeCombinator as Combinator<'a, &'a [
         spec_globaltype().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_globaltype().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_globaltype().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_globaltype().spec_serialize(v@))
         },
 {
     let combinator = globaltype();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn globaltype_len<'a>(v: <GlobaltypeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -15822,7 +15822,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ImportdescCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ImportdescCombinatorAlias = Mapped<ImportdescCombinator3, ImportdescMapper>;
 
@@ -15866,14 +15866,14 @@ pub fn serialize_importdesc<'a>(v: <ImportdescCombinator as Combinator<'a, &'a [
         spec_importdesc().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_importdesc().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_importdesc().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_importdesc().spec_serialize(v@))
         },
 {
     let combinator = importdesc();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn importdesc_len<'a>(v: <ImportdescCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16033,7 +16033,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ImportCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ImportCombinatorAlias = Mapped<ImportCombinator2, ImportMapper>;
 
@@ -16085,14 +16085,14 @@ pub fn serialize_import<'a>(v: <ImportCombinator as Combinator<'a, &'a [u8], Vec
         spec_import().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_import().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_import().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_import().spec_serialize(v@))
         },
 {
     let combinator = import();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn import_len<'a>(v: <ImportCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16233,7 +16233,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ImportsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ImportsCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<ImportCombinator>, ImportsCont0>, ImportsMapper>;
 
@@ -16300,14 +16300,14 @@ pub fn serialize_imports<'a>(v: <ImportsCombinator as Combinator<'a, &'a [u8], V
         spec_imports().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_imports().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_imports().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_imports().spec_serialize(v@))
         },
 {
     let combinator = imports();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn imports_len<'a>(v: <ImportsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16479,7 +16479,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ImportsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ImportsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, ImportsCombinator>, ImportsecCont0>, ImportsecMapper>;
 
@@ -16546,14 +16546,14 @@ pub fn serialize_importsec<'a>(v: <ImportsecCombinator as Combinator<'a, &'a [u8
         spec_importsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_importsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_importsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_importsec().spec_serialize(v@))
         },
 {
     let combinator = importsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn importsec_len<'a>(v: <ImportsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16725,7 +16725,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FuncsecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FuncsecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<TypeidxCombinator>, FuncsecContentCont0>, FuncsecContentMapper>;
 
@@ -16792,14 +16792,14 @@ pub fn serialize_funcsec_content<'a>(v: <FuncsecContentCombinator as Combinator<
         spec_funcsec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_funcsec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_funcsec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_funcsec_content().spec_serialize(v@))
         },
 {
     let combinator = funcsec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn funcsec_content_len<'a>(v: <FuncsecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -16971,7 +16971,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FuncsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FuncsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, FuncsecContentCombinator>, FuncsecCont0>, FuncsecMapper>;
 
@@ -17038,14 +17038,14 @@ pub fn serialize_funcsec<'a>(v: <FuncsecCombinator as Combinator<'a, &'a [u8], V
         spec_funcsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_funcsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_funcsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_funcsec().spec_serialize(v@))
         },
 {
     let combinator = funcsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn funcsec_len<'a>(v: <FuncsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17214,7 +17214,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TableCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TableCombinatorAlias = Mapped<TabletypeCombinator, TableMapper>;
 
@@ -17266,14 +17266,14 @@ pub fn serialize_table<'a>(v: <TableCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_table().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_table().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_table().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_table().spec_serialize(v@))
         },
 {
     let combinator = table();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn table_len<'a>(v: <TableCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17414,7 +17414,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TablesecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TablesecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<TableCombinator>, TablesecContentCont0>, TablesecContentMapper>;
 
@@ -17481,14 +17481,14 @@ pub fn serialize_tablesec_content<'a>(v: <TablesecContentCombinator as Combinato
         spec_tablesec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tablesec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tablesec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tablesec_content().spec_serialize(v@))
         },
 {
     let combinator = tablesec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tablesec_content_len<'a>(v: <TablesecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17660,7 +17660,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for TablesecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type TablesecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, TablesecContentCombinator>, TablesecCont0>, TablesecMapper>;
 
@@ -17727,14 +17727,14 @@ pub fn serialize_tablesec<'a>(v: <TablesecCombinator as Combinator<'a, &'a [u8],
         spec_tablesec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_tablesec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_tablesec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_tablesec().spec_serialize(v@))
         },
 {
     let combinator = tablesec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn tablesec_len<'a>(v: <TablesecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -17913,7 +17913,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GlobalCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GlobalCombinatorAlias = Mapped<GlobalCombinator1, GlobalMapper>;
 
@@ -17965,14 +17965,14 @@ pub fn serialize_global<'a>(v: <GlobalCombinator as Combinator<'a, &'a [u8], Vec
         spec_global().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_global().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_global().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_global().spec_serialize(v@))
         },
 {
     let combinator = global();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn global_len<'a>(v: <GlobalCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18113,7 +18113,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GlobalsecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GlobalsecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<GlobalCombinator>, GlobalsecContentCont0>, GlobalsecContentMapper>;
 
@@ -18180,14 +18180,14 @@ pub fn serialize_globalsec_content<'a>(v: <GlobalsecContentCombinator as Combina
         spec_globalsec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_globalsec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_globalsec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_globalsec_content().spec_serialize(v@))
         },
 {
     let combinator = globalsec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn globalsec_content_len<'a>(v: <GlobalsecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18359,7 +18359,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GlobalsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type GlobalsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, GlobalsecContentCombinator>, GlobalsecCont0>, GlobalsecMapper>;
 
@@ -18426,14 +18426,14 @@ pub fn serialize_globalsec<'a>(v: <GlobalsecCombinator as Combinator<'a, &'a [u8
         spec_globalsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_globalsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_globalsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_globalsec().spec_serialize(v@))
         },
 {
     let combinator = globalsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn globalsec_len<'a>(v: <GlobalsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18605,7 +18605,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExportsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExportsCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<ExportCombinator>, ExportsCont0>, ExportsMapper>;
 
@@ -18672,14 +18672,14 @@ pub fn serialize_exports<'a>(v: <ExportsCombinator as Combinator<'a, &'a [u8], V
         spec_exports().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_exports().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_exports().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_exports().spec_serialize(v@))
         },
 {
     let combinator = exports();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn exports_len<'a>(v: <ExportsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -18851,7 +18851,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExportsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExportsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, ExportsCombinator>, ExportsecCont0>, ExportsecMapper>;
 
@@ -18918,14 +18918,14 @@ pub fn serialize_exportsec<'a>(v: <ExportsecCombinator as Combinator<'a, &'a [u8
         spec_exportsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_exportsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_exportsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_exportsec().spec_serialize(v@))
         },
 {
     let combinator = exportsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn exportsec_len<'a>(v: <ExportsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19094,7 +19094,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for StartCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type StartCombinatorAlias = Mapped<FuncidxCombinator, StartMapper>;
 
@@ -19146,14 +19146,14 @@ pub fn serialize_start<'a>(v: <StartCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_start().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_start().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_start().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_start().spec_serialize(v@))
         },
 {
     let combinator = start();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn start_len<'a>(v: <StartCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19294,7 +19294,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for StartsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type StartsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, StartCombinator>, StartsecCont0>, StartsecMapper>;
 
@@ -19361,14 +19361,14 @@ pub fn serialize_startsec<'a>(v: <StartsecCombinator as Combinator<'a, &'a [u8],
         spec_startsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_startsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_startsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_startsec().spec_serialize(v@))
         },
 {
     let combinator = startsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn startsec_len<'a>(v: <StartsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19540,7 +19540,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FuncidxsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FuncidxsCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<FuncidxCombinator>, FuncidxsCont0>, FuncidxsMapper>;
 
@@ -19607,14 +19607,14 @@ pub fn serialize_funcidxs<'a>(v: <FuncidxsCombinator as Combinator<'a, &'a [u8],
         spec_funcidxs().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_funcidxs().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_funcidxs().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_funcidxs().spec_serialize(v@))
         },
 {
     let combinator = funcidxs();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn funcidxs_len<'a>(v: <FuncidxsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -19793,7 +19793,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem0Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem0CombinatorAlias = Mapped<ParsedElem0Combinator1, ParsedElem0Mapper>;
 
@@ -19845,14 +19845,14 @@ pub fn serialize_parsed_elem0<'a>(v: <ParsedElem0Combinator as Combinator<'a, &'
         spec_parsed_elem0().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem0().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem0().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem0().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem0();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem0_len<'a>(v: <ParsedElem0Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20000,7 +20000,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem1Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem1CombinatorAlias = Mapped<ParsedElem1Combinator1, ParsedElem1Mapper>;
 
@@ -20052,14 +20052,14 @@ pub fn serialize_parsed_elem1<'a>(v: <ParsedElem1Combinator as Combinator<'a, &'
         spec_parsed_elem1().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem1().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem1().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem1().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem1();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem1_len<'a>(v: <ParsedElem1Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20231,7 +20231,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem2Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem2CombinatorAlias = Mapped<ParsedElem2Combinator3, ParsedElem2Mapper>;
 
@@ -20283,14 +20283,14 @@ pub fn serialize_parsed_elem2<'a>(v: <ParsedElem2Combinator as Combinator<'a, &'
         spec_parsed_elem2().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem2().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem2().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem2().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem2();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem2_len<'a>(v: <ParsedElem2Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20357,7 +20357,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem3Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem3CombinatorAlias = ParsedElem1Combinator;
 
@@ -20401,14 +20401,14 @@ pub fn serialize_parsed_elem3<'a>(v: <ParsedElem3Combinator as Combinator<'a, &'
         spec_parsed_elem3().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem3().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem3().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem3().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem3();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem3_len<'a>(v: <ParsedElem3Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20549,7 +20549,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ExprsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ExprsCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<ExprCombinator>, ExprsCont0>, ExprsMapper>;
 
@@ -20616,14 +20616,14 @@ pub fn serialize_exprs<'a>(v: <ExprsCombinator as Combinator<'a, &'a [u8], Vec<u
         spec_exprs().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_exprs().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_exprs().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_exprs().spec_serialize(v@))
         },
 {
     let combinator = exprs();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn exprs_len<'a>(v: <ExprsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -20802,7 +20802,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem4Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem4CombinatorAlias = Mapped<ParsedElem4Combinator1, ParsedElem4Mapper>;
 
@@ -20854,14 +20854,14 @@ pub fn serialize_parsed_elem4<'a>(v: <ParsedElem4Combinator as Combinator<'a, &'
         spec_parsed_elem4().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem4().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem4().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem4().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem4();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem4_len<'a>(v: <ParsedElem4Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21009,7 +21009,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem5Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem5CombinatorAlias = Mapped<ParsedElem5Combinator1, ParsedElem5Mapper>;
 
@@ -21061,14 +21061,14 @@ pub fn serialize_parsed_elem5<'a>(v: <ParsedElem5Combinator as Combinator<'a, &'
         spec_parsed_elem5().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem5().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem5().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem5().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem5();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem5_len<'a>(v: <ParsedElem5Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21240,7 +21240,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem6Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem6CombinatorAlias = Mapped<ParsedElem6Combinator3, ParsedElem6Mapper>;
 
@@ -21292,14 +21292,14 @@ pub fn serialize_parsed_elem6<'a>(v: <ParsedElem6Combinator as Combinator<'a, &'
         spec_parsed_elem6().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem6().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem6().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem6().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem6();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem6_len<'a>(v: <ParsedElem6Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21447,7 +21447,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ParsedElem7Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ParsedElem7CombinatorAlias = Mapped<ParsedElem7Combinator1, ParsedElem7Mapper>;
 
@@ -21499,14 +21499,14 @@ pub fn serialize_parsed_elem7<'a>(v: <ParsedElem7Combinator as Combinator<'a, &'
         spec_parsed_elem7().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_parsed_elem7().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_parsed_elem7().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_parsed_elem7().spec_serialize(v@))
         },
 {
     let combinator = parsed_elem7();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn parsed_elem7_len<'a>(v: <ParsedElem7Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21795,7 +21795,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ElemCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ElemCombinatorAlias = Mapped<ElemCombinator7, ElemMapper>;
 
@@ -21839,14 +21839,14 @@ pub fn serialize_elem<'a>(v: <ElemCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_elem().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_elem().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_elem().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_elem().spec_serialize(v@))
         },
 {
     let combinator = elem();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn elem_len<'a>(v: <ElemCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -21987,7 +21987,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ElemsecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ElemsecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<ElemCombinator>, ElemsecContentCont0>, ElemsecContentMapper>;
 
@@ -22054,14 +22054,14 @@ pub fn serialize_elemsec_content<'a>(v: <ElemsecContentCombinator as Combinator<
         spec_elemsec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_elemsec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_elemsec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_elemsec_content().spec_serialize(v@))
         },
 {
     let combinator = elemsec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn elemsec_content_len<'a>(v: <ElemsecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22233,7 +22233,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ElemsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ElemsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, ElemsecContentCombinator>, ElemsecCont0>, ElemsecMapper>;
 
@@ -22300,14 +22300,14 @@ pub fn serialize_elemsec<'a>(v: <ElemsecCombinator as Combinator<'a, &'a [u8], V
         spec_elemsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_elemsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_elemsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_elemsec().spec_serialize(v@))
         },
 {
     let combinator = elemsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn elemsec_len<'a>(v: <ElemsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22479,7 +22479,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DatacountsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DatacountsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, UnsignedLEB128>, DatacountsecCont0>, DatacountsecMapper>;
 
@@ -22546,14 +22546,14 @@ pub fn serialize_datacountsec<'a>(v: <DatacountsecCombinator as Combinator<'a, &
         spec_datacountsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_datacountsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_datacountsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_datacountsec().spec_serialize(v@))
         },
 {
     let combinator = datacountsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn datacountsec_len<'a>(v: <DatacountsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22732,7 +22732,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LocalCompressedCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LocalCompressedCombinatorAlias = Mapped<LocalCompressedCombinator1, LocalCompressedMapper>;
 
@@ -22784,14 +22784,14 @@ pub fn serialize_local_compressed<'a>(v: <LocalCompressedCombinator as Combinato
         spec_local_compressed().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_local_compressed().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_local_compressed().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_local_compressed().spec_serialize(v@))
         },
 {
     let combinator = local_compressed();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn local_compressed_len<'a>(v: <LocalCompressedCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -22932,7 +22932,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for LocalsCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type LocalsCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<LocalCompressedCombinator>, LocalsCont0>, LocalsMapper>;
 
@@ -22999,14 +22999,14 @@ pub fn serialize_locals<'a>(v: <LocalsCombinator as Combinator<'a, &'a [u8], Vec
         spec_locals().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_locals().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_locals().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_locals().spec_serialize(v@))
         },
 {
     let combinator = locals();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn locals_len<'a>(v: <LocalsCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23185,7 +23185,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for FuncCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type FuncCombinatorAlias = Mapped<FuncCombinator1, FuncMapper>;
 
@@ -23237,14 +23237,14 @@ pub fn serialize_func<'a>(v: <FuncCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_func().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_func().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_func().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_func().spec_serialize(v@))
         },
 {
     let combinator = func();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn func_len<'a>(v: <FuncCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23385,7 +23385,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CodeCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CodeCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, FuncCombinator>, CodeCont0>, CodeMapper>;
 
@@ -23452,14 +23452,14 @@ pub fn serialize_code<'a>(v: <CodeCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_code().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_code().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_code().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_code().spec_serialize(v@))
         },
 {
     let combinator = code();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn code_len<'a>(v: <CodeCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23631,7 +23631,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CodesecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CodesecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<CodeCombinator>, CodesecContentCont0>, CodesecContentMapper>;
 
@@ -23698,14 +23698,14 @@ pub fn serialize_codesec_content<'a>(v: <CodesecContentCombinator as Combinator<
         spec_codesec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_codesec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_codesec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_codesec_content().spec_serialize(v@))
         },
 {
     let combinator = codesec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn codesec_content_len<'a>(v: <CodesecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -23877,7 +23877,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CodesecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CodesecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, CodesecContentCombinator>, CodesecCont0>, CodesecMapper>;
 
@@ -23944,14 +23944,14 @@ pub fn serialize_codesec<'a>(v: <CodesecCombinator as Combinator<'a, &'a [u8], V
         spec_codesec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_codesec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_codesec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_codesec().spec_serialize(v@))
         },
 {
     let combinator = codesec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn codesec_len<'a>(v: <CodesecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24130,7 +24130,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ActiveData0Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ActiveData0CombinatorAlias = Mapped<ActiveData0Combinator1, ActiveData0Mapper>;
 
@@ -24182,14 +24182,14 @@ pub fn serialize_active_data0<'a>(v: <ActiveData0Combinator as Combinator<'a, &'
         spec_active_data0().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_active_data0().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_active_data0().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_active_data0().spec_serialize(v@))
         },
 {
     let combinator = active_data0();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn active_data0_len<'a>(v: <ActiveData0Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24256,7 +24256,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PassiveDataCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type PassiveDataCombinatorAlias = ByteVecCombinator;
 
@@ -24300,14 +24300,14 @@ pub fn serialize_passive_data<'a>(v: <PassiveDataCombinator as Combinator<'a, &'
         spec_passive_data().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_passive_data().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_passive_data().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_passive_data().spec_serialize(v@))
         },
 {
     let combinator = passive_data();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn passive_data_len<'a>(v: <PassiveDataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24501,7 +24501,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DataCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DataCombinatorAlias = Mapped<DataCombinator2, DataMapper>;
 
@@ -24545,14 +24545,14 @@ pub fn serialize_data<'a>(v: <DataCombinator as Combinator<'a, &'a [u8], Vec<u8>
         spec_data().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_data().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_data().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_data().spec_serialize(v@))
         },
 {
     let combinator = data();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn data_len<'a>(v: <DataCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24693,7 +24693,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DatasecContentCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DatasecContentCombinatorAlias = Mapped<Pair<UnsignedLEB128, RepeatN<DataCombinator>, DatasecContentCont0>, DatasecContentMapper>;
 
@@ -24760,14 +24760,14 @@ pub fn serialize_datasec_content<'a>(v: <DatasecContentCombinator as Combinator<
         spec_datasec_content().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_datasec_content().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_datasec_content().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_datasec_content().spec_serialize(v@))
         },
 {
     let combinator = datasec_content();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn datasec_content_len<'a>(v: <DatasecContentCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -24939,7 +24939,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for DatasecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type DatasecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, DatasecContentCombinator>, DatasecCont0>, DatasecMapper>;
 
@@ -25006,14 +25006,14 @@ pub fn serialize_datasec<'a>(v: <DatasecCombinator as Combinator<'a, &'a [u8], V
         spec_datasec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_datasec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_datasec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_datasec().spec_serialize(v@))
         },
 {
     let combinator = datasec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn datasec_len<'a>(v: <DatasecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25386,7 +25386,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ModuleCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type ModuleCombinatorAlias = Mapped<ModuleCombinator13, ModuleMapper>;
 
@@ -25438,14 +25438,14 @@ pub fn serialize_module<'a>(v: <ModuleCombinator as Combinator<'a, &'a [u8], Vec
         spec_module().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_module().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_module().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_module().spec_serialize(v@))
         },
 {
     let combinator = module();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn module_len<'a>(v: <ModuleCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25512,7 +25512,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Signed32Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Signed32CombinatorAlias = bytes::Fixed<4>;
 
@@ -25556,14 +25556,14 @@ pub fn serialize_signed_32<'a>(v: <Signed32Combinator as Combinator<'a, &'a [u8]
         spec_signed_32().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_signed_32().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_signed_32().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_signed_32().spec_serialize(v@))
         },
 {
     let combinator = signed_32();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn signed_32_len<'a>(v: <Signed32Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25625,14 +25625,14 @@ pub fn serialize_ELEMKIND<'a>(v: <ELEMKINDCombinator as Combinator<'a, &'a [u8],
         spec_ELEMKIND().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_ELEMKIND().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_ELEMKIND().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_ELEMKIND().spec_serialize(v@))
         },
 {
     let combinator = ELEMKIND();
-    combinator.serialize(v, data, pos)
+    combinator.serialize(v, &mut *data, pos)
 }
 
 pub fn ELEMKIND_len<'a>(v: <ELEMKINDCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25698,7 +25698,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for MyCustomSectionCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type MyCustomSectionCombinatorAlias = ByteVecCombinator;
 
@@ -25742,14 +25742,14 @@ pub fn serialize_my_custom_section<'a>(v: <MyCustomSectionCombinator as Combinat
         spec_my_custom_section().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_my_custom_section().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_my_custom_section().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_my_custom_section().spec_serialize(v@))
         },
 {
     let combinator = my_custom_section();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn my_custom_section_len<'a>(v: <MyCustomSectionCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -25897,7 +25897,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CustomCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CustomCombinatorAlias = Mapped<CustomCombinator1, CustomMapper>;
 
@@ -25949,14 +25949,14 @@ pub fn serialize_custom<'a>(v: <CustomCombinator as Combinator<'a, &'a [u8], Vec
         spec_custom().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_custom().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_custom().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_custom().spec_serialize(v@))
         },
 {
     let combinator = custom();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn custom_len<'a>(v: <CustomCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -26023,7 +26023,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Signed64Combinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type Signed64CombinatorAlias = bytes::Fixed<8>;
 
@@ -26067,14 +26067,14 @@ pub fn serialize_signed_64<'a>(v: <Signed64Combinator as Combinator<'a, &'a [u8]
         spec_signed_64().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_signed_64().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_signed_64().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_signed_64().spec_serialize(v@))
         },
 {
     let combinator = signed_64();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn signed_64_len<'a>(v: <Signed64Combinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)
@@ -26215,7 +26215,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for CustomsecCombinator {
     fn parse(&self, s: &'a [u8]) -> (res: Result<(usize, Self::Type), ParseError>)
     { <_ as Combinator<'a, &'a [u8],Vec<u8>>>::parse(&self.0, s) }
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (o: Result<usize, SerializeError>)
-    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos) }
+    { <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos) }
 }
 pub type CustomsecCombinatorAlias = Mapped<Pair<UnsignedLEB128, AndThen<bytes::Variable, CustomCombinator>, CustomsecCont0>, CustomsecMapper>;
 
@@ -26282,14 +26282,14 @@ pub fn serialize_customsec<'a>(v: <CustomsecCombinator as Combinator<'a, &'a [u8
         spec_customsec().wf(v@),
     ensures
         o matches Ok(n) ==> {
-            &&& data@.len() == old(data)@.len()
-            &&& pos <= usize::MAX - n && pos + n <= data@.len()
+            &&& final(data)@.len() == old(data)@.len()
+            &&& pos <= usize::MAX - n && pos + n <= final(data)@.len()
             &&& n == spec_customsec().spec_serialize(v@).len()
-            &&& data@ == seq_splice(old(data)@, pos, spec_customsec().spec_serialize(v@))
+            &&& final(data)@ == seq_splice(old(data)@, pos, spec_customsec().spec_serialize(v@))
         },
 {
     let combinator = customsec();
-    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, data, pos)
+    <_ as Combinator<'a, &'a [u8], Vec<u8>>>::serialize(&combinator, v, &mut *data, pos)
 }
 
 pub fn customsec_len<'a>(v: <CustomsecCombinator as Combinator<'a, &'a [u8], Vec<u8>>>::SType) -> (serialize_len: usize)

--- a/vest-examples/Cargo.toml
+++ b/vest-examples/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-vstd = "0.0.0-2026-03-17-2326"
+vstd = "=0.0.0-2026-05-10-0145"
 # verus_builtin = "=0.0.0-2026-01-11-0057"
 # verus_builtin_macros = "0.0.0-2025-12-07-0054"
 #verus_builtin = { git = "https://github.com/verus-lang/verus", branch = "main" }

--- a/vest-examples/asn1/src/asn1/big_int.rs
+++ b/vest-examples/asn1/src/asn1/big_int.rs
@@ -177,7 +177,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BigInt {
         proof {
             use_type_invariant(&v);
         }
-        new_big_int_inner().serialize(&v.0, data, pos)
+        new_big_int_inner().serialize(&v.0, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/bit_string.rs
+++ b/vest-examples/asn1/src/asn1/bit_string.rs
@@ -244,7 +244,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BitString {
             assert(BitStringValue::spec_wf(slice@));
             assert(OctetString.wf(slice@));
         }
-        OctetString.serialize(&slice, data, pos)
+        OctetString.serialize(&slice, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/explicit.rs
+++ b/vest-examples/asn1/src/asn1/explicit.rs
@@ -95,7 +95,7 @@ impl<'a, T> Combinator<'a, &'a [u8], Vec<u8>> for ExplicitTag<T> where
 
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
-        LengthWrapped(&self.1).serialize(v, data, pos)
+        LengthWrapped(&self.1).serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/gen_time.rs
+++ b/vest-examples/asn1/src/asn1/gen_time.rs
@@ -107,7 +107,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for GeneralizedTime {
 
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
-        LengthWrapped(GeneralizedTimeInner).serialize(v, data, pos)
+        LengthWrapped(GeneralizedTimeInner).serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/ia5_string.rs
+++ b/vest-examples/asn1/src/asn1/ia5_string.rs
@@ -112,7 +112,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for IA5String {
         Refined {
             inner: UTF8String,
             predicate: IA5StringPred,
-        }.serialize(v, data, pos)
+        }.serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/implicit.rs
+++ b/vest-examples/asn1/src/asn1/implicit.rs
@@ -99,7 +99,7 @@ impl<'a, T> Combinator<'a, &'a [u8], Vec<u8>> for ImplicitTag<T> where
 
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
-        self.1.serialize(v, data, pos)
+        self.1.serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/integer.rs
+++ b/vest-examples/asn1/src/asn1/integer.rs
@@ -106,7 +106,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Integer {
         proof {
             lemma_min_num_bytes_signed(v);
         }
-        new_integer_inner().serialize((min_num_bytes_signed_exec(v) as LengthValue, v), data, pos)
+        new_integer_inner().serialize((min_num_bytes_signed_exec(v) as LengthValue, v), &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/len.rs
+++ b/vest-examples/asn1/src/asn1/len.rs
@@ -214,7 +214,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for Length {
         }
 
         data.set(pos, (0x80 + bytes) as u8);
-        let len = VarUInt(bytes as usize).serialize(v as VarUIntResult, data, pos + 1)?;
+        let len = VarUInt(bytes as usize).serialize(v as VarUIntResult, &mut *data, pos + 1)?;
 
         proof {
             lemma_min_num_bytes_unsigned(v as VarUIntResult);

--- a/vest-examples/asn1/src/asn1/len_wrapped.rs
+++ b/vest-examples/asn1/src/asn1/len_wrapped.rs
@@ -99,7 +99,7 @@ impl<'a, T> Combinator<'a, &'a [u8], Vec<u8>> for LengthWrapped<T> where
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         let len = self.0.length(v);
-        let final_len = new_length_wrapped_inner(&self.0).serialize((len as LengthValue, v), data, pos)?;
+        let final_len = new_length_wrapped_inner(&self.0).serialize((len as LengthValue, v), &mut *data, pos)?;
 
         if pos < data.len() && final_len < data.len() - pos {
             assert(data@ =~= seq_splice(old(data)@, pos, self@.spec_serialize(v@)));

--- a/vest-examples/asn1/src/asn1/octet_string.rs
+++ b/vest-examples/asn1/src/asn1/octet_string.rs
@@ -89,7 +89,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OctetString {
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         let bytes = *v;
-        new_octet_string_inner().serialize((bytes.len() as LengthValue, &bytes), data, pos)
+        new_octet_string_inner().serialize((bytes.len() as LengthValue, &bytes), &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/oid.rs
+++ b/vest-examples/asn1/src/asn1/oid.rs
@@ -236,11 +236,11 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ObjectIdentifier {
         let mut rest_arcs_clone = Clone::clone(&v.0.0);
         let rest_arcs = RepeatResult(rest_arcs_clone.split_off(2));
 
-        let len = (U8, Repeat(Base128UInt)).serialize((&first_byte, &rest_arcs), data, pos)?;
+        let len = (U8, Repeat(Base128UInt)).serialize((&first_byte, &rest_arcs), &mut *data, pos)?;
 
         let ghost rest_arcs_spec = rest_arcs@;
         let length_value: LengthValue = len;
-        let len2 = new_object_identifier_inner().serialize((length_value, (&first_byte, &rest_arcs)), data, pos)?;
+        let len2 = new_object_identifier_inner().serialize((length_value, (&first_byte, &rest_arcs)), &mut *data, pos)?;
 
         if pos.checked_add(len2).is_some() && pos + len2 <= data.len() {
             proof {

--- a/vest-examples/asn1/src/asn1/printable_string.rs
+++ b/vest-examples/asn1/src/asn1/printable_string.rs
@@ -112,7 +112,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for PrintableString {
         Refined {
             inner: UTF8String,
             predicate: PrintableStringPred,
-        }.serialize(v, data, pos)
+        }.serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/seq_of.rs
+++ b/vest-examples/asn1/src/asn1/seq_of.rs
@@ -110,7 +110,7 @@ impl<'a, C> Combinator<'a, &'a [u8], Vec<u8>> for SequenceOf<C> where
 
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
-        ExplicitTag(self.tag(), Repeat(&self.0)).serialize(v, data, pos)
+        ExplicitTag(self.tag(), Repeat(&self.0)).serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/tag.rs
+++ b/vest-examples/asn1/src/asn1/tag.rs
@@ -432,7 +432,7 @@ impl<'a, T> Combinator<'a, &'a [u8], Vec<u8>> for ASN1<T> where
             self.0.lemma_view_preserves_tag();
         }
 
-        (ASN1Tag, &self.0).serialize((self.0.tag(), v), data, pos)
+        (ASN1Tag, &self.0).serialize((self.0.tag(), v), &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/utc_time.rs
+++ b/vest-examples/asn1/src/asn1/utc_time.rs
@@ -96,7 +96,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for UTCTime {
     }
 
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
-        LengthWrapped(UTCTimeInner).serialize(v, data, pos)
+        LengthWrapped(UTCTimeInner).serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/asn1/utf8_string.rs
+++ b/vest-examples/asn1/src/asn1/utf8_string.rs
@@ -136,7 +136,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for UTF8String {
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         let s = str_to_utf8(*v);
-        let n = Length.serialize(s.len() as LengthValue, data, pos)?;
+        let n = Length.serialize(s.len() as LengthValue, &mut *data, pos)?;
 
         if pos.checked_add(n).is_none() {
             return Err(SerializeError::Other("Size overflow".to_string()));

--- a/vest-examples/asn1/src/asn1/var_int.rs
+++ b/vest-examples/asn1/src/asn1/var_int.rs
@@ -1047,7 +1047,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for VarInt {
             VarUInt::lemma_mask_fits(self.0, v as VarUIntResult);
         };
 
-        VarUInt(self.0).serialize((v as VarUIntResult) & n_byte_max_unsigned!(self.0), data, pos)
+        VarUInt(self.0).serialize((v as VarUIntResult) & n_byte_max_unsigned!(self.0), &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/common/cached.rs
+++ b/vest-examples/asn1/src/common/cached.rs
@@ -168,7 +168,7 @@ impl<'a, T> Combinator<'a, &'a [u8], Vec<u8>> for Cached<T> where
         usize,
         SerializeError,
     >) {
-        self.0.serialize(v, data, pos)
+        self.0.serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest-examples/asn1/src/common/default.rs
+++ b/vest-examples/asn1/src/common/default.rs
@@ -157,9 +157,9 @@ impl<'a, C1, C2> Combinator<'a, &'a [u8], Vec<u8>> for Default<<C1 as Combinator
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         let pair = (&self.1, &self.2);
         let len = if v.0.polyfill_eq(&self.0.clone().ex_into()) {
-            self.2.serialize(v.1, data, pos)?
+            self.2.serialize(v.1, &mut *data, pos)?
         } else {
-            pair.serialize((v.0, v.1), data, pos)?
+            pair.serialize((v.0, v.1), &mut *data, pos)?
         };
 
         assert(data@ =~= seq_splice(old(data)@, pos, self@.spec_serialize(v@)));

--- a/vest-examples/asn1/src/common/optional.rs
+++ b/vest-examples/asn1/src/common/optional.rs
@@ -240,8 +240,8 @@ impl<'a, C1, C2> Combinator<'a, &'a [u8], Vec<u8>> for Optional<C1, C2> where
     #[inline(always)]
     fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
         let len = match v {
-            (OptionDeep::Some(v1), v2) => (&self.0, &self.1).serialize((v1, v2), data, pos),
-            (OptionDeep::None, v2) => self.1.serialize(v2, data, pos),
+            (OptionDeep::Some(v1), v2) => (&self.0, &self.1).serialize((v1, v2), &mut *data, pos),
+            (OptionDeep::None, v2) => self.1.serialize(v2, &mut *data, pos),
         }?;
 
         proof {

--- a/vest-examples/asn1/src/common/polyfill.rs
+++ b/vest-examples/asn1/src/common/polyfill.rs
@@ -94,7 +94,7 @@ pub fn slice_eq<T: PartialEq>(a: &[T], b: &[T]) -> (res: bool)
 #[verifier::external_body]
 pub fn slice_skip_copy<T: PartialEq + Copy>(a: &mut [T], skip: usize, b: &[T])
     requires old(a)@.len() >= b@.len() + skip
-    ensures a@ == old(a)@.take(skip as int) + b@ + old(a)@.skip(skip + b.len())
+    ensures final(a)@ == old(a)@.take(skip as int) + b@ + old(a)@.skip(skip + b.len())
 {
     (&mut a[skip..skip + b.len()]).copy_from_slice(b)
 }
@@ -208,7 +208,7 @@ pub fn u64_to_string(x: u64) -> (res: String)
 #[verifier::external_body]
 #[inline(always)]
 pub fn u64_to_string_inplace(res: &mut String, x: u64)
-    ensures res@ == old(res)@ + spec_u64_to_string(x)
+    ensures final(res)@ == old(res)@ + spec_u64_to_string(x)
 {
     write!(res, "{}", x).unwrap();
 }
@@ -244,8 +244,9 @@ pub fn vec_set<T>(v: &mut Vec<T>, i: usize, x: T)
     requires
         0 <= i < old(v).len(),
     ensures
-        v.len() == old(v).len() && (forall|j| 0 <= j < v.len() && j != i ==> v[j] == old(v)[j])
-            && v[i as int] == x,
+        final(v).len() == old(v).len()
+            && (forall|j| 0 <= j < final(v).len() && j != i ==> final(v)[j] == old(v)[j])
+            && final(v)[i as int] == x,
 {
     v[i] = x;
 }
@@ -256,10 +257,10 @@ pub fn vec_push_nested<T>(v: &mut Vec<Vec<T>>, i: usize, x: T)
         0 <= i < old(v)@.len(),
 
     ensures
-        v.len() == old(v).len(),
-        forall |j| #![trigger v@[j]] 0 <= j < v@.len() ==> {
-            &&& i == j ==> v@[j]@ == old(v)@[j]@.push(x)
-            &&& i != j ==> v@[j] == old(v)@[j]
+        final(v).len() == old(v).len(),
+        forall |j| #![trigger final(v)@[j]] 0 <= j < final(v)@.len() ==> {
+            &&& i == j ==> final(v)@[j]@ == old(v)@[j]@.push(x)
+            &&& i != j ==> final(v)@[j] == old(v)@[j]
         },
 {
     v[i].push(x);
@@ -289,8 +290,8 @@ pub fn vec_init_n<T: Clone + View>(n: usize, v: &T) -> (res: Vec<T>)
 /// Copied from Verus example
 pub fn vec_reverse<T: DeepView>(v: &mut Vec<&T>)
     ensures
-        v.len() == old(v).len(),
-        old(v).deep_view().reverse() =~= v.deep_view(),
+        final(v).len() == old(v).len(),
+        old(v).deep_view().reverse() =~= final(v).deep_view(),
 {
     let length = v.len();
     let ghost v1 = v.deep_view();
@@ -450,9 +451,9 @@ pub fn chars_iter_next<'a>(iter: &mut CharsIter<'a>) -> (res: Option<char>)
     ensures ({
         let raw = spec_chars_iter_str(*old(iter));
         let prev_idx = spec_chars_iter_index(*old(iter));
-        let new_idx = spec_chars_iter_index(*iter);
+        let new_idx = spec_chars_iter_index(*final(iter));
 
-        &&& spec_chars_iter_str(*iter) == raw
+        &&& spec_chars_iter_str(*final(iter)) == raw
         &&& res matches Some(c) ==> prev_idx < raw.len() && c == raw[prev_idx] && new_idx == prev_idx + 1
         &&& res is None <==> new_idx == prev_idx == raw.len()
     })
@@ -497,7 +498,7 @@ pub fn string_new() -> (res: String)
 #[verifier::external_body]
 #[inline(always)]
 pub fn string_push(s: &mut String, c: char)
-    ensures s@ == old(s)@.push(c)
+    ensures final(s)@ == old(s)@.push(c)
 {
     s.push(c)
 }
@@ -505,7 +506,7 @@ pub fn string_push(s: &mut String, c: char)
 #[verifier::external_body]
 #[inline(always)]
 pub fn string_push_str(s: &mut String, r: &str)
-    ensures s@ == old(s)@ + r@
+    ensures final(s)@ == old(s)@ + r@
 {
     s.push_str(r)
 }

--- a/vest-examples/asn1/src/common/wrapped.rs
+++ b/vest-examples/asn1/src/common/wrapped.rs
@@ -254,7 +254,7 @@ macro_rules! wrap_combinator_impls {
                 #[inline(always)]
                 fn serialize(&self, v: Self::SType, data: &mut Vec<u8>, pos: usize) -> (res: Result<usize, SerializeError>) {
                     $(let $field_name: $field_type = self.$field_name;)*
-                    $inner_expr.serialize(v, data, pos)
+                    $inner_expr.serialize(v, &mut *data, pos)
                 }
             }
         }

--- a/vest-examples/repeat/src/lib.rs
+++ b/vest-examples/repeat/src/lib.rs
@@ -233,7 +233,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for OpaqueU16Combinator {
         usize,
         SerializeError,
     >) {
-        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos)
+        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos)
     }
 }
 
@@ -396,7 +396,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdCombinator {
         usize,
         SerializeError,
     >) {
-        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos)
+        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos)
     }
 }
 
@@ -507,7 +507,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdListListCombinator {
         usize,
         SerializeError,
     >) {
-        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos)
+        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos)
     }
 }
 
@@ -736,7 +736,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for ResponderIdListCombinator {
         usize,
         SerializeError,
     >) {
-        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, data, pos)
+        <_ as Combinator<&'a [u8], Vec<u8>>>::serialize(&self.0, v, &mut *data, pos)
     }
 }
 

--- a/vest/Cargo.toml
+++ b/vest/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-vstd = "0.0.0-2026-03-17-2326"
+vstd = "=0.0.0-2026-05-10-0145"
 
 #vstd = { git = "https://github.com/verus-lang/verus", branch = "main" }
 #verus_builtin = { git = "https://github.com/verus-lang/verus", branch = "main" }

--- a/vest/Cargo.toml
+++ b/vest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vest_lib"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 license = "MIT"
 description = "VestLib: A library of formally verified parser and serializer combinators"

--- a/vest/src/bitcoin/varint.rs
+++ b/vest/src/bitcoin/varint.rs
@@ -484,7 +484,7 @@ impl<'a> Combinator<'a, &'a [u8], Vec<u8>> for BtcVarint {
         usize,
         SerializeError,
     >) {
-        btc_varint_inner().serialize(v, data, pos)
+        btc_varint_inner().serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest/src/buf_traits.rs
+++ b/vest/src/buf_traits.rs
@@ -62,9 +62,9 @@ pub trait VestOutput<I>: View<V = Seq<u8>> where I: View<V = Seq<u8>> {
         requires
             0 <= i + input@.len() <= old(self)@.len() <= usize::MAX,
         ensures
-            self@.len() == old(self)@.len() && self@ == old(self)@.subrange(0, i as int).add(
+            final(self)@.len() == old(self)@.len() && final(self)@ == old(self)@.subrange(0, i as int).add(
                 input@,
-            ).add(old(self)@.subrange(i + input@.len(), self@.len() as int)),
+            ).add(old(self)@.subrange(i + input@.len(), final(self)@.len() as int)),
     ;
 }
 
@@ -76,7 +76,7 @@ pub trait VestPublicOutput<I>: VestOutput<I> where I: View<V = Seq<u8>> {
         requires
             i < old(self)@.len(),
         ensures
-            self@ == old(self)@.update(i as int, value),
+            final(self)@ == old(self)@.update(i as int, value),
     ;
 
     /// Copy `input` to `self` starting at index `i`. (Same as `set_range` but with byte slice input.)
@@ -84,9 +84,9 @@ pub trait VestPublicOutput<I>: VestOutput<I> where I: View<V = Seq<u8>> {
         requires
             0 <= i + input@.len() <= old(self)@.len() <= usize::MAX,
         ensures
-            self@.len() == old(self)@.len() && self@ == old(self)@.subrange(0, i as int).add(
+            final(self)@.len() == old(self)@.len() && final(self)@ == old(self)@.subrange(0, i as int).add(
                 input@,
-            ).add(old(self)@.subrange(i + input@.len(), self@.len() as int)),
+            ).add(old(self)@.subrange(i + input@.len(), final(self)@.len() as int)),
     ;
 }
 

--- a/vest/src/properties.rs
+++ b/vest/src/properties.rs
@@ -283,10 +283,10 @@ pub trait Combinator<'x, I, O>: View where
             pos <= old(buf)@.len() <= usize::MAX,
         ensures
             res matches Ok(n) ==> {
-                &&& buf@.len() == old(buf)@.len()
-                &&& pos <= usize::MAX - n && pos + n <= buf@.len()
+                &&& final(buf)@.len() == old(buf)@.len()
+                &&& pos <= usize::MAX - n && pos + n <= final(buf)@.len()
                 &&& n == self@.spec_serialize(v@).len()
-                &&& buf@ == seq_splice(old(buf)@, pos, self@.spec_serialize(v@))
+                &&& final(buf)@ == seq_splice(old(buf)@, pos, self@.spec_serialize(v@))
             },
     ;
 }

--- a/vest/src/regular/modifier.rs
+++ b/vest/src/regular/modifier.rs
@@ -656,7 +656,7 @@ impl<'x, I, O, Inner, P> Combinator<'x, I, O> for Refined<Inner, P> where
 
     fn serialize(&self, v: Self::SType, data: &mut O, pos: usize) -> Result<usize, SerializeError> {
         // we know `v` is well-formed, so we can skip the predicate check
-        self.inner.serialize(v, data, pos)
+        self.inner.serialize(v, &mut *data, pos)
     }
 }
 

--- a/vest/src/regular/repetition.rs
+++ b/vest/src/regular/repetition.rs
@@ -433,7 +433,7 @@ impl<I, O, C, 'x> Combinator<'x, I, O> for RepeatN<C> where
             let v = &vs.0[i];
             assert(v@ == _vs[i as int]);
             assert(_vs.take((i + 1) as int).drop_last() == _vs.take(i as int));  // <-- this is the key
-            let l = self.0.serialize(v, data, pos)?;
+            let l = self.0.serialize(v, &mut *data, pos)?;
             pos += l;
             assert(data@ == seq_splice(
                 old_data,
@@ -689,7 +689,7 @@ impl<I, O, C, 'x> Combinator<'x, I, O> for Repeat<C> where
         usize,
         SerializeError,
     >) {
-        RepeatN(&self.0, vs.0.len()).serialize(vs, data, pos)
+        RepeatN(&self.0, vs.0.len()).serialize(vs, &mut *data, pos)
     }
 }
 

--- a/vest/src/regular/sequence.rs
+++ b/vest/src/regular/sequence.rs
@@ -515,7 +515,7 @@ impl<'x, I, O, Fst, Snd> Combinator<'x, I, O> for Preceded<Fst, Snd> where
         usize,
         SerializeError,
     > {
-        (&self.0, &self.1).serialize(((), v), data, pos)
+        (&self.0, &self.1).serialize(((), v), &mut *data, pos)
     }
 }
 
@@ -627,7 +627,7 @@ impl<'x, I, O, Fst, Snd> Combinator<'x, I, O> for Terminated<Fst, Snd> where
         usize,
         SerializeError,
     > {
-        (&self.0, &self.1).serialize((v, ()), data, pos)
+        (&self.0, &self.1).serialize((v, ()), &mut *data, pos)
     }
 }
 

--- a/vest/src/regular/tag.rs
+++ b/vest/src/regular/tag.rs
@@ -218,7 +218,7 @@ impl<'x, const N: usize> Combinator<'x, &'x [u8], Vec<u8>> for Tag<
         usize,
         SerializeError,
     > {
-        self.0.serialize(&self.0.predicate.0.as_slice(), data, pos)
+        self.0.serialize(&self.0.predicate.0.as_slice(), &mut *data, pos)
     }
 }
 

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -403,9 +403,9 @@ pub trait FromToBytes where Self: ViewReflex + core::marker::Sized + Copy {
         requires
             old(s)@.len() - pos >= size_of::<Self>(),
         ensures
-            old(s)@.len() == s@.len(),
+            old(s)@.len() == final(s)@.len(),
             self.spec_to_le_bytes().len() == size_of::<Self>(),
-            s@ == seq_splice(old(s)@, pos, self.spec_to_le_bytes()),
+            final(s)@ == seq_splice(old(s)@, pos, self.spec_to_le_bytes()),
     ;
 
     /// Converts a sequence of bytes to an integer in big-endian byte order.
@@ -424,9 +424,9 @@ pub trait FromToBytes where Self: ViewReflex + core::marker::Sized + Copy {
         requires
             old(s)@.len() - pos >= size_of::<Self>(),
         ensures
-            old(s)@.len() == s@.len(),
+            old(s)@.len() == final(s)@.len(),
             self.spec_to_be_bytes().len() == size_of::<Self>(),
-            s@ == seq_splice(old(s)@, pos, self.spec_to_be_bytes()),
+            final(s)@ == seq_splice(old(s)@, pos, self.spec_to_be_bytes()),
     ;
 
     /// Compares two integers for equality.

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -1103,7 +1103,7 @@ impl<'x> Combinator<'x, &[u8], Vec<u8>> for U24Le {
         <_ as Combinator<&[u8], Vec<u8>>>::serialize(
             &Fixed::<3>,
             &[v.0[2], v.0[1], v.0[0]].as_slice(),
-            data,
+            &mut *data,
             pos,
         )
     }
@@ -1203,7 +1203,7 @@ impl<'x> Combinator<'x, &[u8], Vec<u8>> for U24Be {
         usize,
         SerializeError,
     >) {
-        <_ as Combinator<&[u8], Vec<u8>>>::serialize(&Fixed::<3>, &v.0.as_slice(), data, pos)
+        <_ as Combinator<&[u8], Vec<u8>>>::serialize(&Fixed::<3>, &v.0.as_slice(), &mut *data, pos)
     }
 }
 

--- a/vest/src/regular/uints.rs
+++ b/vest/src/regular/uints.rs
@@ -1004,9 +1004,9 @@ impl u24 {
             o == self.spec_as_u32(),
     {
         let mut bytes = [0;4];
-        bytes.set(1, self.0[0]);
-        bytes.set(2, self.0[1]);
-        bytes.set(3, self.0[2]);
+        bytes[1] = self.0[0];
+        bytes[2] = self.0[1];
+        bytes[3] = self.0[2];
         u32::ex_from_be_bytes(bytes.as_slice())
     }
 }

--- a/vest/src/regular/variant.rs
+++ b/vest/src/regular/variant.rs
@@ -380,7 +380,7 @@ impl<'x, I, O, T> Combinator<'x, I, O> for Opt<T> where
         SerializeError,
     >) {
         match &v.0 {
-            Some(v) => self.0.serialize(v, data, pos),
+            Some(v) => self.0.serialize(v, &mut *data, pos),
             None => {
                 if pos <= data.len() {
                     assert(seq_splice(old(data)@, pos, Seq::<u8>::empty()) == data@);
@@ -595,8 +595,8 @@ impl<'x, I, O, Fst, Snd> Combinator<'x, I, O> for OptThen<Fst, Snd> where
         usize,
         SerializeError,
     >) {
-        let n = self.0.0.serialize(&v.0, data, pos)?;
-        let m = self.0.1.serialize(v.1, data, pos + n)?;
+        let n = self.0.0.serialize(&v.0, &mut *data, pos)?;
+        let m = self.0.1.serialize(v.1, &mut *data, pos + n)?;
         Ok(n + m)
     }
 }

--- a/vest/src/utils.rs
+++ b/vest/src/utils.rs
@@ -185,8 +185,8 @@ pub fn vec_u8_extend_from_slice(dest: &mut Vec<u8>, src: &[u8])
     requires
         old(dest)@.len() + src@.len() <= usize::MAX,
     ensures
-        dest@.len() == old(dest)@.len() + src@.len(),
-        dest@ == old(dest)@.add(src@),
+        final(dest)@.len() == old(dest)@.len() + src@.len(),
+        final(dest)@ == old(dest)@.add(src@),
 {
     dest.extend_from_slice(src);
 }
@@ -196,8 +196,8 @@ pub fn set_range<'a>(data: &mut Vec<u8>, i: usize, input: &[u8])
     requires
         0 <= i + input@.len() <= old(data)@.len() <= usize::MAX,
     ensures
-        data@.len() == old(data)@.len()
-        && data@ == seq_splice(old(data)@, i, input@),
+        final(data)@.len() == old(data)@.len()
+        && final(data)@ == seq_splice(old(data)@, i, input@),
 {
     // data[i..i + input.len()].copy_from_slice(input);
     let mut j = 0;


### PR DESCRIPTION
We'll still need to update VestDSL to emit code that conforms with the new framework.